### PR TITLE
Do not display readonly translatable fields in the translate dialog

### DIFF
--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -43,7 +43,10 @@ openerp.web_translate_dialog = function (instance) {
             this.view_type = parent.fields_view.type || '';
             this.$view_form = null;
             this.$sidebar_form = null;
-            this.translatable_fields_keys = _.map(this.view.translatable_fields || [], function(i) { return i.name;});
+            this.translatable_fields = _.filter(this.view.translatable_fields || [],
+                                                this.filter_translatable_fields);
+            this.translatable_fields_keys = _.map(this.translatable_fields,
+                                                  function(i) { return i.name;});
             this.languages = null;
             this.languages_loaded = $.Deferred();
             (new instance.web.DataSetSearch(this,
@@ -52,6 +55,9 @@ openerp.web_translate_dialog = function (instance) {
                                             [['translatable', '=', '1']]))
                 .read_slice(['code', 'name'], { sort: 'id' })
                 .then(this.on_languages_loaded);
+        },
+        filter_translatable_fields: function(field) {
+            return !field.field.readonly;
         },
         on_languages_loaded: function(langs) {
             this.languages = langs;

--- a/web_translate_dialog/static/src/xml/base.xml
+++ b/web_translate_dialog/static/src/xml/base.xml
@@ -10,7 +10,7 @@
                 <div class="separator horizontal"><t t-esc="name"/></div>
             </th>
         </tr>
-        <tr t-foreach="widget.view.translatable_fields" t-as="field" t-att-data-field="field.name">
+        <tr t-foreach="widget.translatable_fields" t-as="field" t-att-data-field="field.name">
             <td class="oe_form_frame_cell" width="1%" nowrap="nowrap">
                 <label class="oe_label"><t t-esc="field.string"/>:</label>
             </td>


### PR DESCRIPTION
Do not display readonly translatable fields in the translate dialog.

Bug report: https://code.launchpad.net/bugs/1335045
Original proposal: https://code.launchpad.net/~camptocamp/web-addons/7.0-web_translate_dialog-no-readonly-gbr/+merge/224780
