### PR TITLE
[FIX] Ambiguous import

### DIFF
--- a/web_export_view/controllers.py
+++ b/web_export_view/controllers.py
@@ -23,9 +23,9 @@ try:
 except ImportError:
     import simplejson as json
 
-import web.http as openerpweb
+from openerp.addons.web import http as openerpweb
 
-from web.controllers.main import ExcelExport
+from openerp.addons.web.controllers.main import ExcelExport
 
 
 class ExcelExportView(ExcelExport):


### PR DESCRIPTION
WARNING ? openerp.modules.module:
Ambiguous import: the OpenERP module `web` is shadowed by another
module (available at /home/elbati/workspace/openerp/progetti/siem/git/siem/parts/odoo/addons/web).
To import it, use `import openerp.addons.<module>.`.
