### PR TITLE
[FIX] Remove obsolete instruct (JS) in openerp.py

### DIFF
--- a/web_easy_switch_company/__openerp__.py
+++ b/web_easy_switch_company/__openerp__.py
@@ -60,9 +60,6 @@ Copyright, Author and Licence:
     'data': [
         'view/res_users_view.xml',
     ],
-    'js': [
-        'static/src/js/switch_company.js',
-    ],
     'qweb': [
         'static/src/xml/switch_company.xml',
     ],

--- a/web_easy_switch_company/view/res_users_view.xml
+++ b/web_easy_switch_company/view/res_users_view.xml
@@ -14,7 +14,7 @@
             </field>
         </record>
 
-        <template id="assets_backend" name="web_tests assets" inherit_id="web.assets_backend">
+        <template id="assets_backend" name="web_easy_switch_company assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
                 <script type="text/javascript" src="/web_easy_switch_company/static/src/js/switch_company.js"></script>
             </xpath>


### PR DESCRIPTION
Remove obsolete instruct (JS) in **openerp**.py
In the new version of Odoo the JS is appended using template and xpath
Check this file : view/res_users_view
