### PR TITLE
[FIX] inherit from "assets_editor" instead of "layout" to avoid "uncaugh...

### DIFF
--- a/help_online/views/website_help_online.xml
+++ b/help_online/views/website_help_online.xml
@@ -2,8 +2,8 @@
 <openerp>
 <data>
 
-<template id="head" inherit_id="website.layout" name="Help online customization">
-    <xpath expr="//head" position="inside">
+<template id="assets_editor" inherit_id="website.assets_editor" name="Help online customization">
+    <xpath expr="." position="inside">
         <script type="text/javascript" src="/help_online/static/src/js/website_help_online.editor.js" groups="base.group_website_publisher"></script>
     </xpath>
 </template>


### PR DESCRIPTION
...t ReferenceError"
![uncaught_referenceerror](https://cloud.githubusercontent.com/assets/7601731/4677038/76ee5676-55e2-11e4-9342-9e7bf73f69a0.png)
