### PR TITLE
Fix parsing of integers with separator

### DIFF
--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -85,7 +85,8 @@ openerp.web_export_view = function (instance) {
                                 }
                             }
                             else if (cell.classList.contains("oe_list_field_integer")) {
-                                export_row.push(parseInt(text));
+                                tmp2 = text.replace(instance.web._t.database.parameters.thousands_sep, "");
+                                export_row.push(parseInt(tmp2));
                             }
                             else {
                                 export_row.push(text.trim());

--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -85,7 +85,12 @@ openerp.web_export_view = function (instance) {
                                 }
                             }
                             else if (cell.classList.contains("oe_list_field_integer")) {
-                                tmp2 = text.replace(instance.web._t.database.parameters.thousands_sep, "");
+                                var tmp2 = text;
+                                do {
+                                    tmp = tmp2;
+                                    tmp2 = tmp.replace(instance.web._t.database.parameters.thousands_sep, "");
+                                } while (tmp !== tmp2);
+
                                 export_row.push(parseInt(tmp2));
                             }
                             else {


### PR DESCRIPTION
Small fix to allow integers to be parsed correctly when a locate with a thousand separator is used.
