### PR TITLE
[IMP] monkey patch lxml's html cleaner

### DIFF
--- a/web_ckeditor4/models/__init__.py
+++ b/web_ckeditor4/models/__init__.py
@@ -1,9 +1,8 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2013 Therp BV (<http://therp.nl>)
-#    All Rights Reserved
+#    This module copyright (C) 2015 Therp BV (<http://therp.nl>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -19,4 +18,4 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from . import models
+from . import ckeditor_monkeypatch

--- a/web_ckeditor4/models/ckeditor_monkeypatch.py
+++ b/web_ckeditor4/models/ckeditor_monkeypatch.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+import re
+from lxml.html import clean
+from openerp import models
+
+
+class CkeditorMonkeypatch(models.AbstractModel):
+    _name = 'ckeditor.monkeypatch'
+    _description = 'Monkeypatches for CKEditor'
+
+    def _register_hook(self, cr):
+        marker = self._name.replace('.', '_')
+        if not hasattr(clean, marker):
+            # monkey patch lxml's html cleaner to allow image data urls
+            if hasattr(clean, '_is_javascript_scheme'):
+                # this is the case in lxml >= 3.3
+                _is_javascript_scheme = clean._is_javascript_scheme
+                _is_image_dataurl = re.compile(
+                    r'^data:image/.+;base64', re.I).search
+                clean._is_javascript_scheme = lambda s:\
+                    None if _is_image_dataurl(s) else _is_javascript_scheme(s)
+            # TODO: do something else for 2.3.1 <= version <= 3.2, before data
+            # urls were not cleaned at all
+            setattr(clean, marker, True)
+        return super(CkeditorMonkeypatch, self)._register_hook(cr)


### PR DESCRIPTION
in order to allow image data urls in html code (this widget's image upload feature uses this)

I made a PR on lxml for that too: https://github.com/lxml/lxml/pull/162
