### PR TITLE
[ADD] Added web_remove_developer_mode_link.

### DIFF
--- a/web_remove_developer_mode_link/README.rst
+++ b/web_remove_developer_mode_link/README.rst
@@ -1,0 +1,36 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License
+
+Demove Developer Mode link
+==========================
+
+This module removes the link that activates the Developer Mode.
+
+
+Known issues / Roadmap
+======================
+
+* It would be desirable to make the link available to a certain group of users.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alejandro Santana <alejandrosantana@anubia.es
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/web_remove_developer_mode_link/__init__.py
+++ b/web_remove_developer_mode_link/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+#
+# License, author and contributors information in:
+# __openerp__.py file at the root folder of this module.
+#

--- a/web_remove_developer_mode_link/__openerp__.py
+++ b/web_remove_developer_mode_link/__openerp__.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (c) All rights reserved:
+#        (c) 2015      Anubía, soluciones en la nube,SL (http://www.anubia.es)
+#                      Alejandro Santana <alejandrosantana@anubia.es>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses
+#
+##############################################################################
+{
+    'name': 'Remove Developer Mode link',
+    'version': '0.1',
+    'category': 'Generic Modules/Others',
+    'summary': 'This module removes the link that activates Developer Mode.',
+    'author': ('Alejandro Santana, '
+               'Odoo Community Association (OCA)'),
+    'website': 'http://www.nubia.es',
+    'license': 'AGPL-3',
+    'depends': [
+        'web',
+    ],
+    'qweb': [
+        'static/src/xml/base.xml',
+    ],
+    'installable': True,
+    'application': True,
+    'auto_install': False,
+}

--- a/web_remove_developer_mode_link/static/src/xml/base.xml
+++ b/web_remove_developer_mode_link/static/src/xml/base.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates id="template" xml:space="preserve">
+
+    <t t-extend="UserMenu.about">
+        <t t-jquery=".oe_activate_debug_mode" t-operation="replace"></t>
+    </t>
+
+</templates>


### PR DESCRIPTION
As some customers want to restrict 'Developer Mode' for most users, this is simple module that removes the link in "About" dialog that activates Developer Mode.
It still allows to type ?debug in URL for those technical users that actually need this.

As a sidenote, first I wanted to make it optional and be able to show it only to a certain group of users, but it seems impossible to apply "groups" policy in qweb-json temapletes (see https://github.com/odoo/odoo/issues/5058 and https://github.com/odoo/odoo/issues/6190). Or, at least, I do not know how to do it.
As other option I thought in allowing only Administrator user (uid == 1), but I do not know how to get user id in such qweb template.
I tried this with out any luck (nor 'groups' nor uid):

```
    <t t-extend="UserMenu.about">
        <t t-jquery=".oe_activate_debug_mode" t-operation="replace">
            <t t-if="uid == 1">
                <a class="oe_activate_debug_mode oe_right label label-primary" href="?debug" groups="base.group_no_one">Activate the developer mode</a>
            </t>
        </t>
    </t>
```

I am open to ideas to enhace this.
Same PR as https://github.com/OCA/web/pull/109 , but sent again due to OCA CLA verification.
