### PR TITLE
Added new module web_widget_options

### DIFF
--- a/web_widget_options/__init__.py
+++ b/web_widget_options/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2015 Savoir-faire Linux (<www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/web_widget_options/__openerp__.py
+++ b/web_widget_options/__openerp__.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2015 Savoir-faire Linux (<www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Web widget options',
+    'version': '0.1',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'category': 'Account',
+    'summary': 'Customize web widgets',
+    'description': """
+Web widget options
+==================
+
+Allow the customization of web widgets using certain rules. Using
+a rule to match the group_id or the action_id, it is possible to
+remove the button "add item" on one2many fields.
+
+
+Contributors
+------------
+* Loïc Faure-Lacroix <loic.lacroix@savoirfairelinux.com>
+""",
+    'depends': [
+    ],
+    'data': [
+    ],
+    'js': [
+        'static/src/js/web_widgets.js',
+    ],
+    'auto_install': False,
+    'installable': True,
+}

--- a/web_widget_options/static/src/js/web_widgets.js
+++ b/web_widget_options/static/src/js/web_widgets.js
@@ -1,0 +1,74 @@
+openerp.web_widget_options = function(instance, m) {
+  var _t = instance.web._t,
+      QWeb = instance.web.qweb;
+  var wwo = instance.wwo = {};
+  var o2m = instance.wwo.o2m = {}
+
+  o2m.rules = {
+    groups: function (rule, context) {
+      var user_id = instance.session.uid,
+          users = new instance.web.Model('res.users'),
+          query = users.query(['name', 'groups_id']).filter([['id', '=', user_id]]);
+
+      return query.all().then(function (res) {
+               var user = res[0];
+
+               return rule.reduce(function (accum, val) {
+                 return accum && user.groups_id.indexOf(val) >= 0;
+               }, true);
+             });
+    },
+
+    action_id: function (rule, context) {
+      var action_id = context.view.options.action.id;
+      return rule == action_id;
+    }
+  };
+
+  function and(a, b) {
+    return a && b;
+  };
+
+  function can_add_items(view_root, field_name, rules) {
+    var def = $.Deferred(),
+        context = {
+          view: view_root,
+          field_name: field_name,
+          rule: rules
+        },
+        pending = Object.keys(rules).map(function (rule_name) {
+          // Call all rules
+          return o2m.rules[rule_name](rules[rule_name], context);
+        });
+
+    $.when.apply($, pending).done(function () {
+      var all_true = Array.prototype.slice.call(arguments).reduce(and, true);
+
+      if (!all_true) {
+        view_root.fields[field_name].views[0].embedded_view['arch'].attrs.create = 'false';
+        view_root.reload();
+      }
+    });
+  };
+
+  instance.web.form.FieldOne2Many.include({
+    start: function () {
+      /*
+       * Extend the view to check for create_rule
+       */
+      var res = this._super.apply(this, arguments),
+          action_id = this.view.options.action.id,
+          view = this.views[0].embedded_view,
+          view_name = this.name,
+          view_root = this.view,
+          rules = {};
+
+      if (view && view['arch'].attrs.create_rule) {
+        rules = JSON.parse(view['arch'].attrs.create_rule);
+        can_add_items(view_root, this.name, rules);
+      }
+
+      return res;
+    }
+  });
+};

--- a/web_widget_options/static/src/js/web_widgets.js
+++ b/web_widget_options/static/src/js/web_widgets.js
@@ -57,7 +57,6 @@ openerp.web_widget_options = function(instance, m) {
        * Extend the view to check for create_rule
        */
       var res = this._super.apply(this, arguments),
-          action_id = this.view.options.action.id,
           view = this.views[0].embedded_view,
           view_name = this.name,
           view_root = this.view,


### PR DESCRIPTION
This module allow the user to set some rules that will control the visibility of the "Add item" on a `one2many` field. This module can be extended to support more than the `create` attributes.

It is possible to extend the set of rules. 

It currently can test for the action_id and if the user has all_groups defined in `groups`.

A rule looks like this on a tree object.

```
<tree create_rule='{"groups": [1,2], "action_id": 34}' ...>
```

Here's a more complex example of how to use:

```
<xpath expr="//tree" position="attributes">
      <attribute name="create_rule">
        {
          "groups": [%(some_group_id)d],
          "action_id": %(some_action_group)d
        }
      </attribute>
  </xpath>
```
