### PR TITLE
[IMP] web_m2x_options

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -14,9 +14,9 @@ add some new display control options.
 ** New: support global option management with ir.config_parameter ! **
 
 The options provided include the possibility to remove "Create..." and/or
-"Create and Edit..." entries from many2one drop down. You can also change
-the default number of entries appearing in the drop-down, or prevent the
-dialog box poping in case of validation error.
+"Create and Edit..." entries from many2one and many2many drop down lists. You
+can also change the default number of entries appearing in the drop-down, or
+ prevent the dialog box poping in case of validation error occurring.
 
 If not specified, the module will avoid proposing any of the create options
 if the current user have no permission rights to create the related object.

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -11,6 +11,8 @@ control options.
 
 ** New: support many2manytags widget ! **
 
+** New: support global option management with ir.config_parameter ! **
+
 Options provided includes possibility to remove "Create..." and/or "Create and
 Edit..." entries from many2one drop down. You can also change default number of
 proposition appearing in the drop-down. Or prevent the dialog box poping in
@@ -46,6 +48,31 @@ New option
   Number of displayed record in drop-down panel
 
 
+ir.config_parameter options
+---------------------------
+
+Now you can disable "Create..." and "Create and Edit..." entry for all widgets in the odoo instance.
+If you disable one option, you can enable it for particular field by setting "create: True" option directly on the field definition.
+
+``web_m2x_options.create`` *boolean* (Default: depends if user have create rights)
+
+  Whether to display the "Create..." entry in dropdown panel for all fields in the odoo instance.
+
+``web_m2x_options.create_edit`` *boolean* (Default: depends if user have create rights)
+
+  Whether to display "Create and Edit..." entry in dropdown panel for all fields in the odoo instance.
+
+``web_m2x_options.limit`` *int* (Default: openerp default value is ``7``)
+
+  Number of displayed records in drop-down panel for all fields in the odoo instance
+
+To add these parameters go to Configuration -> Technical -> Parameters -> System Parameters and add new parameters like:
+
+- web_m2x_options.create: False
+- web_m2x_options.create_edit: False
+- web_m2x_options.limit: 10
+
+
 Example
 -------
 
@@ -59,5 +86,5 @@ Note
 ----
 
 Double check that you have no inherited view that remote ``options`` you set on a field ! 
-If nothing work, add a debugger in the first ligne of ``get_search_result method`` and enable debug mode in OpenERP. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
+If nothing work, add a debugger in the first line of ``get_search_result`` method and enable debug mode in OpenERP. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
 

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -6,17 +6,17 @@ Add new options for many2one field
 Description
 -----------
 
-This modules modifies "many2one" form fields so as to add some new display
-control options.
+This module changes "many2one" and "many2manytags" form widgets, so as to
+add some new display control options.
 
 ** New: support many2manytags widget ! **
 
 ** New: support global option management with ir.config_parameter ! **
 
-Options provided includes possibility to remove "Create..." and/or "Create and
-Edit..." entries from many2one drop down. You can also change default number of
-proposition appearing in the drop-down. Or prevent the dialog box poping in
-case of validation error.
+The options provided include the possibility to remove "Create..." and/or
+"Create and Edit..." entries from many2one drop down. You can also change
+the default number of entries appearing in the drop-down, or prevent the
+dialog box poping in case of validation error.
 
 If not specified, the module will avoid proposing any of the create options
 if the current user have no permission rights to create the related object.

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -8,7 +8,34 @@ openerp.web_m2x_options = function (instance) {
         _t  = instance.web._t,
         _lt = instance.web._lt;
 
+    var OPTIONS = ['web_m2x_options.create',
+                   'web_m2x_options.create_edit',
+		           'web_m2x_options.limit',];
+
     instance.web.form.FieldMany2One.include({
+
+        start: function() {
+            this._super.apply(this, arguments);
+            return this.get_options();
+        },
+
+        get_options: function() {
+            var self = this;
+            if (!_.isUndefined(this.view) && _.isUndefined(this.view.ir_options_loaded)) {
+            this.view.ir_options_loaded = $.Deferred();
+            this.view.ir_options = {};
+            (new instance.web.Model("ir.config_parameter"))
+                .query(["key", "value"]).filter([['key', 'in', OPTIONS]])
+                .all().then(function(records) {
+                _(records).each(function(record) {
+                    self.view.ir_options[record.key] = record.value;
+                });
+                self.view.ir_options_loaded.resolve();
+                });
+                return this.view.ir_options_loaded;
+            }
+            return $.when();
+        },
 
         show_error_displayer: function () {
             if ((typeof this.options.m2o_dialog === 'undefined' && this.can_create) ||
@@ -23,6 +50,12 @@ openerp.web_m2x_options = function (instance) {
             var self = this;
             // add options limit used to change number of selections record
             // returned.
+
+            if (_.isUndefined(this.view))
+                    return this._super.apply(this, arguments);
+            if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
+                this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
+            }
 
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
@@ -65,7 +98,7 @@ openerp.web_m2x_options = function (instance) {
                     };
                 });
 
-                // search more... if more results that max
+                // search more... if more results than max
 
                 if (values.length > self.limit) {
                     values = values.slice(0, self.limit);
@@ -88,7 +121,8 @@ openerp.web_m2x_options = function (instance) {
                     return x[1];
                 });
 
-                if ((typeof self.options.create === 'undefined' && can_create) ||
+                if ((_.isUndefined(self.options.create) && _.isUndefined(self.view.ir_options['web_m2x_options.create']) && can_create) ||
+		            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create'] == "True") ||
                     self.options.create) {
 
                     if (search_val.length > 0 &&
@@ -106,9 +140,11 @@ openerp.web_m2x_options = function (instance) {
                     }
                 }
 
+
                 // create...
 
-                if ((typeof self.options.create_edit === 'undefined' && can_create) ||
+                if ((_.isUndefined(self.options.create_edit) && _.isUndefined(self.view.ir_options['web_m2x_options.create_edit']) && can_create) ||
+		            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create_edit'] == "True") ||
                     self.options.create_edit) {
 
                     values.push({
@@ -138,6 +174,28 @@ openerp.web_m2x_options = function (instance) {
             }
         },
 
+        start: function() {
+            this._super.apply(this, arguments);
+            return this.get_options();
+        },
+
+        get_options: function() {
+            var self = this;
+            if (_.isUndefined(this.view.ir_options_loaded)) {
+                this.view.ir_options_loaded = $.Deferred();
+                this.view.ir_options = {};
+                (new instance.web.Model("ir.config_parameter"))
+                        .query(["key", "value"]).filter([['key', 'in', OPTIONS]])
+                        .all().then(function(records) {
+                        _(records).each(function(record) {
+                    self.view.ir_options[record.key] = record.value;
+                    });
+                self.view.ir_options_loaded.resolve();
+            });
+            }
+            return this.view.ir_options_loaded;
+        },
+
         /**
         * Call this method to search using a string.
         */
@@ -147,6 +205,10 @@ openerp.web_m2x_options = function (instance) {
 
             // add options limit used to change number of selections record
             // returned.
+
+            if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
+                this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
+            }
 
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
@@ -186,7 +248,8 @@ openerp.web_m2x_options = function (instance) {
                 }
                 // quick create
 
-                if ((typeof self.options.create === 'undefined') ||
+                if ((_.isUndefined(self.options.create) && _.isUndefined(self.view.ir_options['web_m2x_options.create'])) ||
+		            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create'] == 'True') ||
                     self.options.create) {
 
                     var raw_result = _(data.result).map(function(x) {return x[1];});
@@ -201,10 +264,10 @@ openerp.web_m2x_options = function (instance) {
                         });
                     }
                 }
-
                 // create...
 
-                if ((typeof self.options.create_edit === 'undefined') ||
+                if ((_.isUndefined(self.options.create_edit === 'undefined') && _.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) ||
+	            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create_edit'] == 'True') ||
                     self.options.create_edit) {
 
                     values.push({

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -10,7 +10,7 @@ openerp.web_m2x_options = function (instance) {
 
     var OPTIONS = ['web_m2x_options.create',
                    'web_m2x_options.create_edit',
-		           'web_m2x_options.limit',];
+                   'web_m2x_options.limit',];
 
     instance.web.form.FieldMany2One.include({
 


### PR DESCRIPTION
This PR is a backport from the 8.0, that adds the feature that makes it possible to disable "Create..." and "Create and Edit..." entry for all widgets in the odoo instance.

I could not test the option 'm2o_dialog'. I don't really understand what it means. By inspecting the code it seems that this option has no effect in the application.

Regards,
Jordi.
