### PR TITLE
Add two new functionalities to m2x dialogs

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -46,6 +46,18 @@ New option
 ``limit`` *int* (Default: openerp default value is ``7``)
 
   Number of displayed record in drop-down panel
+  
+``field_color`` *string*
+
+  A string to define the field used to define color.
+  This option has to be used with colors.
+  
+``colors`` *dictionary*
+
+  A dictionary to link field value with a HTML color.
+  This option has to be used with field_color.
+  
+
 
 
 ir.config_parameter options
@@ -79,7 +91,7 @@ Example
 Your XML form view definition could contain::
 
     ...
-    <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false}"/>
+    <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false, 'field_color':'state', 'colors':{'active':'green'}}"/>
     ...
 
 Note

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -78,6 +78,10 @@ If you disable one option, you can enable it for particular field by setting "cr
 
   Whether to display "Create and Edit..." entry in dropdown panel for all fields in the odoo instance.
 
+``web_m2x_options.m2o_dialog`` *boolean* (Default: depends if user have create rights)
+
+  Whether to display the many2one dialog in case of validation error for all fields in the odoo instance.
+
 ``web_m2x_options.limit`` *int* (Default: openerp default value is ``7``)
 
   Number of displayed records in drop-down panel for all fields in the odoo instance
@@ -90,6 +94,7 @@ To add these parameters go to Configuration -> Technical -> Parameters -> System
 
 - web_m2x_options.create: False
 - web_m2x_options.create_edit: False
+- web_m2x_options.m2o_dialog: False
 - web_m2x_options.limit: 10
 - web_m2x_options.search_more: True
 

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -82,11 +82,16 @@ If you disable one option, you can enable it for particular field by setting "cr
 
   Number of displayed records in drop-down panel for all fields in the odoo instance
 
+``web_m2x_options.search_more`` *boolean* (Default: default value is ``False``)
+
+  Whether the field should always show "Search more..." entry or not.
+
 To add these parameters go to Configuration -> Technical -> Parameters -> System Parameters and add new parameters like:
 
 - web_m2x_options.create: False
 - web_m2x_options.create_edit: False
 - web_m2x_options.limit: 10
+- web_m2x_options.search_more: True
 
 
 Example

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -46,6 +46,10 @@ New option
 ``limit`` *int* (Default: openerp default value is ``7``)
 
   Number of displayed record in drop-down panel
+
+``search_more`` *boolean* 
+
+  Used to force disable/enable search more button.
   
 ``field_color`` *string*
 
@@ -91,7 +95,7 @@ Example
 Your XML form view definition could contain::
 
     ...
-    <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false, 'field_color':'state', 'colors':{'active':'green'}}"/>
+    <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false, 'search_more':true 'field_color':'state', 'colors':{'active':'green'}}"/>
     ...
 
 Note

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -12,12 +12,16 @@ Add new options for many2one and many2manytags field:
 - create_edit: true/false -> disable "create and edit" entry in dropdown panel
 - limit: 10 (int) -> change number of selected record return in dropdown panel
 - m2o_dialog: true/false -> disable quick create M20Dialog triggered on error.
+- search_more: true/false -> force disable/enable search more button.
+- field_color -> define the field used to define color.
+- colors -> link field values to a HTML color.
+
 
 Example:
 --------
 
 ``<field name="partner_id" options="{'limit': 10, 'create': false,
-'create_edit': false}"/>``
+'create_edit': false, 'field_color':'state', colors:{'active':'green'}}"/>``
 
 Note:
 -----

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -21,7 +21,7 @@ Example:
 --------
 
 ``<field name="partner_id" options="{'limit': 10, 'create': false,
-'create_edit': false, 'field_color':'state', colors:{'active':'green'}}"/>``
+'create_edit': false, 'field_color':'state', 'colors':{'active':'green'}}"/>``
 
 Note:
 -----

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -61,16 +61,18 @@ openerp.web_m2x_options = function (instance) {
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
             }
-            
+
             // add options search_more to force enable or disable search_more button
-            if(typeof this.options.search_more === 'boolean') {
-                this.search_more = this.options.search_more
+            var search_more_defined = !_.isUndefined(this.options.search_more)
+            if((search_more_defined && this.options.search_more.toLowerCase() === "true") ||
+               !(search_more_defined && this.options.search_more.toLowerCase() === "false") && (self.view.ir_options['web_m2x_options.search_more'] === "True")) {
+                this.search_more = true
             }
-            
+
             // add options field_color and colors to color item(s) depending on field_color value
             this.field_color = this.options.field_color
             this.colors = this.options.colors
-            
+
             var dataset = new instance.web.DataSet(this, this.field.relation,
                                                    self.build_context());
             var blacklist = this.get_search_blacklist();

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -39,9 +39,24 @@ openerp.web_m2x_options = function (instance) {
             return $.when();
         },
 
+        is_option_set: function(option) {
+            if (_.isUndefined(option)) {
+                return false
+            }
+            var is_string = typeof option === 'string'
+            var is_bool = typeof option === 'boolean'
+            if (is_string) {
+                return option === 'true' || option === 'True'
+            } else if (is_bool) {
+                return option
+            }
+            return false
+        },
+
         show_error_displayer: function () {
-            if (((typeof this.options.m2o_dialog === 'undefined' && this.can_create) ||
-                this.options.m2o_dialog) && (!this.view.ir_options['web_m2x_options.search_more'] === "False")) {
+            if(this.is_option_set(this.options.m2o_dialog) ||
+               _.isUndefined(this.options.m2o_dialog) && this.is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']) ||
+               this.can_create && _.isUndefined(this.options.m2o_dialog) && _.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
                 new instance.web.form.M2ODialog(this).open();
             }
         },
@@ -64,9 +79,7 @@ openerp.web_m2x_options = function (instance) {
             }
 
             // add options search_more to force enable or disable search_more button
-            var search_more_defined = !_.isUndefined(this.options.search_more)
-            if((search_more_defined && this.options.search_more.toLowerCase() === "true") ||
-               !(search_more_defined && this.options.search_more.toLowerCase() === "false") && (self.view.ir_options['web_m2x_options.search_more'] === "True")) {
+            if (this.is_option_set(this.options.search_more) || _.isUndefined(this.options.search_more) && this.is_option_set(self.view.ir_options['web_m2x_options.search_more'])) {
                 this.search_more = true
             }
 

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -119,10 +119,10 @@ openerp.web_m2x_options = function (instance) {
                     Objects.query([self.field_color])
                                 .filter([['id', 'in', value_ids]])
                                 .all().done(function (objects) {
-                                    console.log(objects);
                                     for (var index in objects) {
                                         var value = values[index];
-                                        var color = self.colors[objects[index].state] || 'black';
+                                        // Find color with field value as key
+                                        var color = self.colors[objects[index][self.field_color]] || 'black';
                                         value.label = '<span style="color:'+color+'">'+value.label+'</span>';
                                     }
                                     def.resolve(values);

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -11,7 +11,8 @@ openerp.web_m2x_options = function (instance) {
     var OPTIONS = ['web_m2x_options.create',
                    'web_m2x_options.create_edit',
                    'web_m2x_options.limit',
-                   'web_m2x_options.search_more',];
+                   'web_m2x_options.search_more',
+                   'web_m2x_options.m2o_dialog',];
 
     instance.web.form.FieldMany2One = instance.web.form.FieldMany2One.extend({
 
@@ -39,8 +40,8 @@ openerp.web_m2x_options = function (instance) {
         },
 
         show_error_displayer: function () {
-            if ((typeof this.options.m2o_dialog === 'undefined' && this.can_create) ||
-                this.options.m2o_dialog) {
+            if (((typeof this.options.m2o_dialog === 'undefined' && this.can_create) ||
+                this.options.m2o_dialog) && (!this.view.ir_options['web_m2x_options.search_more'] === "False")) {
                 new instance.web.form.M2ODialog(this).open();
             }
         },

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -12,7 +12,7 @@ openerp.web_m2x_options = function (instance) {
                    'web_m2x_options.create_edit',
                    'web_m2x_options.limit',];
 
-    instance.web.form.FieldMany2One.include({
+    instance.web.form.FieldMany2One = instance.web.form.FieldMany2One.extend({
 
         start: function() {
             this._super.apply(this, arguments);
@@ -45,7 +45,7 @@ openerp.web_m2x_options = function (instance) {
         },
 
         get_search_result: function (search_val) {
-
+            var Objects = new instance.web.Model(this.field.relation);
             var def = $.Deferred();
             var self = this;
             // add options limit used to change number of selections record
@@ -65,7 +65,11 @@ openerp.web_m2x_options = function (instance) {
             if(typeof this.options.search_more === 'boolean') {
                 this.search_more = this.options.search_more
             }
-
+            
+            // add options field_color and colors to color item(s) depending on field_color value
+            this.field_color = this.options.field_color
+            this.colors = this.options.colors
+            
             var dataset = new instance.web.DataSet(this, this.field.relation,
                                                    self.build_context());
             var blacklist = this.get_search_blacklist();
@@ -102,6 +106,28 @@ openerp.web_m2x_options = function (instance) {
                         id: x[0],
                     };
                 });
+                
+                // Search result value colors
+
+                if (self.colors && self.field_color) {
+                    var value_ids = [];
+                    for (var index in values) {
+                        value_ids.push(values[index].id);
+                    }
+                    
+                    // RPC request to get field_color from Objects
+                    Objects.query([self.field_color])
+                                .filter([['id', 'in', value_ids]])
+                                .all().done(function (objects) {
+                                    console.log(objects);
+                                    for (var index in objects) {
+                                        var value = values[index];
+                                        var color = self.colors[objects[index].state] || 'black';
+                                        value.label = '<span style="color:'+color+'">'+value.label+'</span>';
+                                    }
+                                    def.resolve(values);
+                                });
+                }
 
                 // search more... if more results than max
 
@@ -162,8 +188,11 @@ openerp.web_m2x_options = function (instance) {
                         classname: 'oe_m2o_dropdown_option'
                     });
                 }
-
-                def.resolve(values);
+                
+                // Check if colors specified to wait for RPC
+                if (!(self.field_color && self.colors)){
+                    def.resolve(values);
+                }
             });
 
             return def;

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -10,7 +10,8 @@ openerp.web_m2x_options = function (instance) {
 
     var OPTIONS = ['web_m2x_options.create',
                    'web_m2x_options.create_edit',
-                   'web_m2x_options.limit',];
+                   'web_m2x_options.limit',
+                   'web_m2x_options.search_more',];
 
     instance.web.form.FieldMany2One = instance.web.form.FieldMany2One.extend({
 

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -120,10 +120,17 @@ openerp.web_m2x_options = function (instance) {
                                 .filter([['id', 'in', value_ids]])
                                 .all().done(function (objects) {
                                     for (var index in objects) {
-                                        var value = values[index];
-                                        // Find color with field value as key
-                                        var color = self.colors[objects[index][self.field_color]] || 'black';
-                                        value.label = '<span style="color:'+color+'">'+value.label+'</span>';
+                                        for (var index_value in values) {
+                                            if (values[index_value].id == objects[index].id) {
+                                                // Find value in values by comparing ids
+                                                var value = values[index_value];
+                                                
+                                                // Find color with field value as key
+                                                var color = self.colors[objects[index][self.field_color]] || 'black';
+                                                value.label = '<span style="color:'+color+'">'+value.label+'</span>';
+                                                break;
+                                            }
+                                        }
                                     }
                                     def.resolve(values);
                                 });

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -60,6 +60,11 @@ openerp.web_m2x_options = function (instance) {
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
             }
+            
+            // add options search_more to force enable or disable search_more button
+            if(typeof this.options.search_more === 'boolean') {
+                this.search_more = this.options.search_more
+            }
 
             var dataset = new instance.web.DataSet(this, this.field.relation,
                                                    self.build_context());
@@ -100,7 +105,7 @@ openerp.web_m2x_options = function (instance) {
 
                 // search more... if more results than max
 
-                if (values.length > self.limit) {
+                if (values.length > self.limit || self.search_more) {
                     values = values.slice(0, self.limit);
                     values.push({
                         label: _t("Search More..."),


### PR DESCRIPTION
Add two new options in module web_m2x_options :
- search_more : option to always show the "Search more..." in one2many dialogs, even if all search results are displayed.
- field_color : option for changing the color of listed records based on field's values

Other changes :
- Added option m2o_dialog in system parameters
- Added function to check either for "True" or "true" values
