### PR TITLE
[7.0] New module 'web_vendor_info'

### DIFF
--- a/web_vendor_info/README.rst
+++ b/web_vendor_info/README.rst
@@ -24,3 +24,18 @@ Contributors
 ------------
 
 * Sébastien Alix <sebastien.alix@osiell.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/web_vendor_info/README.rst
+++ b/web_vendor_info/README.rst
@@ -1,0 +1,26 @@
+
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License
+
+Display the vendor's name and the current release number
+========================================================
+
+This module replaces the `Powered by OpenERP` at the bottom of the Web
+interface by the vendor's name, and optionally the release number.
+
+Configuration
+=============
+
+These new configuration parameters are available in
+*Settings / Technical / Parameters / System Parameters*:
+
+    * ``web_vendor_name``
+    * ``web_vendor_release``
+
+Credits
+=======
+
+Contributors
+------------
+
+* Sébastien Alix <sebastien.alix@osiell.com>

--- a/web_vendor_info/__init__.py
+++ b/web_vendor_info/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Web Vendor Info module for OpenERP
+#    Copyright (C) 2015 ABF OSIELL SARL (http://osiell.com)
+#                       Sebastien Alix (https://twitter.com/seb_alix)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import models

--- a/web_vendor_info/__openerp__.py
+++ b/web_vendor_info/__openerp__.py
@@ -1,0 +1,62 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Web Vendor Info, Open Source Management Solution
+#    Copyright (C) 2015 ABF Osiell (http://osiell.com)
+#                       Sebastien Alix (https://twitter.com/seb_alix)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': "Vendor Information",
+    'version': '1.0',
+    'category': 'web',
+    'description': """
+Display the vendor's name and the current release number
+==========================================================
+
+This module replaces the `Powered by OpenERP` at the bottom of the Web
+interface by the vendor's name, and optionally the release number.
+
+Configuration
+=============
+
+These new configuration parameters are available:
+
+    * ``web_vendor_name``
+    * ``web_vendor_release``
+    """,
+    'author': 'ABF OSIELL',
+    'maintainer': 'ABF OSIELL',
+    'website': 'http://www.osiell.com',
+    'depends': [
+        'web',
+    ],
+    'data': [
+        'data/config.xml',
+    ],
+    'js': [
+        'static/src/js/vendor_info.js',
+    ],
+    'qweb': [
+        'static/src/xml/vendor_info.xml',
+    ],
+    'css': [
+        'static/src/css/vendor_info.css',
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/web_vendor_info/data/config.xml
+++ b/web_vendor_info/data/config.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="1">
+
+        <record id="ir_config_parameter_vendor_name" model="ir.config_parameter">
+            <field name="key">web_vendor_name</field>
+            <field name="value" eval="''"/>
+        </record>
+
+        <record id="ir_config_parameter_vendor_release" model="ir.config_parameter">
+            <field name="key">web_vendor_release</field>
+            <field name="value" eval="''"/>
+        </record>
+
+    </data>
+</openerp>

--- a/web_vendor_info/models/__init__.py
+++ b/web_vendor_info/models/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Web Vendor Info module for OpenERP
+#    Copyright (C) 2015 ABF OSIELL SARL (http://osiell.com)
+#                       Sebastien Alix (https://twitter.com/seb_alix)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import company

--- a/web_vendor_info/models/company.py
+++ b/web_vendor_info/models/company.py
@@ -57,7 +57,8 @@ class res_company(osv.Model):
             res[company_id] = vendor_release
         return res
 
-    def _vendor_release_inv(self, cr, uid, id_, name, value, arg, context=None):
+    def _vendor_release_inv(
+            self, cr, uid, id_, name, value, arg, context=None):
         if context is None:
             context = {}
         config_model = self.pool.get('ir.config_parameter')

--- a/web_vendor_info/models/company.py
+++ b/web_vendor_info/models/company.py
@@ -1,0 +1,76 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Web Vendor Info module for OpenERP
+#    Copyright (C) 2015 ABF OSIELL SARL (http://osiell.com)
+#                       Sebastien Alix (https://twitter.com/seb_alix)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import osv, fields
+
+
+class res_company(osv.Model):
+    _inherit = 'res.company'
+
+    def _vendor_name(self, cr, uid, ids, name, arg, context=None):
+        """fields.function 'vendor_name'."""
+        if context is None:
+            context = {}
+        res = {}
+        config_model = self.pool.get('ir.config_parameter')
+        vendor_name = config_model.get_param(
+            cr, uid, 'web_vendor_name', context=context)
+        for company_id in ids:
+            res[company_id] = vendor_name
+        return res
+
+    def _vendor_name_inv(self, cr, uid, id_, name, value, arg, context=None):
+        if context is None:
+            context = {}
+        config_model = self.pool.get('ir.config_parameter')
+        config_model.set_param(
+            cr, uid, 'web_vendor_name', value, context=context)
+
+    def _vendor_release(self, cr, uid, ids, name, arg, context=None):
+        """fields.function 'vendor_release'."""
+        if context is None:
+            context = {}
+        res = {}
+        config_model = self.pool.get('ir.config_parameter')
+        vendor_release = config_model.get_param(
+            cr, uid, 'web_vendor_release', context=context)
+        for company_id in ids:
+            res[company_id] = vendor_release
+        return res
+
+    def _vendor_release_inv(self, cr, uid, id_, name, value, arg, context=None):
+        if context is None:
+            context = {}
+        config_model = self.pool.get('ir.config_parameter')
+        config_model.set_param(
+            cr, uid, 'web_vendor_release', value, context=context)
+
+    _columns = {
+        'vendor_name': fields.function(
+            _vendor_name, fnct_inv=_vendor_name_inv,
+            type='char',
+            string=u"Vendor name"),
+        'vendor_release': fields.function(
+            _vendor_release, fnct_inv=_vendor_release_inv,
+            type='char',
+            string=u"Vendor release"),
+    }

--- a/web_vendor_info/static/src/css/vendor_info.css
+++ b/web_vendor_info/static/src/css/vendor_info.css
@@ -1,0 +1,7 @@
+.openerp .oe_vendor_name {
+    color: blue;
+    font-weight: bold;
+}
+
+.openerp .oe_vendor_release {
+}

--- a/web_vendor_info/static/src/js/vendor_info.js
+++ b/web_vendor_info/static/src/js/vendor_info.js
@@ -59,10 +59,10 @@ openerp.web_vendor_info = function (instance) {
     });
 
     /**************************************************************************
-    Extend 'WebClient' Widget to insert a 'VendorInfoWidget' widget
+    Extend 'Menu' Widget to insert a 'VendorInfoWidget' widget
     only if required data to display are available.
     **************************************************************************/
-    instance.web.WebClient.include({
+    instance.web.Menu.include({
 
         start: function() {
             return $.when(this._super()).then(function() {

--- a/web_vendor_info/static/src/js/vendor_info.js
+++ b/web_vendor_info/static/src/js/vendor_info.js
@@ -1,0 +1,75 @@
+/******************************************************************************
+
+    Web Vendor Info module for OpenERP
+    Copyright (C) 2015 ABF OSIELL SARL (http://osiell.com)
+                       Sebastien Alix (https://twitter.com/seb_alix)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+******************************************************************************/
+
+openerp.web_vendor_info = function (instance) {
+
+    /**************************************************************************
+    Create an new 'VendorInfoWidget' widget
+    **************************************************************************/
+    instance.web.VendorInfoWidget = instance.web.Widget.extend({
+
+        template: 'VendorInfoWidget',
+
+        init: function(parent) {
+            this._super(parent);
+            this.release = '';
+            this.vendor = '';
+            this._load_data();
+        },
+
+        _fetch: function(model, fields, domain){
+            return new instance.web.Model(model).query(fields).filter(domain).all();
+        },
+
+        _load_data: function() {
+            var self = this
+            query = self._fetch('res.company', ['vendor_name', 'vendor_release'])
+            query.then(function(result) {
+                self.vendor = result[0].vendor_name;
+                self.release = result[0].vendor_release
+                self._display_data();
+            });
+        },
+
+        _display_data: function() {
+            if (this.vendor) {
+                instance.webclient.$el.find('.oe_footer').html('');
+                this.appendTo(instance.webclient.$el.find('.oe_footer'));
+            };
+        },
+
+    });
+
+    /**************************************************************************
+    Extend 'WebClient' Widget to insert a 'VendorInfoWidget' widget
+    only if required data to display are available.
+    **************************************************************************/
+    instance.web.WebClient.include({
+
+        start: function() {
+            return $.when(this._super()).then(function() {
+                new instance.web.VendorInfoWidget();
+            });
+        },
+
+    });
+
+};

--- a/web_vendor_info/static/src/xml/vendor_info.xml
+++ b/web_vendor_info/static/src/xml/vendor_info.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ********************************************************************** -->
+<!--                                                                        -->
+<!--Web Vendor Info module for OpenERP                                    -->
+<!--Copyright (C) 2015  ABF OSIELL SARL (http://osiell.com)                 -->
+<!--                    Sebastien Alix (https://twitter.com/seb_alix)       -->
+<!--                                                                        -->
+<!--This program is free software: you can redistribute it and/or modify    -->
+<!--it under the terms of the GNU Affero General Public License as          -->
+<!--published by the Free Software Foundation, either version 3 of the      -->
+<!--License, or (at your option) any later version.                         -->
+<!--                                                                        -->
+<!--This program is distributed in the hope that it will be useful,         -->
+<!--but WITHOUT ANY WARRANTY; without even the implied warranty of          -->
+<!--MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           -->
+<!--GNU Affero General Public License for more details.                     -->
+<!--                                                                        -->
+<!--You should have received a copy of the GNU Affero General Public License-->
+<!--along with this program.  If not, see <http://www.gnu.org/licenses/>.   -->
+<!--                                                                        -->
+<!-- ********************************************************************** -->
+<template>
+
+    <t t-name="VendorInfoWidget">
+        <span>Powered by <span class="oe_vendor_name"><t t-esc="widget.vendor"/></span></span>
+        <t t-if="widget.release">
+            <br/>
+            <span class="oe_vendor_release"><t t-esc="widget.release"/></span>
+        </t>
+    </t>
+
+</template>
+


### PR DESCRIPTION
This module replaces the _Powered by OpenERP_ at the bottom of the Web interface by the vendor's name, and optionally the release number.

These new configuration parameters are available:
- `web_vendor_name`
- `web_vendor_release`
