### PR TITLE
[FIX][8.0] web_shortcuts : Make sure that the menu still exists in odoo

### DIFF
--- a/web_shortcuts/model/web_shortcut.py
+++ b/web_shortcuts/model/web_shortcut.py
@@ -39,14 +39,17 @@ class web_shortcut(models.Model):
     @api.model
     def get_user_shortcuts(self, user_id):
         shortcuts = self.search([('user_id', '=', user_id)])
-        results = shortcuts.read(['menu_id'])
-        ir_ui_menu_obj = self.env['ir.ui.menu']
-        menus = ir_ui_menu_obj.search([('id', 'in', [x['menu_id'][0]
-                                                     for x in results])])
-        name_map = dict(menus.name_get())
-        # Make sure to return only shortcuts pointing to existing menu items.
-        filtered_results = filter(lambda result: result['menu_id'][0] in
-                                  name_map, results)
-        for result in filtered_results:
-            result.update(name=name_map[result['menu_id'][0]])
-        return filtered_results
+        res = []
+        for shortcut in shortcuts:
+            if shortcut.menu_id:
+                _name = shortcut.menu_id.name_get()
+                _name = _name[0][1] if len(_name) else ''
+                _id = shortcut.menu_id.id
+                res.append(
+                    {
+                        'id': shortcut.id,
+                        'name': _name,
+                        'menu_id': (_id, _name)
+                    }
+                )
+        return res

--- a/web_shortcuts/model/web_shortcut.py
+++ b/web_shortcuts/model/web_shortcut.py
@@ -40,16 +40,15 @@ class web_shortcut(models.Model):
     def get_user_shortcuts(self, user_id):
         shortcuts = self.search([('user_id', '=', user_id)])
         res = []
-        for shortcut in shortcuts:
-            if shortcut.menu_id:
-                _name = shortcut.menu_id.name_get()
-                _name = _name[0][1] if len(_name) else ''
-                _id = shortcut.menu_id.id
-                res.append(
-                    {
-                        'id': shortcut.id,
-                        'name': _name,
-                        'menu_id': (_id, _name)
-                    }
-                )
+        for shortcut in shortcuts.filtered('menu_id'):
+            _name = shortcut.menu_id.name_get()
+            _name = _name[0][1] if len(_name) else ''
+            _id = shortcut.menu_id.id
+            res.append(
+                {
+                    'id': shortcut.id,
+                    'name': _name,
+                    'menu_id': (_id, _name)
+                }
+            )
         return res

--- a/web_shortcuts/model/web_shortcut.py
+++ b/web_shortcuts/model/web_shortcut.py
@@ -22,11 +22,11 @@
 from openerp import models, fields, api
 
 
-class web_shortcut(models.Model):
+class WebShortcut(models.Model):
     _name = 'web.shortcut'
 
     name = fields.Char('Shortcut Name', size=64)
-    menu_id = fields.Many2one('ir.ui.menu')
+    menu_id = fields.Many2one('ir.ui.menu', ondelete='cascade')
     user_id = fields.Many2one('res.users', 'User Ref.', required=True,
                               ondelete='cascade', select=True,
                               default=lambda obj, cr, uid, context: uid)
@@ -51,4 +51,16 @@ class web_shortcut(models.Model):
                     'menu_id': (_id, _name)
                 }
             )
+        return res
+
+
+class IrUiView(models.Model):
+    _inherit = 'ir.ui.menu'
+
+    @api.multi
+    def unlink(self):
+        res = super(IrUiView, self).unlink()
+        shortcuts = self.env['web.shortcut'].search([('menu_id', '=', False)])
+        for shortcut in shortcuts:
+            shortcut.unlink()
         return res


### PR DESCRIPTION
[FIX] : make sure that the menu still exists in odoo
[IMP] : simplify the code

``` python
Traceback (most recent call last):
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/http.py", line 530, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/http.py", line 567, in dispatch
    result = self._call_function(**self.params)
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/http.py", line 303, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/service/model.py", line 113, in wrapper
    return f(dbname, *args, **kwargs)
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/http.py", line 300, in checked_call
    return self.endpoint(*a, **kw)
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/http.py", line 796, in __call__
    return self.method(*args, **kw)
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/http.py", line 396, in response_wrap
    response = f(*args, **kw)
  File "/usr/local/openerp/openerp-buildout/parts/addons/addons/web/controllers/main.py", line 949, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/usr/local/openerp/openerp-buildout/parts/addons/addons/web/controllers/main.py", line 941, in _call_kw
    return getattr(request.registry.get(model), method)(request.cr, request.uid, *args, **kwargs)
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/api.py", line 241, in wrapper
    return old_api(self, *args, **kwargs)
  File "/usr/local/openerp/openerp-buildout/parts/addons/openerp/api.py", line 336, in old_api
    result = method(recs, *args, **kwargs)
  File "/usr/local/openerp/openerp-buildout/addons-web/web_shortcuts/model/web_shortcut.py", line 45, in get_user_shortcuts
    [x['menu_id'][0] for x in results if x['menu_id']]
TypeError: 'bool' object has no attribute '__getitem__'
```
