### PR TITLE
[ADD] support 'open' on many2many_tags

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -1,17 +1,13 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
 ==================================
 Add new options for many2one field
 ==================================
 
-
-Description
------------
-
 This modules modifies "many2one" and "many2manytags" form widgets so as to add some new display
 control options.
-
-**New: support many2manytags widget !**
-
-**New: support global option management with ir.config_parameter !**
 
 Options provided includes possibility to remove "Create..." and/or "Create and
 Edit..." entries from many2one drop down. You can also change default number of
@@ -19,17 +15,21 @@ proposition appearing in the drop-down. Or prevent the dialog box poping in
 case of validation error.
 
 If not specified, the module will avoid proposing any of the create options
-if the current user have no permission rights to create the related object.
+if the current has no permission rights to create the related object.
 
+Usage
+=====
 
-Requirements
-------------
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/162/8.0
 
-Was tested on openerp 8.0, trunk, saas-5 branch. New way to import js file. (thanks to tfossoul)
+For further information, please visit:
 
+* https://www.odoo.com/forum/help-1
 
-New options
------------
+in the field's options dict
+---------------------------
 
 ``create`` *boolean* (Default: depends if user have create rights)
 
@@ -47,20 +47,20 @@ New options
 
   Number of displayed record in drop-down panel
 
-``search_more`` *boolean* 
+``search_more`` *boolean*
 
   Used to force disable/enable search more button.
-  
+
 ``field_color`` *string*
 
   A string to define the field used to define color.
   This option has to be used with colors.
-  
+
 ``colors`` *dictionary*
 
   A dictionary to link field value with a HTML color.
   This option has to be used with field_color.
-  
+
 ``no_open_edit`` *boolean* (Default: value of ``no_open`` which is ``False`` if not set)
 
   Causes a many2one not to offer to click through in edit mode, but well in read mode
@@ -113,9 +113,43 @@ Your XML form view definition could contain::
     <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false, 'search_more':true 'field_color':'state', 'colors':{'active':'green'}}"/>
     ...
 
-Note
-----
+Known issues
+============
 
 Double check that you have no inherited view that remove ``options`` you set on a field ! 
-If nothing works, add a debugger in the first line of ``get_search_result method`` and enable debug mode in OpenERP. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
+If nothing works, add a debugger in the first line of ``get_search_result method`` and enable debug mode in Odoo. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
 
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/web/issues/new?body=module:%20web_m2x_options%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* David Coninckx <davconinckx@gmail.com>
+* Emanuel Cino <ecino@compassion.ch>
+* Holger Brunn <hbrunn@therp.nl>
+* Nicolas JEUDY <nicolas@sudokeys.com>
+* Yannick Vaucher <yannick.vaucher@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -119,6 +119,13 @@ Known issues
 Double check that you have no inherited view that remove ``options`` you set on a field ! 
 If nothing works, add a debugger in the first line of ``get_search_result method`` and enable debug mode in Odoo. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
 
+Roadmap
+=======
+
+- Instead of making the tags rectangle clickable, I think it's better to put the text as a clickable link, so we will get a consistent behaviour/aspect with other clickable elements (many2one...).
+- In edit mode, it would be great to add an icon like the one on many2one fields to allow to open the many2many in a popup window.
+- Include this feature as a configurable option via parameter to have this behaviour by default in all many2many tags.
+
 Bug Tracker
 ===========
 

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -61,7 +61,13 @@ New options
   A dictionary to link field value with a HTML color.
   This option has to be used with field_color.
   
+``no_open_edit`` *boolean* (Default: value of ``no_open`` which is ``False`` if not set)
 
+  Causes a many2one not to offer to click through in edit mode, but well in read mode
+
+``open`` *boolean* (Default: ``False``)
+
+  Makes many2many_tags buttons that open the linked resource
 
 ir.config_parameter options
 ---------------------------
@@ -110,6 +116,6 @@ Your XML form view definition could contain::
 Note
 ----
 
-Double check that you have no inherited view that remote ``options`` you set on a field ! 
-If nothing work, add a debugger in the first ligne of ``get_search_result method`` and enable debug mode in OpenERP. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
+Double check that you have no inherited view that remove ``options`` you set on a field ! 
+If nothing works, add a debugger in the first line of ``get_search_result method`` and enable debug mode in OpenERP. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
 

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -15,7 +15,7 @@ proposition appearing in the drop-down. Or prevent the dialog box poping in
 case of validation error.
 
 If not specified, the module will avoid proposing any of the create options
-if the current has no permission rights to create the related object.
+if the current user has no permission rights to create the related object.
 
 Usage
 =====

--- a/web_m2x_options/__init__.py
+++ b/web_m2x_options/__init__.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -10,8 +10,8 @@
     'qweb': [
         'static/src/xml/base.xml',
     ],
+    'license': 'AGPL-3',
     'data': ['views/view.xml'],
     "author": "0k.io,Odoo Community Association (OCA)",
     "installable": True,
-    "active": False,
 }

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -7,6 +7,9 @@
         'base',
         'web',
     ],
+    'qweb': [
+        'static/src/xml/base.xml',
+    ],
     'data': ['views/view.xml'],
     "author": "0k.io,Odoo Community Association (OCA)",
     "installable": True,

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -336,6 +336,30 @@ openerp.web_m2x_options = function (instance) {
                 return values;
             })
         },
+
+        render_value: function()
+        {
+            var self = this;
+            return jQuery.when(this._super.apply(this, arguments))
+            .then(function()
+            {
+                if(self.options.open)
+                {
+                    self.$el.find('.oe_tag')
+                    .css('cursor', 'pointer')
+                    .click(function(e)
+                    {
+                        var id = parseInt(jQuery(this).attr('data-id'));
+                        self.do_action({
+                            type: 'ir.actions.act_window',
+                            res_model: self.field.relation,
+                            views: [[false, 'form']],
+                            res_id: id,
+                        });
+                    });
+                }
+            });
+        },
     });
 };
 

--- a/web_m2x_options/static/src/xml/base.xml
+++ b/web_m2x_options/static/src/xml/base.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+<t t-extend="FieldMany2One">
+    <t t-jquery="a.oe_m2o_cm_button">
+        jQuery(this).attr('t-if', '!(widget.options.no_open || widget.options.no_open_edit)');
+    </t>
+</t>
+<t t-extend="FieldMany2ManyTag">
+    <t t-jquery="span.oe_tag">
+        jQuery(this).attr('t-att-data-id', 'el[0]');
+    </t>
+</t>
+</templates>


### PR DESCRIPTION
[ADD] support 'no_open_edit' on many2one
[FIX] typos

---

`no_open_edit` _boolean_ (Default: value of `no_open` which is `False` if not set)

  Causes a many2one not to offer to click through in edit mode, but well in read mode

`open` _boolean_ (Default: `False`)

  Makes many2many_tags buttons that open the linked resource
