### PR TITLE
IMP web_last_viewed_records - use full width of the header

### DIFF
--- a/web_last_viewed_records/static/src/xml/main.xml
+++ b/web_last_viewed_records/static/src/xml/main.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="web_last_viewed_records.header">
         <tr class="oe_header_row">
-            <td t-att-colspan="colspan or '3'">
+            <td t-att-colspan="colspan or '4'">
                 <div class="oe_view_manager_last_viewed"/>
             </td>
             <td></td>
@@ -16,7 +16,7 @@
     <t t-extend="mail.wall">
         <t t-jquery="tr.oe_header_row_top" t-operation="after">
             <t t-call="web_last_viewed_records.header">
-                <t t-set="colspan" t-value="2"/>
+                <t t-set="colspan" t-value="3"/>
             </t>
         </t>
     </t>


### PR DESCRIPTION
This change will allow the use of the full width when displaying the last viewed records.

Currently: 
<img width="1052" alt="screen shot 2015-08-05 at 1 37 06 pm" src="https://cloud.githubusercontent.com/assets/7885477/9092952/566e8396-3b77-11e5-9e77-4e8ab43d0e2c.png">

With this change:
<img width="1053" alt="screen shot 2015-08-05 at 1 38 03 pm" src="https://cloud.githubusercontent.com/assets/7885477/9093136/37a14e84-3b78-11e5-9874-679ebc967855.png">
