### PR TITLE
IMP web_environment_ribbon - Minor improvement of transparency to all…

### DIFF
--- a/web_environment_ribbon/static/src/css/ribbon.css
+++ b/web_environment_ribbon/static/src/css/ribbon.css
@@ -16,7 +16,7 @@
     z-index: 10000;
     position: fixed;
     box-shadow: 0 0 3px rgba(0,0,0,.3);
-    background: #e43;
+    background: rgba(255, 0, 0, .6);;
 }
 
 .test-ribbon b {


### PR DESCRIPTION
…ow top menu visibility

Users can not see the top menu. Changing the transparency seems to be an easy fix

Currently:
<img width="206" alt="screen shot 2015-08-05 at 1 50 47 pm" src="https://cloud.githubusercontent.com/assets/7885477/9093408/fdcd2064-3b79-11e5-847f-9cb9936ac9a1.png">

With this change:
<img width="202" alt="screen shot 2015-08-05 at 1 50 23 pm" src="https://cloud.githubusercontent.com/assets/7885477/9093414/03b82b86-3b7a-11e5-98c7-3b862f1653fa.png">
