### PR TITLE
[FIX] Issue #193. Display help button as inline-block

### DIFF
--- a/help_online/static/src/css/help_online.css
+++ b/help_online/static/src/css/help_online.css
@@ -8,5 +8,5 @@ li.oe_help_online_not_found {
   text-align: center;
   margin: 3px auto 4px;
   position: relative;
-  display: block;
+  display: inline-block;
 }


### PR DESCRIPTION
Tested with FF 40.0.3 and Chromium 44.0.2403.89 Ubuntu 15.04 (64-bit)
