### PR TITLE
7.0 backport web widget many2many tags multi selection from 8.0

### DIFF
--- a/web_widget_many2many_tags_multi_selection/README.rst
+++ b/web_widget_many2many_tags_multi_selection/README.rst
@@ -1,3 +1,8 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================================
 Allows multiple selection on many2many_tags widget
 ==================================================
 
@@ -13,20 +18,39 @@ Installation
 
 It was tested on Odoo 7.0 branch.
 
+Configuration
+=============
+
+Once installed, there is nothing else to do.
+
+Usage
+=====
+
+Open the `search more...` popup on any ``many2many_tags`` widget.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/162/7.0
+
+
+Known issues / Roadmap
+======================
+
+* allow multi selection in drop-down.
 
 Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/web/issues/new?body=module:%20web_widget_many2many_tags_multi_selection%0Aversion:%207.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+web/issues/new?body=module:%20
+web_widget_many2many_tags_multi_selection%0Aversion:%20
+7.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits
 =======
-
-Akretion
 
 Contributors
 ------------
@@ -37,13 +61,14 @@ Contributors
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
-OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
 
 To contribute to this module, please visit http://odoo-community.org.
-

--- a/web_widget_many2many_tags_multi_selection/README.rst
+++ b/web_widget_many2many_tags_multi_selection/README.rst
@@ -1,0 +1,49 @@
+Allows multiple selection on many2many_tags widget
+==================================================
+
+In a many2many_tags widget when a lot of entries should be selected it's
+fastidious to select 80% of them. Then you may click on 'search more',
+but impossible to select several attributes at once.
+
+This module adds a checkbox to this list so multiple entries can be selected
+at once.
+
+Installation
+============
+
+It was tested on Odoo 7.0 branch.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/web/issues/new?body=module:%20web_widget_many2many_tags_multi_selection%0Aversion:%207.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Akretion
+
+Contributors
+------------
+
+* Sylvain Calador <sylvain.calador@akretion.com>
+* Pierre Verkest <pverkest@anybox.fr>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+

--- a/web_widget_many2many_tags_multi_selection/__init__.py
+++ b/web_widget_many2many_tags_multi_selection/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2015-TODAY Akretion (<http://www.akretion.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################

--- a/web_widget_many2many_tags_multi_selection/__openerp__.py
+++ b/web_widget_many2many_tags_multi_selection/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2015-TODAY Akretion (<http://www.akretion.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Tags multiple selection',
+    'version': '0.1',
+    'author': 'Akretion, Anybox, Odoo Community Association (OCA)',
+    'depends': [
+        'web',
+    ],
+    'demo': [],
+    'website': 'https://www.akretion.com',
+    'js': [
+        'static/src/js/view_form.js',
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/web_widget_many2many_tags_multi_selection/__openerp__.py
+++ b/web_widget_many2many_tags_multi_selection/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     'name': 'Tags multiple selection',
-    'version': '0.1',
+    'version': '7.0.1.0',
     'author': 'Akretion, Anybox, Odoo Community Association (OCA)',
     'descriptions': """
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg

--- a/web_widget_many2many_tags_multi_selection/__openerp__.py
+++ b/web_widget_many2many_tags_multi_selection/__openerp__.py
@@ -23,7 +23,7 @@
     'name': 'Tags multiple selection',
     'version': '7.0.1.0',
     'author': 'Akretion, Anybox, Odoo Community Association (OCA)',
-    'descriptions': """
+    'description': """
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3

--- a/web_widget_many2many_tags_multi_selection/__openerp__.py
+++ b/web_widget_many2many_tags_multi_selection/__openerp__.py
@@ -23,6 +23,85 @@
     'name': 'Tags multiple selection',
     'version': '0.1',
     'author': 'Akretion, Anybox, Odoo Community Association (OCA)',
+    'descriptions': """
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================================
+Allows multiple selection on many2many_tags widget
+==================================================
+
+In a many2many_tags widget when a lot of entries should be selected it's
+fastidious to select 80% of them. Then you may click on 'search more',
+but impossible to select several attributes at once.
+
+This module adds a checkbox to this list so multiple entries can be selected
+at once.
+
+Installation
+============
+
+It was tested on Odoo 7.0 branch.
+
+Configuration
+=============
+
+Once installed, there is nothing else to do.
+
+Usage
+=====
+
+Open the `search more...` popup on any ``many2many_tags`` widget.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/
+           datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/162/7.0
+
+
+Known issues / Roadmap
+======================
+
+* allow multi selection in drop-down.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and
+welcomed feedback `here <https://github.com/OCA/web/issues/new?body=module:%20
+web_widget_many2many_tags_multi_selection%0Aversion:%207.0%0A%0A
+**Steps%20to%20reproduce**%0A-%20...%0A%0A
+**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Sylvain Calador <sylvain.calador@akretion.com>
+* Pierre Verkest <pverkest@anybox.fr>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+
+    """,
     'depends': [
         'web',
     ],
@@ -33,4 +112,5 @@
     ],
     'installable': True,
     'auto_install': False,
+    'license': 'AGPL-3',
 }

--- a/web_widget_many2many_tags_multi_selection/static/src/js/view_form.js
+++ b/web_widget_many2many_tags_multi_selection/static/src/js/view_form.js
@@ -1,0 +1,45 @@
+openerp.web_widget_many2many_tags_multi_selection = function(instance) {
+    "use strict";
+
+    var _t = instance.web._t;
+
+    instance.web.form.CompletionFieldMixin._search_create_popup = function(view, ids, context) {
+        var self = this;
+        var pop = new instance.web.form.SelectCreatePopup(this);
+        var domain = self.build_domain();
+
+        if (self.field.type == 'many2many') {
+            var selected_ids = self.get_search_blacklist();
+            if (selected_ids.length > 0) {
+                domain = new instance.web.CompoundDomain(domain, ["!", ["id", "in", selected_ids]]);
+            }
+        }
+
+        pop.select_element(
+            self.field.relation,
+            {
+                title: (view === 'search' ? _t("Search: ") : _t("Create: ")) + this.string,
+                initial_ids: ids ? _.map(ids, function(x) {return x[0];}) : undefined,
+                initial_view: view,
+                disable_multiple_selection: this.field.type != 'many2many',
+            },
+            domain,
+            new instance.web.CompoundContext(self.build_context(), context || {})
+        );
+        pop.on("elements_selected", self, function(element_ids) {
+            for(var i=0, len=element_ids.length; i<len;i++) {
+                self.add_id(element_ids[i]);
+                if (self.field.type != 'many2many') {
+                    break;
+                }
+            }
+            self.focus();
+        });
+    };
+
+    instance.web.form.FieldMany2ManyTags.include({
+        _search_create_popup: function() {
+            return instance.web.form.CompletionFieldMixin._search_create_popup.apply(this, arguments);
+        },
+    });
+};


### PR DESCRIPTION
This is a backport to v 7.0 of @sylvainc module: [web_widget_many2many_tags_multi_selection](https://github.com/OCA/web/tree/8.0/web_widget_many2many_tags_multi_selection).
