### PR TITLE
[web_tree_image]: Add support for image resize

### DIFF
--- a/web_tree_image/README.rst
+++ b/web_tree_image/README.rst
@@ -1,9 +1,13 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+=====================================
 Display images and icons in tree view
 =====================================
 
 This module defines a tree image widget, to be used with either binary fields
-or (function) fields of type character. Use widget='image' in your view
-definition. Optionally, set a 'height' tag. Default height is 16px.
+or (function) fields of type character. Use ``widget='image'`` in your view
+definition. Optionally, set a ``height`` attribute. Default height is 16px.
 
 If you use the widget with a character field, the content of the field can be
 any of the following:
@@ -16,3 +20,33 @@ any of the following:
 
 * A dynamic image in a data url base 64 format. Prefix with
   'data:image/png;base64,'
+
+Usage
+=====
+
+This module defines a new widget type for tree views columns.
+
+Set the attribute ``widget=image`` in a ``field`` tag in a tree view.
+You can also set ``height=<height>`` to set the height the image will have.
+Note that this just sets the CSS ``max-height`` attribute,
+if you want to make the server return a resized, maybe to save data by making it
+return a smaller one or to have uniform images, use the
+``resize="<width>,<height>"`` attribute.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Stefan Rijnhart
+* Leonardo Donelli <donelli@webmonks.it>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.

--- a/web_tree_image/__openerp__.py
+++ b/web_tree_image/__openerp__.py
@@ -3,6 +3,7 @@
 #
 #    OpenERP, Open Source Management Solution
 #    This module copyright (C) 2014 Therp BV (<http://therp.nl>).
+#    copyright (C) 2015 Leonardo Donelli @ MONKSoftware
 #
 #    Snippet from https://github.com/hsd/listview_images
 #    Copyright (C) 2013 Marcel van der Boom <marcel@hsdev.com>
@@ -22,10 +23,12 @@
 #
 ##############################################################################
 {
-    "name": "Show images in tree views",
-    "version": "8.0.1.0.0",
-    "author": "Therp BV,Odoo Community Association (OCA)",
-    'url': 'https://github.com/OCA/Web',
+    'name': 'Show images in tree views',
+    'version': '8.0.1.1.0',
+    'author': 'Therp BV, MONK Software, Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/Web',
+    'license': 'AGPL-3',
+    'category': 'Web',
     'depends': [
         'web',
     ],

--- a/web_tree_image/static/src/js/web_tree_image.js
+++ b/web_tree_image/static/src/js/web_tree_image.js
@@ -35,7 +35,15 @@ openerp.web_tree_image = function (instance) {
                     // The media subtype (png) seems to be arbitrary
                     src = "data:image/png;base64," + value;
                 } else {
-                    src = instance.session.url('/web/binary/image', {model: options.model, field: this.id, id: options.id});
+                    var imageArgs = {
+                        model: options.model,
+                        field: this.id,
+                        id: options.id
+                    }
+                    if (this.resize) {
+                        imageArgs.resize = this.resize;
+                    }
+                    src = instance.session.url('/web/binary/image', imageArgs);
                 }
             } else {
                 if (!/\//.test(row_data[this.id].value)) {


### PR DESCRIPTION
Add support for server-side resizing of the images before they are sent to the web client tree view.

You may want to do this for:
- Saving data: no need to have the server send a 3200x1600 1,5MB image if you just need it to display a thumb of it in a 32 pixels height row of a tree view.
- Uniform images: no more rows with very different image widths! The web resizers can resize all images to any dimension (max 500x500) while keeping aspect ratio by centering the image and filling it with transparent background.
