### PR TITLE
[FIX] the polymorphic widget was not correctly rendered

### DIFF
--- a/web_polymorphic_many2one/static/src/js/view_form.js
+++ b/web_polymorphic_many2one/static/src/js/view_form.js
@@ -18,7 +18,7 @@
 *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 *
 ******************************************************************************/
-openerp.web_polymorphic = function (instance) {
+openerp.web_polymorphic_many2one = function (instance) {
     instance.web.form.FieldPolymorphic = instance.web.form.FieldMany2One.extend( {
         template: "FieldMany2One",
         events: {


### PR DESCRIPTION
This fix will make module 'web_polymorphic_many2one' usable. Without it, the widget is not correctly rendered.
