### PR TITLE
[FIX] web_m2x_options check Many2one and Many2many options

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -67,11 +67,11 @@ openerp.web_m2x_options = function (instance) {
             var self = this;
             // add options limit used to change number of selections record
             // returned.
-	    if (_.isUndefined(this.view))
-                return this._super.apply(this, arguments);
-            if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
-		    this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
-	    }
+            if (_.isUndefined(this.view))
+                    return this._super.apply(this, arguments);
+                if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
+                this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
+            }
 
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
@@ -99,8 +99,7 @@ openerp.web_m2x_options = function (instance) {
                 self.build_context()));
 
             var create_rights;
-            if (typeof this.options.create === "undefined" ||
-                typeof this.options.create_edit === "undefined") {
+            if (!(self.options && (self.options.no_create || self.options.no_create_edit))) {
                 create_rights = new instance.web.Model(this.field.relation).call(
                     "check_access_rights", ["create", false]);
             }
@@ -119,7 +118,7 @@ openerp.web_m2x_options = function (instance) {
                         id: x[0],
                     };
                 });
-                
+
                 // Search result value colors
 
                 if (self.colors && self.field_color) {
@@ -127,7 +126,7 @@ openerp.web_m2x_options = function (instance) {
                     for (var index in values) {
                         value_ids.push(values[index].id);
                     }
-                    
+
                     // RPC request to get field_color from Objects
                     Objects.query([self.field_color])
                                 .filter([['id', 'in', value_ids]])
@@ -137,7 +136,7 @@ openerp.web_m2x_options = function (instance) {
                                             if (values[index_value].id == objects[index].id) {
                                                 // Find value in values by comparing ids
                                                 var value = values[index_value];
-                                                
+
                                                 // Find color with field value as key
                                                 var color = self.colors[objects[index][self.field_color]] || 'black';
                                                 value.label = '<span style="color:'+color+'">'+value.label+'</span>';
@@ -171,10 +170,15 @@ openerp.web_m2x_options = function (instance) {
                 var raw_result = _(data.result).map(function (x) {
                     return x[1];
                 });
+                var no_quick_create = (
+                    self.options && (self.options.no_create ||
+                                     self.options.no_quick_create)
+                )
+                var m2x_create_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create'])
+                var m2x_create = self.view.ir_options['web_m2x_options.create'] == "True"
 
-                if ((_.isUndefined(self.options.create) && _.isUndefined(self.view.ir_options['web_m2x_options.create']) && can_create) || 
-		    (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create'] == "True") ||
-                    self.options.create) {
+                if (!no_quick_create && ((m2x_create_undef && can_create) ||
+                                         m2x_create)) {
 
                     if (search_val.length > 0 &&
                         !_.include(raw_result, search_val)) {
@@ -192,10 +196,15 @@ openerp.web_m2x_options = function (instance) {
                 }
 
                 // create...
+                var no_create_edit = (
+                    self.options && (self.options.no_create ||
+                                     self.options.no_create_edit)
+                )
+                var m2x_create_edit_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])
+                var m2x_create_edit = self.view.ir_options['web_m2x_options.create_edit'] == "True"
 
-                if ((_.isUndefined(self.options.create_edit) && _.isUndefined(self.view.ir_options['web_m2x_options.create_edit']) && can_create) ||
-		    (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create_edit'] == "True") ||
-                    self.options.create_edit) {
+                if (!no_create_edit && ((m2x_create_edit_undef && can_create) ||
+                                        m2x_create_edit)) {
 
                     values.push({
                         label: _t("Create and Edit..."),
@@ -207,7 +216,7 @@ openerp.web_m2x_options = function (instance) {
                         classname: 'oe_m2o_dropdown_option'
                     });
                 }
-                
+
                 // Check if colors specified to wait for RPC
                 if (!(self.field_color && self.colors)){
                     def.resolve(values);
@@ -226,28 +235,28 @@ openerp.web_m2x_options = function (instance) {
                 new instance.web.form.M2ODialog(this).open();
             }
         },
-	
-	start: function() {
-	    this._super.apply(this, arguments);
-	    return this.get_options();
-	},
 
-	get_options: function() {
-	    var self = this;
-	    if (_.isUndefined(this.view.ir_options_loaded)) {
-		    this.view.ir_options_loaded = $.Deferred();
-		    this.view.ir_options = {};
-		    (new instance.web.Model("ir.config_parameter"))
-	                .query(["key", "value"]).filter([['key', 'in', OPTIONS]])
-	                .all().then(function(records) {
-		            _(records).each(function(record) {
-			    self.view.ir_options[record.key] = record.value;
-			    });
-		    self.view.ir_options_loaded.resolve();
-		});
-	    }
-	    return this.view.ir_options_loaded;
-	},
+        start: function() {
+            this._super.apply(this, arguments);
+            return this.get_options();
+        },
+
+        get_options: function() {
+            var self = this;
+            if (_.isUndefined(this.view.ir_options_loaded)) {
+                this.view.ir_options_loaded = $.Deferred();
+                this.view.ir_options = {};
+                (new instance.web.Model("ir.config_parameter"))
+                        .query(["key", "value"]).filter([['key', 'in', OPTIONS]])
+                        .all().then(function(records) {
+                        _(records).each(function(record) {
+                    self.view.ir_options[record.key] = record.value;
+                    });
+                self.view.ir_options_loaded.resolve();
+            });
+            }
+            return this.view.ir_options_loaded;
+        },
 
         /**
         * Call this method to search using a string.
@@ -258,10 +267,10 @@ openerp.web_m2x_options = function (instance) {
 
             // add options limit used to change number of selections record
             // returned.
-	
-	    if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
-	        this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
-	    }
+
+            if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
+                this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
+            }
 
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
@@ -300,10 +309,15 @@ openerp.web_m2x_options = function (instance) {
                     });
                 }
                 // quick create
+                var no_quick_create = (
+                    self.options && (self.options.no_create ||
+                                     self.options.no_quick_create)
+                )
+                var m2x_create_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create'])
+                var m2x_create = self.view.ir_options['web_m2x_options.create'] == "True"
 
-                if ((_.isUndefined(self.options.create) && _.isUndefined(self.view.ir_options['web_m2x_options.create'])) ||
-		    (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create'] == 'True') ||
-                    self.options.create) {
+                if (!no_quick_create && ((m2x_create_undef && can_create) ||
+                                         m2x_create)) {
 
                     var raw_result = _(data.result).map(function(x) {return x[1];});
                     if (search_val.length > 0 && !_.include(raw_result, search_val)) {
@@ -319,10 +333,15 @@ openerp.web_m2x_options = function (instance) {
                 }
 
                 // create...
+                var no_create_edit = (
+                    self.options && (self.options.no_create ||
+                                     self.options.no_create_edit)
+                )
+                var m2x_create_edit_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])
+                var m2x_create_edit = self.view.ir_options['web_m2x_options.create_edit'] == "True"
 
-                if ((_.isUndefined(self.options.create_edit === 'undefined') && _.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) ||
-	            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create_edit'] == 'True') ||
-                    self.options.create_edit) {
+                if (!no_create_edit && ((m2x_create_edit_undef && can_create) ||
+                                        m2x_create_edit)) {
 
                     values.push({
                         label: _t("Create and Edit..."),

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -316,8 +316,7 @@ openerp.web_m2x_options = function (instance) {
                 var m2x_create_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create'])
                 var m2x_create = self.view.ir_options['web_m2x_options.create'] == "True"
 
-                if (!no_quick_create && ((m2x_create_undef && can_create) ||
-                                         m2x_create)) {
+                if (!no_quick_create && (m2x_create_undef || m2x_create)) {
 
                     var raw_result = _(data.result).map(function(x) {return x[1];});
                     if (search_val.length > 0 && !_.include(raw_result, search_val)) {
@@ -340,8 +339,7 @@ openerp.web_m2x_options = function (instance) {
                 var m2x_create_edit_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])
                 var m2x_create_edit = self.view.ir_options['web_m2x_options.create_edit'] == "True"
 
-                if (!no_create_edit && ((m2x_create_edit_undef && can_create) ||
-                                        m2x_create_edit)) {
+                if (!no_create_edit && (m2x_create_edit_undef || m2x_create_edit)) {
 
                     values.push({
                         label: _t("Create and Edit..."),


### PR DESCRIPTION
This fix these issues:
- Do not overwrite options defined in view
- Read `no_create`, `no_create_edit` and `no_quick_create` options, instead of  `create`
- Replace tabs by spaces for cleaner alignment.

For testing propuse in runbot, you can do this:
- Set  `web_m2x_options.create` system parameter as False
- Go to any view and edit it setting any Many2one field adding options attribute as `options="{'no_create': True}"`

In this case, addon will remove 'Create...' (quick create) option, but view is removing both (quick create and create edit). With this fix addon is taking care of this.

I've done this in `res.partner.title` field in runbot
