### PR TITLE
[9.0] web_dialog_size: Do make the dialog window moveable

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.js
@@ -13,6 +13,7 @@ openerp.web_dialog_size= function (instance) {
                 self.$dialog_box.find('.dialog_button_extend').on('click', self._extending);
                 self.$dialog_box.find('.dialog_button_restore').on('click', self._restore);
             }
+            $(".modal-dialog").draggable();
         },
 
         _extending: function() {


### PR DESCRIPTION
Please accept this small addition to make the dialog moveable.
Very often the dialog does hide some things in the background you may need - so i think this is a great thing here.
