### PR TITLE
[IMP] 7.0 add m2x options for view

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -99,6 +99,33 @@ To add these parameters go to Configuration -> Technical -> Parameters -> System
 - web_m2x_options.search_more: True
 
 
+ir.actions.act_window context options
+-------------------------------------
+
+The following options can be specified in the ``context`` field of an
+``ir.actions.act_window`` to provide the same functionality at the form level:
+
+``create`` *boolean* (Default: depends if user have create rights)
+
+  Whether to display the "Create..." entry in dropdown panels.
+
+``create_edit`` *boolean* (Default: depends if user have create rights)
+
+  Whether to display the "Create and Edit..." entry in dropdown panels.
+
+``m2o_dialog`` *boolean* (Default: depends if user have create rights)
+
+  Whether to display the many2one dialog in case of validation error.
+
+``limit`` *int* (Default: openerp default value is ``7``)
+
+  Number of displayed records in drop-down panels.
+
+``search_more`` *boolean*
+
+  Whether to always display the "Search More..." entry in dropdown panels.
+
+
 Example
 -------
 

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -16,7 +16,7 @@ add some new display control options.
 The options provided include the possibility to remove "Create..." and/or
 "Create and Edit..." entries from many2one and many2many drop down lists. You
 can also change the default number of entries appearing in the drop-down, or
- prevent the dialog box poping in case of validation error occurring.
+prevent the dialog box popping in case of validation error occurring.
 
 If not specified, the module will avoid proposing any of the create options
 if the current user have no permission rights to create the related object.
@@ -132,7 +132,7 @@ Example
 Your XML form view definition could contain::
 
     ...
-    <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false, 'search_more':true 'field_color':'state', 'colors':{'active':'green'}}"/>
+    <field name="partner_id" options="{'limit': 10, 'create': false, 'create_edit': false, 'search_more': true, 'field_color': 'state', 'colors': {'active':'green'}}"/>
     ...
 
 Note

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -2,7 +2,7 @@
 
 {
     "name": 'web_m2x_options',
-    "version": "0.1",
+    "version": "7.0.1.0.0",
     "description": """
 =====================================================
 Add new options for many2one and many2manytags field:
@@ -44,6 +44,7 @@ Thanks to:
         'static/src/js/form.js',
     ],
     "author": "Tuxservices,initOS GmbH,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
     "installable": True,
     "active": False,
 }

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -43,7 +43,7 @@ Thanks to:
     "js": [
         'static/src/js/form.js',
     ],
-    "author": "Tuxservices,Odoo Community Association (OCA)",
+    "author": "Tuxservices,initOS GmbH,Odoo Community Association (OCA)",
     "installable": True,
     "active": False,
 }

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -54,9 +54,15 @@ openerp.web_m2x_options = function (instance) {
         },
 
         show_error_displayer: function () {
-            if(this.is_option_set(this.options.m2o_dialog) ||
-               _.isUndefined(this.options.m2o_dialog) && this.is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']) ||
-               this.can_create && _.isUndefined(this.options.m2o_dialog) && _.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
+            var allow_dialog = this.can_create;
+            if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
+                allow_dialog = this.is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
+            }
+            if (!_.isUndefined(this.options.m2o_dialog)) {
+                allow_dialog = this.is_option_set(this.options.m2o_dialog);
+            }
+
+            if (allow_dialog) {
                 new instance.web.form.M2ODialog(this).open();
             }
         },
@@ -70,17 +76,21 @@ openerp.web_m2x_options = function (instance) {
 
             if (_.isUndefined(this.view))
                     return this._super.apply(this, arguments);
+
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
                 this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
             }
-
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
             }
 
             // add options search_more to force enable or disable search_more button
-            if (this.is_option_set(this.options.search_more) || _.isUndefined(this.options.search_more) && this.is_option_set(self.view.ir_options['web_m2x_options.search_more'])) {
-                this.search_more = true
+            this.search_more = false
+            if (!_.isUndefined(this.view.ir_options['web_m2x_options.search_more'])) {
+                this.search_more = this.is_option_set(this.view.ir_options['web_m2x_options.search_more']);
+            }
+            if (!_.isUndefined(this.options.search_more)) {
+                this.search_more = this.is_option_set(this.options.search_more);
             }
 
             // add options field_color and colors to color item(s) depending on field_color value
@@ -176,9 +186,15 @@ openerp.web_m2x_options = function (instance) {
                     return x[1];
                 });
 
-                if ((_.isUndefined(self.options.create) && _.isUndefined(self.view.ir_options['web_m2x_options.create']) && can_create) ||
-		            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create'] == "True") ||
-                    self.options.create) {
+                var allow_create = can_create;
+                if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
+                    allow_create = self.is_option_set(self.view.ir_options['web_m2x_options.create']);
+                }
+                if (!_.isUndefined(self.options.create)) {
+                    allow_create = self.is_option_set(self.options.create);
+                }
+
+                if (allow_create) {
 
                     if (search_val.length > 0 &&
                         !_.include(raw_result, search_val)) {
@@ -198,9 +214,15 @@ openerp.web_m2x_options = function (instance) {
 
                 // create...
 
-                if ((_.isUndefined(self.options.create_edit) && _.isUndefined(self.view.ir_options['web_m2x_options.create_edit']) && can_create) ||
-		            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create_edit'] == "True") ||
-                    self.options.create_edit) {
+                var allow_create_edit = can_create;
+                if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
+                    allow_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
+                }
+                if (!_.isUndefined(self.options.create_edit)) {
+                    allow_create_edit = self.is_option_set(self.options.create_edit);
+                }
+
+                if (allow_create_edit) {
 
                     values.push({
                         label: _t("Create and Edit..."),
@@ -225,13 +247,6 @@ openerp.web_m2x_options = function (instance) {
 
     instance.web.form.FieldMany2ManyTags.include({
 
-        show_error_displayer: function () {
-            if ((typeof this.options.m2o_dialog === 'undefined' && this.can_create) ||
-                this.options.m2o_dialog) {
-                new instance.web.form.M2ODialog(this).open();
-            }
-        },
-
         start: function() {
             this._super.apply(this, arguments);
             return this.get_options();
@@ -254,6 +269,34 @@ openerp.web_m2x_options = function (instance) {
             return this.view.ir_options_loaded;
         },
 
+        is_option_set: function(option) {
+            if (_.isUndefined(option)) {
+                return false
+            }
+            var is_string = typeof option === 'string'
+            var is_bool = typeof option === 'boolean'
+            if (is_string) {
+                return option === 'true' || option === 'True'
+            } else if (is_bool) {
+                return option
+            }
+            return false
+        },
+
+        show_error_displayer: function () {
+            var allow_dialog = this.can_create;
+            if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
+                allow_dialog = this.is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
+            }
+            if (!_.isUndefined(this.options.m2o_dialog)) {
+                allow_dialog = this.is_option_set(this.options.m2o_dialog);
+            }
+
+            if (allow_dialog) {
+                new instance.web.form.M2ODialog(this).open();
+            }
+        },
+
         /**
         * Call this method to search using a string.
         */
@@ -267,7 +310,6 @@ openerp.web_m2x_options = function (instance) {
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
                 this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
             }
-
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
             }
@@ -306,9 +348,15 @@ openerp.web_m2x_options = function (instance) {
                 }
                 // quick create
 
-                if ((_.isUndefined(self.options.create) && _.isUndefined(self.view.ir_options['web_m2x_options.create'])) ||
-		            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create'] == 'True') ||
-                    self.options.create) {
+                var allow_create = can_create;
+                if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
+                    allow_create = self.is_option_set(self.view.ir_options['web_m2x_options.create']);
+                }
+                if (!_.isUndefined(self.options.create)) {
+                    allow_create = self.is_option_set(self.options.create);
+                }
+
+                if (allow_create) {
 
                     var raw_result = _(data.result).map(function(x) {return x[1];});
                     if (search_val.length > 0 && !_.include(raw_result, search_val)) {
@@ -324,9 +372,15 @@ openerp.web_m2x_options = function (instance) {
                 }
                 // create...
 
-                if ((_.isUndefined(self.options.create_edit === 'undefined') && _.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) ||
-	            (_.isUndefined(self.options.create) && self.view.ir_options['web_m2x_options.create_edit'] == 'True') ||
-                    self.options.create_edit) {
+                var allow_create_edit = can_create;
+                if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
+                    allow_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
+                }
+                if (!_.isUndefined(self.options.create_edit)) {
+                    allow_create_edit = self.is_option_set(self.options.create_edit);
+                }
+
+                if (allow_create_edit) {
 
                     values.push({
                         label: _t("Create and Edit..."),

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -14,55 +14,54 @@ openerp.web_m2x_options = function (instance) {
                    'web_m2x_options.search_more',
                    'web_m2x_options.m2o_dialog',];
 
+    var get_options = function(widget) {
+        if (!_.isUndefined(widget.view) && _.isUndefined(widget.view.ir_options_loaded)) {
+        widget.view.ir_options_loaded = $.Deferred();
+        widget.view.ir_options = {};
+        (new instance.web.Model("ir.config_parameter"))
+            .query(["key", "value"]).filter([['key', 'in', OPTIONS]])
+            .all().then(function(records) {
+            _(records).each(function(record) {
+                widget.view.ir_options[record.key] = record.value;
+            });
+            widget.view.ir_options_loaded.resolve();
+            });
+            return widget.view.ir_options_loaded;
+        }
+        return $.when();
+    }
+
+    var is_option_set = function(option) {
+        if (_.isUndefined(option)) {
+            return false
+        }
+        var is_string = typeof option === 'string'
+        var is_bool = typeof option === 'boolean'
+        if (is_string) {
+            return option === 'true' || option === 'True'
+        } else if (is_bool) {
+            return option
+        }
+        return false
+    }
+
     instance.web.form.FieldMany2One = instance.web.form.FieldMany2One.extend({
 
         start: function() {
             this._super.apply(this, arguments);
-            return this.get_options();
-        },
-
-        get_options: function() {
-            var self = this;
-            if (!_.isUndefined(this.view) && _.isUndefined(this.view.ir_options_loaded)) {
-            this.view.ir_options_loaded = $.Deferred();
-            this.view.ir_options = {};
-            (new instance.web.Model("ir.config_parameter"))
-                .query(["key", "value"]).filter([['key', 'in', OPTIONS]])
-                .all().then(function(records) {
-                _(records).each(function(record) {
-                    self.view.ir_options[record.key] = record.value;
-                });
-                self.view.ir_options_loaded.resolve();
-                });
-                return this.view.ir_options_loaded;
-            }
-            return $.when();
-        },
-
-        is_option_set: function(option) {
-            if (_.isUndefined(option)) {
-                return false
-            }
-            var is_string = typeof option === 'string'
-            var is_bool = typeof option === 'boolean'
-            if (is_string) {
-                return option === 'true' || option === 'True'
-            } else if (is_bool) {
-                return option
-            }
-            return false
+            return get_options(this);
         },
 
         show_error_displayer: function () {
             var allow_dialog = this.can_create;
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
-                allow_dialog = this.is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
+                allow_dialog = is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
             }
             if (!_.isUndefined(this.view.dataset.context.m2o_dialog)) {
-                allow_dialog = this.is_option_set(this.view.dataset.context.m2o_dialog);
+                allow_dialog = is_option_set(this.view.dataset.context.m2o_dialog);
             }
             if (!_.isUndefined(this.options.m2o_dialog)) {
-                allow_dialog = this.is_option_set(this.options.m2o_dialog);
+                allow_dialog = is_option_set(this.options.m2o_dialog);
             }
 
             if (allow_dialog) {
@@ -95,13 +94,13 @@ openerp.web_m2x_options = function (instance) {
             // add options search_more to force enable or disable search_more button
             this.search_more = false
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.search_more'])) {
-                this.search_more = this.is_option_set(this.view.ir_options['web_m2x_options.search_more']);
+                this.search_more = is_option_set(this.view.ir_options['web_m2x_options.search_more']);
             }
             if (!_.isUndefined(this.view.dataset.context.search_more)) {
-                this.search_more = this.is_option_set(this.view.dataset.context.search_more);
+                this.search_more = is_option_set(this.view.dataset.context.search_more);
             }
             if (!_.isUndefined(this.options.search_more)) {
-                this.search_more = this.is_option_set(this.options.search_more);
+                this.search_more = is_option_set(this.options.search_more);
             }
 
             // add options field_color and colors to color item(s) depending on field_color value
@@ -201,13 +200,13 @@ openerp.web_m2x_options = function (instance) {
 
                 var allow_create = can_create;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
-                    allow_create = self.is_option_set(self.view.ir_options['web_m2x_options.create']);
+                    allow_create = is_option_set(self.view.ir_options['web_m2x_options.create']);
                 }
                 if (!_.isUndefined(ctx.create)) {
-                    allow_create = self.is_option_set(ctx.create);
+                    allow_create = is_option_set(ctx.create);
                 }
                 if (!_.isUndefined(self.options.create)) {
-                    allow_create = self.is_option_set(self.options.create);
+                    allow_create = is_option_set(self.options.create);
                 }
 
                 if (allow_create) {
@@ -232,13 +231,13 @@ openerp.web_m2x_options = function (instance) {
 
                 var allow_create_edit = can_create;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
-                    allow_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
+                    allow_create_edit = is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
                 }
                 if (!_.isUndefined(ctx.create_edit)) {
-                    allow_create_edit = self.is_option_set(ctx.create_edit);
+                    allow_create_edit = is_option_set(ctx.create_edit);
                 }
                 if (!_.isUndefined(self.options.create_edit)) {
-                    allow_create_edit = self.is_option_set(self.options.create_edit);
+                    allow_create_edit = is_option_set(self.options.create_edit);
                 }
 
                 if (allow_create_edit) {
@@ -268,50 +267,19 @@ openerp.web_m2x_options = function (instance) {
 
         start: function() {
             this._super.apply(this, arguments);
-            return this.get_options();
-        },
-
-        get_options: function() {
-            var self = this;
-            if (_.isUndefined(this.view.ir_options_loaded)) {
-                this.view.ir_options_loaded = $.Deferred();
-                this.view.ir_options = {};
-                (new instance.web.Model("ir.config_parameter"))
-                        .query(["key", "value"]).filter([['key', 'in', OPTIONS]])
-                        .all().then(function(records) {
-                        _(records).each(function(record) {
-                    self.view.ir_options[record.key] = record.value;
-                    });
-                self.view.ir_options_loaded.resolve();
-            });
-            }
-            return this.view.ir_options_loaded;
-        },
-
-        is_option_set: function(option) {
-            if (_.isUndefined(option)) {
-                return false
-            }
-            var is_string = typeof option === 'string'
-            var is_bool = typeof option === 'boolean'
-            if (is_string) {
-                return option === 'true' || option === 'True'
-            } else if (is_bool) {
-                return option
-            }
-            return false
+            return get_options(this);
         },
 
         show_error_displayer: function () {
             var allow_dialog = this.can_create;
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
-                allow_dialog = this.is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
+                allow_dialog = is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
             }
             if (!_.isUndefined(this.view.dataset.context.m2o_dialog)) {
-                allow_dialog = this.is_option_set(this.view.dataset.context.m2o_dialog);
+                allow_dialog = is_option_set(this.view.dataset.context.m2o_dialog);
             }
             if (!_.isUndefined(this.options.m2o_dialog)) {
-                allow_dialog = this.is_option_set(this.options.m2o_dialog);
+                allow_dialog = is_option_set(this.options.m2o_dialog);
             }
 
             if (allow_dialog) {
@@ -376,13 +344,13 @@ openerp.web_m2x_options = function (instance) {
 
                 var allow_create = true;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
-                    allow_create = self.is_option_set(self.view.ir_options['web_m2x_options.create']);
+                    allow_create = is_option_set(self.view.ir_options['web_m2x_options.create']);
                 }
                 if (!_.isUndefined(ctx.create)) {
-                    allow_create = self.is_option_set(ctx.create);
+                    allow_create = is_option_set(ctx.create);
                 }
                 if (!_.isUndefined(self.options.create)) {
-                    allow_create = self.is_option_set(self.options.create);
+                    allow_create = is_option_set(self.options.create);
                 }
 
                 if (allow_create) {
@@ -403,13 +371,13 @@ openerp.web_m2x_options = function (instance) {
 
                 var allow_create_edit = true;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
-                    allow_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
+                    allow_create_edit = is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
                 }
                 if (!_.isUndefined(ctx.create_edit)) {
-                    allow_create_edit = self.is_option_set(ctx.create_edit);
+                    allow_create_edit = is_option_set(ctx.create_edit);
                 }
                 if (!_.isUndefined(self.options.create_edit)) {
-                    allow_create_edit = self.is_option_set(self.options.create_edit);
+                    allow_create_edit = is_option_set(self.options.create_edit);
                 }
 
                 if (allow_create_edit) {

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -16,18 +16,36 @@ openerp.web_m2x_options = function (instance) {
 
     var get_options = function(widget) {
         if (!_.isUndefined(widget.view) && _.isUndefined(widget.view.ir_options_loaded)) {
-        widget.view.ir_options_loaded = $.Deferred();
-        widget.view.ir_options = {};
-        (new instance.web.Model("ir.config_parameter"))
+            widget.view.ir_options_loaded = $.Deferred();
+            widget.view.ir_options = {};
+            (new instance.web.Model("ir.config_parameter"))
             .query(["key", "value"]).filter([['key', 'in', OPTIONS]])
             .all().then(function(records) {
-            _(records).each(function(record) {
-                widget.view.ir_options[record.key] = record.value;
-            });
-            widget.view.ir_options_loaded.resolve();
+                _(records).each(function(record) {
+                    // don't overwrite from global parameters if already set from context or widget
+                    if (_.isUndefined(widget.view.ir_options[record.key])) {
+                        widget.view.ir_options[record.key] = record.value;
+                    }
+                });
+                widget.view.ir_options_loaded.resolve();
             });
             return widget.view.ir_options_loaded;
         }
+        // options from widget are only available here
+        _(OPTIONS).each(function(option) {
+            var p = option.indexOf('.');
+            if (p < 0) return;
+            var key = option.substring(p + 1); // w/o 'web_m2x_options' prefix
+            // ... hence set from context ...
+            if (!_.isUndefined(widget.view.dataset.context[key])) {
+                widget.view.ir_options[option] = widget.view.dataset.context[key];
+            }
+            // ... and (overwrite) from widget here ...
+            if (!_.isUndefined(widget.options[key])) {
+                widget.view.ir_options[option] = widget.options[key];
+            }
+            // ... but don't overwrite from global parameters above
+        })
         return $.when();
     }
 
@@ -57,12 +75,6 @@ openerp.web_m2x_options = function (instance) {
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
                 allow_dialog = is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
             }
-            if (!_.isUndefined(this.view.dataset.context.m2o_dialog)) {
-                allow_dialog = is_option_set(this.view.dataset.context.m2o_dialog);
-            }
-            if (!_.isUndefined(this.options.m2o_dialog)) {
-                allow_dialog = is_option_set(this.options.m2o_dialog);
-            }
 
             if (allow_dialog) {
                 new instance.web.form.M2ODialog(this).open();
@@ -73,34 +85,23 @@ openerp.web_m2x_options = function (instance) {
             var Objects = new instance.web.Model(this.field.relation);
             var def = $.Deferred();
             var self = this;
+
+            if (_.isUndefined(this.view))
+                    return this._super.apply(this, arguments);
+
             var ctx = self.view.dataset.context;
 
             // add options limit used to change number of selections record
             // returned.
 
-            if (_.isUndefined(this.view))
-                    return this._super.apply(this, arguments);
-
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
                 this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
-            }
-            if (typeof ctx.limit === 'number') {
-                this.limit = ctx.limit;
-            }
-            if (typeof this.options.limit === 'number') {
-                this.limit = this.options.limit;
             }
 
             // add options search_more to force enable or disable search_more button
             this.search_more = false
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.search_more'])) {
                 this.search_more = is_option_set(this.view.ir_options['web_m2x_options.search_more']);
-            }
-            if (!_.isUndefined(this.view.dataset.context.search_more)) {
-                this.search_more = is_option_set(this.view.dataset.context.search_more);
-            }
-            if (!_.isUndefined(this.options.search_more)) {
-                this.search_more = is_option_set(this.options.search_more);
             }
 
             // add options field_color and colors to color item(s) depending on field_color value
@@ -202,12 +203,6 @@ openerp.web_m2x_options = function (instance) {
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
                     allow_create = is_option_set(self.view.ir_options['web_m2x_options.create']);
                 }
-                if (!_.isUndefined(ctx.create)) {
-                    allow_create = is_option_set(ctx.create);
-                }
-                if (!_.isUndefined(self.options.create)) {
-                    allow_create = is_option_set(self.options.create);
-                }
 
                 if (allow_create) {
 
@@ -232,12 +227,6 @@ openerp.web_m2x_options = function (instance) {
                 var allow_create_edit = can_create;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
                     allow_create_edit = is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
-                }
-                if (!_.isUndefined(ctx.create_edit)) {
-                    allow_create_edit = is_option_set(ctx.create_edit);
-                }
-                if (!_.isUndefined(self.options.create_edit)) {
-                    allow_create_edit = is_option_set(self.options.create_edit);
                 }
 
                 if (allow_create_edit) {
@@ -275,12 +264,6 @@ openerp.web_m2x_options = function (instance) {
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
                 allow_dialog = is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
             }
-            if (!_.isUndefined(this.view.dataset.context.m2o_dialog)) {
-                allow_dialog = is_option_set(this.view.dataset.context.m2o_dialog);
-            }
-            if (!_.isUndefined(this.options.m2o_dialog)) {
-                allow_dialog = is_option_set(this.options.m2o_dialog);
-            }
 
             if (allow_dialog) {
                 new instance.web.form.M2ODialog(this).open();
@@ -300,12 +283,6 @@ openerp.web_m2x_options = function (instance) {
 
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
                 this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
-            }
-            if (typeof ctx.limit === 'number') {
-                this.limit = ctx.limit;
-            }
-            if (typeof this.options.limit === 'number') {
-                this.limit = this.options.limit;
             }
 
             var dataset = new instance.web.DataSet(this, this.field.relation, self.build_context());
@@ -346,12 +323,6 @@ openerp.web_m2x_options = function (instance) {
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
                     allow_create = is_option_set(self.view.ir_options['web_m2x_options.create']);
                 }
-                if (!_.isUndefined(ctx.create)) {
-                    allow_create = is_option_set(ctx.create);
-                }
-                if (!_.isUndefined(self.options.create)) {
-                    allow_create = is_option_set(self.options.create);
-                }
 
                 if (allow_create) {
 
@@ -372,12 +343,6 @@ openerp.web_m2x_options = function (instance) {
                 var allow_create_edit = true;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
                     allow_create_edit = is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
-                }
-                if (!_.isUndefined(ctx.create_edit)) {
-                    allow_create_edit = is_option_set(ctx.create_edit);
-                }
-                if (!_.isUndefined(self.options.create_edit)) {
-                    allow_create_edit = is_option_set(self.options.create_edit);
                 }
 
                 if (allow_create_edit) {

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -45,23 +45,23 @@ openerp.web_m2x_options = function (instance) {
                 widget.view.ir_options[option] = widget.options[key];
             }
             // ... but don't overwrite from global parameters above
-        })
+        });
         return $.when();
-    }
+    };
 
     var is_option_set = function(option) {
         if (_.isUndefined(option)) {
-            return false
+            return false;
         }
-        var is_string = typeof option === 'string'
-        var is_bool = typeof option === 'boolean'
+        var is_string = typeof option === 'string';
+        var is_bool = typeof option === 'boolean';
         if (is_string) {
-            return option === 'true' || option === 'True'
+            return option === 'true' || option === 'True';
         } else if (is_bool) {
-            return option
+            return option;
         }
-        return false
-    }
+        return false;
+    };
 
     instance.web.form.FieldMany2One = instance.web.form.FieldMany2One.extend({
 
@@ -99,14 +99,14 @@ openerp.web_m2x_options = function (instance) {
             }
 
             // add options search_more to force enable or disable search_more button
-            this.search_more = false
+            this.search_more = false;
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.search_more'])) {
                 this.search_more = is_option_set(this.view.ir_options['web_m2x_options.search_more']);
             }
 
             // add options field_color and colors to color item(s) depending on field_color value
-            this.field_color = this.options.field_color
-            this.colors = this.options.colors
+            this.field_color = this.options.field_color;
+            this.colors = this.options.colors;
 
             var dataset = new instance.web.DataSet(this, this.field.relation,
                                                    self.build_context());
@@ -357,7 +357,7 @@ openerp.web_m2x_options = function (instance) {
                 }
 
                 return values;
-            })
+            });
         },
     });
 };

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -58,6 +58,9 @@ openerp.web_m2x_options = function (instance) {
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
                 allow_dialog = this.is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
             }
+            if (!_.isUndefined(this.view.dataset.context.m2o_dialog)) {
+                allow_dialog = this.is_option_set(this.view.dataset.context.m2o_dialog);
+            }
             if (!_.isUndefined(this.options.m2o_dialog)) {
                 allow_dialog = this.is_option_set(this.options.m2o_dialog);
             }
@@ -71,6 +74,8 @@ openerp.web_m2x_options = function (instance) {
             var Objects = new instance.web.Model(this.field.relation);
             var def = $.Deferred();
             var self = this;
+            var ctx = self.view.dataset.context;
+
             // add options limit used to change number of selections record
             // returned.
 
@@ -80,6 +85,9 @@ openerp.web_m2x_options = function (instance) {
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
                 this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
             }
+            if (typeof ctx.limit === 'number') {
+                this.limit = ctx.limit;
+            }
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
             }
@@ -88,6 +96,9 @@ openerp.web_m2x_options = function (instance) {
             this.search_more = false
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.search_more'])) {
                 this.search_more = this.is_option_set(this.view.ir_options['web_m2x_options.search_more']);
+            }
+            if (!_.isUndefined(this.view.dataset.context.search_more)) {
+                this.search_more = this.is_option_set(this.view.dataset.context.search_more);
             }
             if (!_.isUndefined(this.options.search_more)) {
                 this.search_more = this.is_option_set(this.options.search_more);
@@ -110,7 +121,9 @@ openerp.web_m2x_options = function (instance) {
                 self.build_context()));
 
             var create_rights;
-            if (typeof this.options.create === "undefined" ||
+            if (typeof ctx.create === "undefined" ||
+                typeof ctx.create_edit === "undefined" ||
+                typeof this.options.create === "undefined" ||
                 typeof this.options.create_edit === "undefined") {
                 create_rights = new instance.web.Model(this.field.relation).call(
                     "check_access_rights", ["create", false]);
@@ -190,6 +203,9 @@ openerp.web_m2x_options = function (instance) {
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
                     allow_create = self.is_option_set(self.view.ir_options['web_m2x_options.create']);
                 }
+                if (!_.isUndefined(ctx.create)) {
+                    allow_create = self.is_option_set(ctx.create);
+                }
                 if (!_.isUndefined(self.options.create)) {
                     allow_create = self.is_option_set(self.options.create);
                 }
@@ -217,6 +233,9 @@ openerp.web_m2x_options = function (instance) {
                 var allow_create_edit = can_create;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
                     allow_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
+                }
+                if (!_.isUndefined(ctx.create_edit)) {
+                    allow_create_edit = self.is_option_set(ctx.create_edit);
                 }
                 if (!_.isUndefined(self.options.create_edit)) {
                     allow_create_edit = self.is_option_set(self.options.create_edit);
@@ -288,6 +307,9 @@ openerp.web_m2x_options = function (instance) {
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_dialog'])) {
                 allow_dialog = this.is_option_set(this.view.ir_options['web_m2x_options.m2o_dialog']);
             }
+            if (!_.isUndefined(this.view.dataset.context.m2o_dialog)) {
+                allow_dialog = this.is_option_set(this.view.dataset.context.m2o_dialog);
+            }
             if (!_.isUndefined(this.options.m2o_dialog)) {
                 allow_dialog = this.is_option_set(this.options.m2o_dialog);
             }
@@ -303,12 +325,16 @@ openerp.web_m2x_options = function (instance) {
 
         get_search_result: function(search_val) {
             var self = this;
+            var ctx = self.view.dataset.context;
 
             // add options limit used to change number of selections record
             // returned.
 
             if (!_.isUndefined(this.view.ir_options['web_m2x_options.limit'])) {
                 this.limit = parseInt(this.view.ir_options['web_m2x_options.limit']);
+            }
+            if (typeof ctx.limit === 'number') {
+                this.limit = ctx.limit;
             }
             if (typeof this.options.limit === 'number') {
                 this.limit = this.options.limit;
@@ -352,6 +378,9 @@ openerp.web_m2x_options = function (instance) {
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
                     allow_create = self.is_option_set(self.view.ir_options['web_m2x_options.create']);
                 }
+                if (!_.isUndefined(ctx.create)) {
+                    allow_create = self.is_option_set(ctx.create);
+                }
                 if (!_.isUndefined(self.options.create)) {
                     allow_create = self.is_option_set(self.options.create);
                 }
@@ -375,6 +404,9 @@ openerp.web_m2x_options = function (instance) {
                 var allow_create_edit = can_create;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
                     allow_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
+                }
+                if (!_.isUndefined(ctx.create_edit)) {
+                    allow_create_edit = self.is_option_set(ctx.create_edit);
                 }
                 if (!_.isUndefined(self.options.create_edit)) {
                     allow_create_edit = self.is_option_set(self.options.create_edit);

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -374,7 +374,7 @@ openerp.web_m2x_options = function (instance) {
                 }
                 // quick create
 
-                var allow_create = can_create;
+                var allow_create = true;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create'])) {
                     allow_create = self.is_option_set(self.view.ir_options['web_m2x_options.create']);
                 }
@@ -401,7 +401,7 @@ openerp.web_m2x_options = function (instance) {
                 }
                 // create...
 
-                var allow_create_edit = can_create;
+                var allow_create_edit = true;
                 if (!_.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])) {
                     allow_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
                 }


### PR DESCRIPTION
Providing m2x widget options (`create`, `create_edit`, `m2o_dialog`, `limit`, `search_more`) at the view level via the `context` field of the `ir.actions.act_window`.
