### PR TITLE
[9.0] web_access_rule_buttons: Skip check on TransientModels without ID

### DIFF
--- a/web_access_rule_buttons/models.py
+++ b/web_access_rule_buttons/models.py
@@ -15,10 +15,17 @@ def check_access_rule_all(self, operations=None):
    :param operation: a list of ``read``, ``create``, ``write``, ``unlink``
    :return: {operation: access} (access is a boolean)
     """
+    self.ensure_one()
     if operations is None:
         operations = ['read', 'create', 'write', 'unlink']
     result = {}
     for operation in operations:
+        if self.is_transient() and not self.id:
+            # If we call check_access_rule() without id, it will try to run a
+            # SELECT without ID which will crash, so we just blindly allow the
+            # operations
+            result[operation] = True
+            continue
         try:
             self.check_access_rule(operation)
         except exceptions.AccessError:


### PR DESCRIPTION
Fix:

If we call check_access_rule() without id, it will try to run a
SELECT without ID which will crash, so we just blindly allow the
operations

```
Traceback (most recent call last):
  File "/opt/odoo/src/openerp/http.py", line 643, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/src/openerp/http.py", line 680, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/src/openerp/http.py", line 316, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/src/openerp/service/model.py", line 118, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/src/openerp/http.py", line 309, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/src/openerp/http.py", line 959, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/src/openerp/http.py", line 509, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/src/addons/web/controllers/main.py", line 893, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/src/addons/web/controllers/main.py", line 885, in _call_kw
    return getattr(request.registry.get(model), method)(request.cr, request.uid, *args, **kwargs)
  File "/opt/odoo/src/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/opt/odoo/src/openerp/api.py", line 381, in old_api
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/external-src/web/web_access_rule_buttons/models.py", line 24, in check_access_rule_all
    result[operation] = True
  File "/opt/odoo/src/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/odoo/src/openerp/api.py", line 574, in new_api
    result = method(self._model, cr, uid, self.ids, *args, **old_kwargs)
  File "/opt/odoo/src/openerp/models.py", line 3554, in check_access_rule
    WHERE id IN %%s""" % self._table, (tuple(ids),))
  File "/opt/odoo/src/openerp/sql_db.py", line 139, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/src/openerp/sql_db.py", line 218, in execute
    res = self._obj.execute(query, params)
ProgrammingError: syntax error at or near ")"
LINE 3:                           WHERE id IN ()
```
