### PR TITLE
8.0 web ir actions act window message buttons

### DIFF
--- a/web_ir_actions_act_window_message/README.rst
+++ b/web_ir_actions_act_window_message/README.rst
@@ -14,6 +14,30 @@ Depend on this module and return
         'type': 'ir.actions.act_window.message',
         'title': _('My title'),
         'message': _('My message'),
+        # this is an optional list of buttons to show
+        'buttons': [
+            # a button can be any action (also ir.actions.report.xml et al)
+            {
+                'type': 'ir.actions.act_window',
+                'name': 'All customers',
+                'res_model': 'res.partner',
+                'view_mode': 'form',
+                'views': [[False, 'list'], [False, 'form']],
+                'domain': [('customer', '=', True)],
+            },
+            # or if type == method, you need to pass a model, a method name and
+            # parameters
+            {
+                'type': 'method',
+                'name': _('Yes, do it'),
+                'model': self._name,
+                'method': 'myfunction',
+                # list of arguments to pass positionally
+                'args': [self.ids],
+                # dictionary of keyword arguments
+                'kwargs': {'force': True},
+            }
+        ]
     }
 
 You are responsible for translating the messages.
@@ -24,7 +48,6 @@ Known issues / Roadmap
 * add `message_type` to differenciate between warnings, errors, etc.
 * have one `message_type` to show a nonmodal warning on top right
 * have `button_title` to set the button title
-* have `buttons` containing button names and action definitions for triggering actions from the message box
 
 
 Bug Tracker

--- a/web_ir_actions_act_window_message/README.rst
+++ b/web_ir_actions_act_window_message/README.rst
@@ -14,6 +14,11 @@ Depend on this module and return
         'type': 'ir.actions.act_window.message',
         'title': _('My title'),
         'message': _('My message'),
+        # optional title of the close button, if not set, will be _('Close')
+        # if set False, no close button will be shown
+        # you can create your own close button with an action of type
+        # ir.actions.act_window_close
+        'close_button_title': 'Make this window go away',
         # this is an optional list of buttons to show
         'buttons': [
             # a button can be any action (also ir.actions.report.xml et al)
@@ -47,7 +52,6 @@ Known issues / Roadmap
 
 * add `message_type` to differenciate between warnings, errors, etc.
 * have one `message_type` to show a nonmodal warning on top right
-* have `button_title` to set the button title
 
 
 Bug Tracker

--- a/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
+++ b/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
@@ -24,7 +24,8 @@ openerp.web_ir_actions_act_window_message = function(instance)
     instance.web.ActionManager.include({
         ir_actions_act_window_message: function(action, options)
         {
-            var dialog = new instance.web.Dialog(
+            var self = this,
+                dialog = new instance.web.Dialog(
                 this,
                 {
                     size: 'medium',
@@ -35,7 +36,10 @@ openerp.web_ir_actions_act_window_message = function(instance)
                             click: function() { dialog.close() },
                             oe_link_class: 'oe_highlight',
                         },
-                    ],
+                    ].concat(
+                        this.ir_actions_act_window_message_get_buttons(
+                            action, function() { dialog.close() })
+                    ),
                 },
                 jQuery(instance.web.qweb.render(
                     'web_ir_actions_act_window_message',
@@ -45,6 +49,53 @@ openerp.web_ir_actions_act_window_message = function(instance)
                     }))
             )
             return dialog.open();
+        },
+        ir_actions_act_window_message_get_buttons: function(action, close_func)
+        {
+            // return an array of button definitions from action
+            var self = this;
+            return _.map(action.buttons || [], function(button_definition)
+            {
+                return {
+                    text: button_definition.name || 'No name set',
+                    oe_link_class: button_definition.oe_link_class ||
+                                   'oe_highlight',
+                    click: function() {
+                        if(button_definition.type == 'method')
+                        {
+                            (new instance.web.Model(button_definition.model))
+                            .call(
+                                button_definition.method,
+                                button_definition.args,
+                                button_definition.kwargs
+                            ).then(function(result)
+                            {
+                                if(_.isObject(result))
+                                {
+                                    self.do_action(result);
+                                }
+                                else
+                                {
+                                    if(
+                                        self.inner_widget &&
+                                        self.inner_widget.views
+                                    )
+                                    {
+                                        self.inner_widget
+                                        .views[self.inner_widget.active_view]
+                                        .controller.recursive_reload();
+                                    }
+                                }
+                            });
+                        }
+                        else
+                        {
+                            self.do_action(button_definition);
+                        }
+                        close_func();
+                    },
+                }
+            });
         },
     });
 }

--- a/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
+++ b/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
@@ -25,18 +25,24 @@ openerp.web_ir_actions_act_window_message = function(instance)
         ir_actions_act_window_message: function(action, options)
         {
             var self = this,
-                dialog = new instance.web.Dialog(
+                buttons = [];
+
+            if(action.close_button_title !== false)
+            {
+                buttons.push({
+                    text: action.close_button_title ||
+                    instance.web._t('Close'),
+                    click: function() { dialog.close() },
+                    oe_link_class: 'oe_highlight',
+                })
+            }
+
+            var dialog = new instance.web.Dialog(
                 this,
                 {
                     size: 'medium',
                     title: action.title,
-                    buttons: [
-                        {
-                            text: instance.web._t('Close'),
-                            click: function() { dialog.close() },
-                            oe_link_class: 'oe_highlight',
-                        },
-                    ].concat(
+                    buttons: buttons.concat(
                         this.ir_actions_act_window_message_get_buttons(
                             action, function() { dialog.close() })
                     ),


### PR DESCRIPTION
this adds some cool stuff from the roadmap:
# Usage

Depend on this module and return

``` python
    {
        'type': 'ir.actions.act_window.message',
        'title': _('My title'),
        'message': _('My message'),
        # optional title of the close button, if not set, will be _('Close')
        # if set False, no close button will be shown
        # you can create your own close button with an action of type
        # ir.actions.act_window_close
        'close_button_title': 'Make this window go away',
        # this is an optional list of buttons to show
        'buttons': [
            # a button can be any action (also ir.actions.report.xml et al)
            {
                'type': 'ir.actions.act_window',
                'name': 'All customers',
                'res_model': 'res.partner',
                'view_mode': 'form',
                'views': [[False, 'list'], [False, 'form']],
                'domain': [('customer', '=', True)],
            },
            # or if type == method, you need to pass a model, a method name and
            # parameters
            {
                'type': 'method',
                'name': _('Yes, do it'),
                'model': self._name,
                'method': 'myfunction',
                # list of arguments to pass positionally
                'args': [self.ids],
                # dictionary of keyword arguments
                'kwargs': {'force': True},
            }
        ]
    }
```

(the `close_button_title` and `buttons` properties are new in this PR)
