### PR TITLE
[ADD] support color_field attribute

### DIFF
--- a/web_tree_dynamic_colored_field/README.rst
+++ b/web_tree_dynamic_colored_field/README.rst
@@ -64,7 +64,7 @@ Usage
     ...
 
     With this example, the content of the field named `color` will be used to
-    populate the `color` CSS calue. Use a function field to return whichever
+    populate the `color` CSS value. Use a function field to return whichever
     color you want depending on the other record values. Note this this
     overrides the `colors` attribute, and that you need the tree to load your
     field in the first place by adding it as invisible field.

--- a/web_tree_dynamic_colored_field/README.rst
+++ b/web_tree_dynamic_colored_field/README.rst
@@ -4,14 +4,20 @@ Colorize field in tree views
 This module aims to add support for dynamically coloring fields in tree view
 according to data in the record.
 
-It provides new attributes with the same syntax as 'colors' attribute in tree tag.
+It provides attributes on fields with the same syntax as the 'colors' attribute
+in tree tags.
+
+Further, it provides a ``color_field`` attribute on tree tags to use a field's
+value as color.
 
 Features
 ========
 
-* Add attribute 'bg_color' to color background of a cell in tree view
+* Add attribute ``bg_color`` on fields to color background of a cell in tree view
 
-* Add attribute 'fg_color' to change text color of a cell in tree view
+* Add attribute ``fg_color`` on fields to change text color of a cell in tree view
+
+* Add attribute ``color_field`` on the tree element to use as color
 
 
 Usage
@@ -45,7 +51,23 @@ Usage
     
     With this example, column which renders 'name' field will have its text colored in white.
 
+* In the tree view declaration, use color_field="color" attribute in the tree tag::
 
+    ...
+    <field name="arch" type="xml">
+        <tree string="View name" color_field="color">
+            ...
+            <field name="color" invisible="1" />
+            ...
+        </tree>
+    </field>
+    ...
+
+    With this example, the content of the field named `color` will be used to
+    populate the `color` CSS calue. Use a function field to return whichever
+    color you want depending on the other record values. Note this this
+    overrides the `colors` attribute, and that you need the tree to load your
+    field in the first place by adding it as invisible field.
 
 Bug Tracker
 ===========
@@ -63,6 +85,7 @@ Contributors
 ------------
 
 * Damien Crier <damien.crier@camptocamp.com>
+* Holger Brunn <hbrunn@therp.nl>
 
 Maintainer
 ----------

--- a/web_tree_dynamic_colored_field/__openerp__.py
+++ b/web_tree_dynamic_colored_field/__openerp__.py
@@ -22,7 +22,7 @@
     'name': 'Colorize field in tree views',
     'summary': 'Allows you to dynamically color fields on tree views',
     'category': 'Hidden',
-    'version': '8.0.1.0.1',
+    'version': '8.0.2.0.0',
     'depends': ['web'],
     'author': "Camptocamp,Odoo Community Association (OCA)",
     'license': 'AGPL-3',

--- a/web_tree_dynamic_colored_field/__openerp__.py
+++ b/web_tree_dynamic_colored_field/__openerp__.py
@@ -30,7 +30,7 @@
         'views/web_tree_dynamic_colored_field.xml',
     ],
     'qweb': [
-        'static/xml/*.xml',
+        'static/src/xml/*.xml',
     ],
     'auto_install': False
 }

--- a/web_tree_dynamic_colored_field/__openerp__.py
+++ b/web_tree_dynamic_colored_field/__openerp__.py
@@ -19,9 +19,10 @@
 #
 ##############################################################################
 {
-    'name': 'web tree dynamic colored field',
+    'name': 'Colorize field in tree views',
+    'summary': 'Allows you to dynamically color fields on tree views',
     'category': 'Hidden',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.0.1',
     'depends': ['web'],
     'author': "Camptocamp,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
@@ -32,5 +33,4 @@
     'qweb': [
         'static/src/xml/*.xml',
     ],
-    'auto_install': False
 }

--- a/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
+++ b/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
@@ -8,6 +8,14 @@ openerp.web_tree_dynamic_colored_field = function(instance){
         }
     };
 
+    var get_eval_context = function(record){
+        return _.extend(
+            {},
+            record.attributes,
+            instance.web.pyeval.context()
+        );
+    };
+
     var colorize_helper = function(obj, record, column, field_attribute, css_attribute){
         var result = '';
         if (column[field_attribute]){
@@ -18,11 +26,7 @@ openerp.web_tree_dynamic_colored_field = function(instance){
             var colors = colors.filter(function CheckUndefined(value, index, ar) {
                 return value != undefined;
             })
-            var ctx = _.extend(
-                    {},
-                    record.attributes,
-                    instance.web.pyeval.context()
-            );
+            var ctx = get_eval_context(record);
             for(i=0, len=colors.length; i<len; ++i) {
                 pair = colors[i];
                 var color = pair[0];
@@ -46,6 +50,26 @@ openerp.web_tree_dynamic_colored_field = function(instance){
         init: function(group, opts){
             this._super(group, opts);
             this.columns.fct_colorize = colorize;
+        },
+    });
+
+    instance.web.ListView.include({
+        style_for: function (record)
+        {
+            var result = this._super.apply(this, arguments);
+            if(this.fields_view.arch.attrs.color_field)
+            {
+                var color = py.evaluate(
+                    py.parse(py.tokenize(
+                        this.fields_view.arch.attrs.color_field
+                    )),
+                    get_eval_context(record)).toJSON();
+                if(color)
+                {
+                    result += 'color: ' + color;
+                }
+            }
+            return result;
         },
     });
 }

--- a/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
+++ b/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
@@ -1,8 +1,4 @@
 openerp.web_tree_dynamic_colored_field = function(instance){
-    var _t = instance.web._t,
-        _lt = instance.web._lt;
-    var QWeb = instance.web.qweb;
-    
     var pair_colors = function(pair_color){
         if (pair_color != ""){
             var pair_list = pair_color.split(':'),
@@ -25,10 +21,7 @@ openerp.web_tree_dynamic_colored_field = function(instance){
             var ctx = _.extend(
                     {},
                     record.attributes,
-                    {
-                        uid: obj.session.uid,
-                        current_date: new Date().toString('yyyy-MM-dd')
-                    }    
+                    instance.web.pyeval.context()
             );
             for(i=0, len=colors.length; i<len; ++i) {
                 pair = colors[i];
@@ -41,46 +34,18 @@ openerp.web_tree_dynamic_colored_field = function(instance){
         }
         return result
     };
-    
+
     var colorize = function(record, column){
         var res = '';
         res += colorize_helper(this, record, column, 'bg_color', 'background-color');
         res += colorize_helper(this, record, column, 'fg_color', 'color');
         return res;
     };
-    
+
     instance.web.ListView.List.include({
         init: function(group, opts){
             this._super(group, opts);
             this.columns.fct_colorize = colorize;
         },
-        fct_colorize: colorize,
-        render: function() {
-            this.$current.empty().append(
-                QWeb.render('ListView.rows', _.extend({
-                        render_cell: function () {
-                            return self.render_cell.apply(self, arguments); },
-                        fct_colorize: function(){
-                            return self.fct_colorize.apply(self, arguments);
-                        }
-                    }, this)));
-            this.pad_table_to(4);
-        },
-        render_record: function(record) {
-            var self = this;
-            var index = this.records.indexOf(record);
-            return QWeb.render('ListView.row', {
-                columns: this.columns,
-                options: this.options,
-                record: record,
-                row_parity: (index % 2 === 0) ? 'even' : 'odd',
-                view: this.view,
-                render_cell: function () {
-                    return self.render_cell.apply(self, arguments); },
-                fct_colorize: function(){
-                    return self.fct_colorize.apply(self, arguments);
-                }
-            });
-        }
     });
 }

--- a/web_tree_dynamic_colored_field/static/src/xml/web_tree_dynamic_colored_field.xml
+++ b/web_tree_dynamic_colored_field/static/src/xml/web_tree_dynamic_colored_field.xml
@@ -4,7 +4,7 @@
 
     <tr t-extend="ListView.row">
         <t t-jquery="td[t-att-data-field='column.id']" t-operation="attributes">
-            <attribute name="t-att-style">fct_colorize(record, column)</attribute>
+            <attribute name="t-att-style">columns.fct_colorize(record, column)</attribute>
         </t>
     </tr>
 

--- a/web_tree_dynamic_colored_field/views/web_tree_dynamic_colored_field.xml
+++ b/web_tree_dynamic_colored_field/views/web_tree_dynamic_colored_field.xml
@@ -5,7 +5,7 @@
     <data>
         <template id="assets_backend" name="web_tree_dynamic_colored_field assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
-                <script type="text/javascript" src="/web_tree_dynamic_colored_field/static/js/web_tree_dynamic_colored_field.js"></script>
+                <script type="text/javascript" src="/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js"></script>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
This allows you to use some (probably function) character field as foreground color for rows in tree views. I don't think it's a perfect match to have this in this module, but we already have two being busy with colors in tree views, so I think adding it here is better than adding a third module.

The first commit is just a bit of cleanup because the module broke inheritance unnecessarily, the second contains the actual functionality and the last is some messing with the manifest. I figure this makes reviews simpler, I'll be happy to squash the commits once review is done.
