### PR TITLE
[RFR] in order to work properly, we need to use FieldOne2Many's caching logic

### DIFF
--- a/web_widget_one2many_tags/README.rst
+++ b/web_widget_one2many_tags/README.rst
@@ -29,6 +29,16 @@ In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
 `here <https://github.com/OCA/web/issues/new?body=module:%20web_widget_one2many_tags%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
+Known issues / Roadmap
+======================
+
+* as one2many fields are cached on the client side until the user hits `Save`
+  on the main form, no ``name_get`` can be called on those records, which is
+  why changes that update the display name are not reflected until saving, and
+  new records are displayed as `New record` until then. If you don't like this,
+  add the field `display_name` to your form and have it recomputed in an
+  @onchange handler.
+
 Credits
 =======
 

--- a/web_widget_one2many_tags/__openerp__.py
+++ b/web_widget_one2many_tags/__openerp__.py
@@ -15,4 +15,7 @@
     "data": [
         'views/templates.xml',
     ],
+    "qweb": [
+        'static/src/xml/web_widget_one2many_tags.xml',
+    ],
 }

--- a/web_widget_one2many_tags/static/src/xml/web_widget_one2many_tags.xml
+++ b/web_widget_one2many_tags/static/src/xml/web_widget_one2many_tags.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="FieldOne2ManyTags" t-extend="FieldMany2ManyTags" />
+    <t t-name="FieldOne2ManyTag" t-extend="FieldMany2ManyTag" />
+</templates>


### PR DESCRIPTION
while looking into https://github.com/OCA/commission/pull/78, I realized this widget is fundamentally flawed because it doesn't apply caching and directly writes into the database. This is different from standard one2many fields, so it should be adapted to use the same caching mechanism.

Mind you that this is basically a rewrite, so test thoroughly before merging.
