### PR TITLE
[8.0] web_tree_many2one_clickable [ADD] context

### DIFF
--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -71,7 +71,7 @@ openerp.web_tree_many2one_clickable = function(instance, local)
             }
         },
 
-    });
+	});
 
     /* many2one_clickable widget */
 
@@ -91,6 +91,7 @@ openerp.web_tree_many2one_clickable = function(instance, local)
                 self = this;
             this.$current.delegate('a[data-many2one-clickable-model]',
                 'click', function()
+                {
                     var context = jQuery(this).data('many2one-clickable-context')
                     self.view.do_action({
                         type: 'ir.actions.act_window',

--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -60,7 +60,8 @@ openerp.web_tree_many2one_clickable = function(instance, local)
         _format: function (row_data, options)
         {
             if (this.use_many2one_clickable) {
-                return _.str.sprintf('<a class="oe_form_uri" data-many2one-clickable-model="%s" data-many2one-clickable-id="%s">%s</a>',
+                return _.str.sprintf('<a class="oe_form_uri" data-many2one-clickable-context="%s" data-many2one-clickable-model="%s" data-many2one-clickable-id="%s">%s</a>',
+                    $.isEmptyObject(this.context) ? "" : this.context,
                     this.relation,
                     row_data[this.id].value[0],
                     _.escape(row_data[this.id].value[1] || options.value_if_empty));
@@ -70,7 +71,7 @@ openerp.web_tree_many2one_clickable = function(instance, local)
             }
         },
 
-	});
+    });
 
     /* many2one_clickable widget */
 
@@ -90,11 +91,12 @@ openerp.web_tree_many2one_clickable = function(instance, local)
                 self = this;
             this.$current.delegate('a[data-many2one-clickable-model]',
                 'click', function()
-                {
+                    var context = jQuery(this).data('many2one-clickable-context')
                     self.view.do_action({
                         type: 'ir.actions.act_window',
                         res_model: jQuery(this).data('many2one-clickable-model'),
                         res_id: jQuery(this).data('many2one-clickable-id'),
+                        context: context !== "" ? $.parseJSON(context.replace(/\'/g, '\"')) : undefined,
                         views: [[false, 'form']],
                     });
                 });


### PR DESCRIPTION
When configure 'many2one_clickable' on invoice_id it open the wrong form view (supplier) instead
of the customer form view. On many2one fields you can use the context to open a specific view.
This is beeing ignored  by 'many2one_clickable' widet.

Ex.
<field name="invoice_id" widget="many2one_clickable" context="{'form_view_ref': 'account.invoice_form'}"/>
