### PR TITLE
[FIX] pass dataset's context to search_count

### DIFF
--- a/web_search_autocomplete_prefetch/static/src/js/web_search_autocomplete_prefetch.js
+++ b/web_search_autocomplete_prefetch/static/src/js/web_search_autocomplete_prefetch.js
@@ -33,7 +33,8 @@ openerp.web_search_autocomplete_prefetch = function(instance)
         return self.autocomplete_mutex.exec(function()
         {
             return self.view.dataset._model.call(
-                'search_count', [domain.eval()])
+                'search_count', [domain.eval()],
+                {context: self.view.dataset.get_context()})
                 .then(function(count)
                 {
                     if(count)


### PR DESCRIPTION
this fixes a problem with searching translatable fields. The prefetching mechanism showed you expected results in English, but you'll get something quite different in other languages.
