### PR TITLE
Fix issue with bad position of Version div

### DIFF
--- a/support_branding/views/qweb.xml
+++ b/support_branding/views/qweb.xml
@@ -9,8 +9,9 @@
         </template>
         <template id="menu_secondary" inherit_id="web.menu_secondary">
             <xpath expr="//div[@class='oe_footer']" position="inside">
-                <span>, supported by <a target="_new" t-att-href="request.env['ir.config_parameter'].get_param('support_branding.company_url')" t-att-style="'color: ' + request.env['ir.config_parameter'].get_param('support_branding.company_color')"><t t-esc="request.env['ir.config_parameter'].get_param('support_branding.company_name')" /></a></span>
+                <span>, supported by <a target="_new" t-att-href="request.env['ir.config_parameter'].get_param('support_branding.company_url')" t-att-style="'color: ' + request.env['ir.config_parameter'].get_param('support_branding.company_color')"><t t-esc="request.env['ir.config_parameter'].get_param('support_branding.company_name')" /></a>
                 <div t-if="request.env['ir.config_parameter'].get_param('support_branding.release')">Version <t t-esc="request.env['ir.config_parameter'].get_param('support_branding.release')" /></div>
+                </span>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
![support_branding_issue](https://cloud.githubusercontent.com/assets/728779/15503249/34a7fd68-21b9-11e6-970c-134a0a6050e7.png)
When support_branding module is installed and support_branding.release parameter is set, the scrollbar of the menu is moved and the 'Version' indication is not put below the 'Supported by' statement. You can see this on the attached image.
