### PR TITLE
[ADD] web_widget_float_time_second: new module

### DIFF
--- a/web_widget_float_time_second/README.rst
+++ b/web_widget_float_time_second/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License
+
+========================
+Widget Float Time Second
+========================
+
+* This module creates a new widget for float fields (float_time_second)
+that converts those fields into HH:MM:SS format.
+
+* New configuration parameter in General Settings. When checked the
+system will automaticaly load float_time fields with float_time_second
+format.
+
+Known issues / Roadmap
+======================
+
+* When you select Time Float (HH:MM:SS) in General Configuration, in tree views with float_time widget it only applies the format change to the first line. And when you disable the check it still continues applying the format with the seconds to the first line.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/web/issues/new?body=module:%20web_dashboard_open_action%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Ainara Galdona <ainaragaldona@avanzosc.es>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+    :alt: Odoo Community Association
+    :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/web_widget_float_time_second/__init__.py
+++ b/web_widget_float_time_second/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models

--- a/web_widget_float_time_second/__openerp__.py
+++ b/web_widget_float_time_second/__openerp__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Web Widget Float Time Second",
+    "version": "8.0.0.1.0",
+    "depends": ["web",
+                "base_setup"],
+    "author": "OdooMRP team, "
+              "AvanzOSC, "
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+              "Odoo Community Association (OCA)",
+    "website": "http://www.odoomrp.com",
+    "category": "Hidden",
+    'data': ["views/web_widget_float_time_second_view.xml",
+             "views/res_config_view.xml"],
+    'demo': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/web_widget_float_time_second/models/__init__.py
+++ b/web_widget_float_time_second/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Ainara Galdona - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import res_config

--- a/web_widget_float_time_second/models/res_config.py
+++ b/web_widget_float_time_second/models/res_config.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from openerp import api, fields, models
+
+
+class BaseConfigSettings(models.TransientModel):
+    _inherit = 'base.config.settings'
+
+    float_time_with_seconds = fields.Boolean(
+        string='Float time(HH:MM:SS)',
+        help='If this is true, all float_time fields will display HH:MM:SS '
+        'format.')
+
+    def _get_parameter(self, key, default=False):
+        param_obj = self.env['ir.config_parameter']
+        rec = param_obj.search([('key', '=', key)])
+        return rec or default
+
+    def _write_or_create_param(self, key, value):
+        param_obj = self.env['ir.config_parameter']
+        rec = self._get_parameter(key)
+        if rec:
+            if not value:
+                rec.unlink()
+            else:
+                rec.value = value
+        elif value:
+            param_obj.create({'key': key, 'value': value})
+
+    @api.multi
+    def get_default_float_time_parameter(self):
+        def get_value(key, default=''):
+            rec = self._get_parameter(key)
+            return rec and rec.value or default
+        return {
+            'float_time_with_seconds': get_value('float.time.second', False),
+        }
+
+    @api.multi
+    def set_float_time_parameter(self):
+        self._write_or_create_param('float.time.second',
+                                    self.float_time_with_seconds)

--- a/web_widget_float_time_second/static/src/js/form_widgets.js
+++ b/web_widget_float_time_second/static/src/js/form_widgets.js
@@ -1,0 +1,88 @@
+openerp.web_widget_float_time_second = function(instance) {
+
+    get_float_conf_value = function() {
+        if (_.isUndefined(this.is_with_seconds_loaded)) {
+            var self = this; // Needed for binding the instance
+            this.is_with_seconds_loaded = $.Deferred();
+            this.load_seconds = false;
+            (new instance.web.Model("ir.config_parameter"))
+                .query(["value"])
+                .filter([['key', '=', 'float.time.second']])
+                .first()
+                .then(function(param) {
+                    if (param) {
+                        self.load_seconds = (param.value.toLowerCase() == 'true');
+                    }
+                    self.is_with_seconds_loaded.resolve();
+                });
+            return this.is_with_seconds_loaded;
+        }
+        return this.load_seconds;
+    };
+
+    origin_format_value = instance.web.format_value;
+    instance.web.format_value = function(value, descriptor, value_if_empty) {
+        switch (descriptor.widget || descriptor.type || (descriptor.field && descriptor.field.type)) {
+            case 'float_time':
+                if (get_float_conf_value()) {
+                    return instance.web.format_value(value, {type : "float_time_second"});
+                } else {
+                    return origin_format_value(value, descriptor, value_if_empty);
+                }
+            case 'float_time_second':
+                var pattern = '%02d:%02d:%02d';
+                if (value < 0) {
+                    value = Math.abs(value);
+                    pattern = '-' + pattern;
+                }
+                var hour = Math.floor(value);
+                var min = Math.floor((value % 1) * 60);
+                var sec = Math.round((((value % 1) * 60) % 1) * 60);
+                if (sec == 60) {
+                    sec = 0;
+                    min = min + 1;
+                }
+                if (min == 60) {
+                    min = 0;
+                    hour = hour + 1;
+                }
+                return _.str.sprintf(pattern, hour, min, sec);
+        }
+        return origin_format_value(value, descriptor, value_if_empty);
+    };
+
+    origin_parse_value = instance.web.parse_value;
+    instance.web.parse_value = function(value, descriptor, value_if_empty) {
+        switch (descriptor.widget || descriptor.type || (descriptor.field && descriptor.field.type)) {
+            case 'float_time':
+                if (get_float_conf_value()) {
+                    return instance.web.parse_value(value, {type : "float_time_second"});
+                } else {
+                    return origin_parse_value(value, descriptor, value_if_empty);
+                }
+            case 'float_time_second':
+                var factor = 1;
+                if (value[0] === '-') {
+                    value = value.slice(1);
+                    factor = -1;
+                }
+                var float_time_pair = value.split(":");
+                if (float_time_pair.length === 2) {
+                    return factor * instance.web.parse_value(value, {type : "float_time"});
+                }
+                if (float_time_pair.length != 3) {
+                    return factor * instance.web.parse_value(value, {type : "float"});
+                }
+                var hours = instance.web.parse_value(float_time_pair[0], {type : "integer"});
+                var minutes = instance.web.parse_value(float_time_pair[1], {type : "integer"});
+                var seconds = instance.web.parse_value(float_time_pair[2], {type : "integer"});
+                return factor * (hours + (minutes / 60) + (seconds / 3600));
+        }
+        return origin_parse_value(value, descriptor, value_if_empty);
+    };
+
+    instance.web.form.widgets = instance.web.form.widgets.extend({
+        'float_time_second' : 'instance.web.form.FieldFloat',
+    });
+
+};

--- a/web_widget_float_time_second/views/res_config_view.xml
+++ b/web_widget_float_time_second/views/res_config_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_general_configuration" model="ir.ui.view">
+            <field name="name">General Settings</field>
+            <field name="model">base.config.settings</field>
+            <field name="inherit_id" ref="base_setup.view_general_configuration"/>
+            <field name="arch" type="xml">
+                <div name="multi_company" position="after">
+                    <div name="float_time_second">
+                        <field name="float_time_with_seconds" class="oe_inline"/>
+                        <label for="float_time_with_seconds"/>
+                    </div>
+                </div>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/web_widget_float_time_second/views/web_widget_float_time_second_view.xml
+++ b/web_widget_float_time_second/views/web_widget_float_time_second_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <template id="assets_backend" name="account assets" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/web_widget_float_time_second/static/src/js/form_widgets.js"></script>
+            </xpath>
+        </template>
+    </data>
+</openerp>


### PR DESCRIPTION
*New widget(float_time_second) for floats with HH:MM:SS format.
*New configuration check(Float time (HH.MM.SS)) to add seconds to float_time widget.

There is a problem in tree views, the first time you load a view with float_time widget and you have selected the check in configuration it only loads time with seconds in the first line. In order to show time with seconds in other lines you have to select them.
