### PR TITLE
[ADD] disable base_view search for better performance

### DIFF
--- a/web_search_autocomplete_prefetch/__openerp__.py
+++ b/web_search_autocomplete_prefetch/__openerp__.py
@@ -16,6 +16,7 @@
     ],
     "data": [
         'views/templates.xml',
+        'views/base_view.xml',
     ],
     "installable": True,
 }

--- a/web_search_autocomplete_prefetch/views/base_view.xml
+++ b/web_search_autocomplete_prefetch/views/base_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="view_view_search_autocomplete">
+            <field name="model">ir.ui.view</field>
+            <field name="inherit_id" ref="base.view_view_search"/>
+            <field name="arch" type="xml">
+    
+            <field name="name" position="attributes">
+                <attribute name="options">{'web_search_autocomplete_prefetch.disable': true}</attribute>
+            </field>
+
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
When using web_search_autocomplete_prefetch module the search in views can be very slow. 

This patch disables the search on name field to make the search quicker. 
