### PR TITLE
[8.0][IMP][web_widget_image_download] save image with the correct type

### DIFF
--- a/web_widget_image_download/README.rst
+++ b/web_widget_image_download/README.rst
@@ -26,6 +26,7 @@ Known Issues / Roadmap
 ======================
 
 * In order to work correctly, this widget has to detect image type, the server should include this information in the `Content-Type` header. Right now, odoo is not doing so, but a fix has been `proposed <https://github.com/odoo/odoo/pull/12918>`_.
+* For some unknown reason, the widget does not work in the `Preferences` view, because odoo is not rendering the **QWeb** template.
 
 Bug Tracker
 ===========

--- a/web_widget_image_download/README.rst
+++ b/web_widget_image_download/README.rst
@@ -22,6 +22,11 @@ To use this module, you need to:
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/162/8.0
 
+Known Issues / Roadmap
+======================
+
+* In order to work correctly, this widget has to detect image type, the server should include this information in the `Content-Type` header. Right now, odoo is not doing so, but a fix has been `proposed <https://github.com/odoo/odoo/pull/12918>`_.
+
 Bug Tracker
 ===========
 
@@ -32,11 +37,6 @@ help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======
-
-Images
-------
-
-* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------

--- a/web_widget_image_download/__init__.py
+++ b/web_widget_image_download/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Flavio Corpa <flavio.corpa@tecnativa.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).

--- a/web_widget_image_download/__openerp__.py
+++ b/web_widget_image_download/__openerp__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Web Widget - Image Download",
-    "summary": "Allows to download the avatar for the contact",
+    "summary": "Allows to download any image from its widget",
     "version": "8.0.1.0.0",
     "category": "web",
     "website": "https://www.tecnativa.com",

--- a/web_widget_image_download/static/src/js/web_widget_image_download.js
+++ b/web_widget_image_download/static/src/js/web_widget_image_download.js
@@ -2,15 +2,36 @@
  * Copyright 2016 Flavio Corpa <flavio.corpa@tecnativa.com>
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
  */
-openerp.web_widget_image_download = function(instance) {
+openerp.web_widget_image_download = function (instance) {
     'use strict';
 
     instance.web.form.web_widget_image_download = instance.web.form.FieldBinaryImage.include({
         render_value() {
             this._super();
 
-            // take image URI from preceding <img> tag
-            this.$el.find('.oe_form_binary_file_download').attr('href', $('img[name="image"]').attr('src'));
+            const widget = this.$el.find('.oe_form_binary_file_download');
+
+            this.imgSrc = this.$el.find('img[name="image"]').attr('src');
+
+            $.ajax({
+                type: 'HEAD',
+                url: this.imgSrc,
+                complete(xhr) {
+                    // retrieve image type from server ("Content-Type" header)
+                    widget.attr('download', xhr.getResponseHeader("Content-Type").replace('/', '.'));
+                }
+            });
+
+            // use jquery instead of `replace` with qweb (to avoid breaking inheritance)
+            if (this.has_custom_image()) {
+                this.$el.find('.oe_form_binary_file_clear').removeClass('col-md-offset-5');
+            }
+
+            widget.attr('href', this.imgSrc);
+        },
+        has_custom_image() {
+            // check if the image of the widget is different from the default placeholder
+            return this.imgSrc && !this.imgSrc.includes('/placeholder.png');
         }
     });
 }

--- a/web_widget_image_download/static/src/js/web_widget_image_download.js
+++ b/web_widget_image_download/static/src/js/web_widget_image_download.js
@@ -16,7 +16,7 @@ openerp.web_widget_image_download = function (instance) {
             $.ajax({
                 type: 'HEAD',
                 url: this.imgSrc,
-                complete(xhr) {
+                complete: function (xhr) {
                     // retrieve image type from server ("Content-Type" header)
                     $widget.attr('download', xhr.getResponseHeader("Content-Type").replace('/', '.'));
                 }

--- a/web_widget_image_download/static/src/js/web_widget_image_download.js
+++ b/web_widget_image_download/static/src/js/web_widget_image_download.js
@@ -6,10 +6,10 @@ openerp.web_widget_image_download = function (instance) {
     'use strict';
 
     instance.web.form.web_widget_image_download = instance.web.form.FieldBinaryImage.include({
-        render_value() {
+        render_value: function () {
             this._super();
 
-            const widget = this.$el.find('.oe_form_binary_file_download');
+            var $widget = this.$el.find('.oe_form_binary_file_download');
 
             this.imgSrc = this.$el.find('img[name="image"]').attr('src');
 
@@ -18,7 +18,7 @@ openerp.web_widget_image_download = function (instance) {
                 url: this.imgSrc,
                 complete(xhr) {
                     // retrieve image type from server ("Content-Type" header)
-                    widget.attr('download', xhr.getResponseHeader("Content-Type").replace('/', '.'));
+                    $widget.attr('download', xhr.getResponseHeader("Content-Type").replace('/', '.'));
                 }
             });
 
@@ -27,9 +27,9 @@ openerp.web_widget_image_download = function (instance) {
                 this.$el.find('.oe_form_binary_file_clear').removeClass('col-md-offset-5');
             }
 
-            widget.attr('href', this.imgSrc);
+            $widget.attr('href', this.imgSrc);
         },
-        has_custom_image() {
+        has_custom_image: function () {
             // check if the image of the widget is different from the default placeholder
             return this.imgSrc && !this.imgSrc.includes('/placeholder.png');
         }

--- a/web_widget_image_download/static/src/xml/web_widget_image_download.xml
+++ b/web_widget_image_download/static/src/xml/web_widget_image_download.xml
@@ -5,10 +5,9 @@
 <template>
     <t t-extend="FieldBinaryImage">
         <t t-jquery=".oe_form_binary_file_edit" t-operation="after">
-            <a class="fa fa-download fa-1g col-md-4 oe_form_binary_file_download" title="Download" download="image.png"></a>
-        </t>
-        <t t-jquery=".oe_form_binary_file_clear" t-operation="replace">
-            <i class="fa fa-trash-o fa-1g oe_form_binary_file_clear" title="Clear"/>
+            <t t-if="widget.has_custom_image()">
+                <a class="fa fa-download fa-1g col-md-4 oe_form_binary_file_download" title="Download"></a>
+            </t>
         </t>
     </t>
 </template>


### PR DESCRIPTION
This improvement fixes the following points:
- If there's no image, is there the button to download?

**No, it disappears**.
- What happens if the extension of the image is not `png` (for example, `jpg` or `gif`).

**It detects the type**.
- Will this widget break inheritance from other widgets?

**No, cause it uses `JQuery` to safely modify the main _widget_, without replacing it**.

@Tecnativa

---

**To whom it might merge:** please merge this PR with the _squash_ option, in order to preserve a clean history in the remote repo.
