### PR TITLE
Model based quick create config option.

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -103,6 +103,14 @@ To add these parameters go to Configuration -> Technical -> Parameters -> System
 - web_m2x_options.limit: 10
 - web_m2x_options.search_more: True
 
+ir.model options
+----------------
+
+Now you can disable quick create globally on model base of the target model.
+
+``disable_quick_create`` *boolean* (Default: ``False``)
+
+  Whether to disable quick create for this model globally. This has the same effect as if you would add ``no_create`` to all m2x fields in all fields with that target model in their relation.
 
 Example
 -------
@@ -125,6 +133,7 @@ Roadmap
 - Instead of making the tags rectangle clickable, I think it's better to put the text as a clickable link, so we will get a consistent behaviour/aspect with other clickable elements (many2one...).
 - In edit mode, it would be great to add an icon like the one on many2one fields to allow to open the many2many in a popup window.
 - Include this feature as a configurable option via parameter to have this behaviour by default in all many2many tags.
+- Client side caching of 'disable_quick_create' flag query on model.
 
 Bug Tracker
 ===========

--- a/web_m2x_options/__init__.py
+++ b/web_m2x_options/__init__.py
@@ -1,1 +1,2 @@
 # coding: utf-8
+from . import models

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -11,7 +11,10 @@
         'static/src/xml/base.xml',
     ],
     'license': 'AGPL-3',
-    'data': ['views/view.xml'],
+    'data': [
+        'views/view.xml',
+        'views/model_view.xml',
+    ],
     "author": "0k.io,Odoo Community Association (OCA)",
     "installable": True,
 }

--- a/web_m2x_options/models/__init__.py
+++ b/web_m2x_options/models/__init__.py
@@ -1,0 +1,2 @@
+# coding: utf-8
+from . import model

--- a/web_m2x_options/models/model.py
+++ b/web_m2x_options/models/model.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields
+
+
+class IrModel(models.Model):
+    _inherit = 'ir.model'
+
+    disable_quick_create = fields.Boolean('Disable quick create')

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -100,8 +100,19 @@ openerp.web_m2x_options = function (instance) {
 
             var create_rights;
             if (!(self.options && (self.options.no_create || self.options.no_create_edit))) {
-                create_rights = new instance.web.Model(this.field.relation).call(
-                    "check_access_rights", ["create", false]);
+                // check quick create options
+                var target_model = this.field.relation
+                create_rights = new instance.web.Model('ir.model').
+                    query(['disable_quick_create']).
+                    filter([['model', '=', target_model]]).
+                    first().
+                    then(function(result){
+                        if(result.disable_quick_create)
+                            return $.when(false);
+                        else
+                            return new instance.web.Model(target_model).call(
+                                "check_access_rights", ["create", false]);
+                    });
             }
 
             $.when(search_result, create_rights).then(function (data, can_create) {

--- a/web_m2x_options/views/model_view.xml
+++ b/web_m2x_options/views/model_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_model_form" model="ir.ui.view">
+            <field name="model">ir.model</field>
+            <field name="inherit_id" ref="base.view_model_form"></field>
+            <field name="arch" type="xml">
+                <field name="osv_memory" position="after">
+                    <field name="disable_quick_create"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
Add option to disable quick create for a complete odoo instance based on the target model of the relation. E.g. for product.product. 

Similiar to https://github.com/OCA/server-tools/tree/9.0/base_optional_quick_create but disable quick create completely for that model instead of falling back to full create form. 

Same effect as if you would add `no_create` to all m2x fields in all fields with that target model in their relation. 
