### PR TITLE
[IMP] web_widget_x2many_2d_matrix: New option field_att_

### DIFF
--- a/web_widget_x2many_2d_matrix/README.rst
+++ b/web_widget_x2many_2d_matrix/README.rst
@@ -1,5 +1,6 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License: AGPL-3
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
 ===========================
 2D matrix for x2many fields
@@ -8,7 +9,8 @@
 This module allows to show an x2many field with 3-tuples
 ($x_value, $y_value, $value) in a table
 
-          $x_value1   $x_value2 
+========= =========== ===========
+\          $x_value1   $x_value2
 ========= =========== ===========
 $y_value1 $value(1/1) $value(2/1)
 $y_value2 $value(1/2) $value(2/2)
@@ -23,7 +25,9 @@ result could look like this:
 .. image:: /web_widget_x2many_2d_matrix/static/description/screenshot.png
     :alt: Screenshot
 
-The beauty of this is that you have an arbitrary amount of columns with this widget, trying to get this in standard x2many lists involves some quite agly hacks.
+The beauty of this is that you have an arbitrary amount of columns with this
+widget, trying to get this in standard x2many lists involves some quite ugly
+hacks.
 
 Usage
 =====
@@ -54,11 +58,23 @@ show_row_totals
     If field_value is a numeric field, calculate row totals
 show_column_totals
     If field_value is a numeric field, calculate column totals
+field_att_<name>
+    Declare as many options prefixed with this string as you need for binding
+    a field value with an HTML node attribute (disabled, class, style...)
+    called as the `<name>` passed in the option.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/162/8.0
 
 Example
 =======
 
-You need a data structure already filled with values. Let's assume we want to use this widget in a wizard that lets the user fill in planned hours for one task per project per user. In this case, we can use ``project.task`` as our data model and point to it from our wizard. The crucial part is that we fill the field in the default function::
+You need a data structure already filled with values. Let's assume we want to
+use this widget in a wizard that lets the user fill in planned hours for one
+task per project per user. In this case, we can use ``project.task`` as our
+data model and point to it from our wizard. The crucial part is that we fill
+the field in the default function::
 
  class MyWizard(models.TransientModel):
     _name = 'my.wizard'
@@ -85,6 +101,11 @@ Now in our wizard, we can use::
 
 <field name="task_ids" widget="x2many_2d_matrix" field_x_axis="project_id" field_y_axis="user_id" field_value="planned_hours" />
 
+Note that all values in the matrix must exist, so you need to create them
+previously if not present, but you can control visually the editability of
+the fields in the matrix through `field_att_disabled` option with a control
+field.
+
 Known issues / Roadmap
 ======================
 
@@ -93,10 +114,10 @@ Known issues / Roadmap
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
-In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/web/issues/new?body=module:%20web_widget_x2many_2d_matrix%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/web/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======
@@ -105,6 +126,7 @@ Contributors
 ------------
 
 * Holger Brunn <hbrunn@therp.nl>
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
 
 Maintainer
 ----------

--- a/web_widget_x2many_2d_matrix/__openerp__.py
+++ b/web_widget_x2many_2d_matrix/__openerp__.py
@@ -1,27 +1,13 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Therp BV <http://therp.nl>.
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Holger Brunn <hbrunn@therp.nl>
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 {
     "name": "2D matrix for x2many fields",
-    "version": "8.0.1.0.0",
+    "version": "8.0.1.1.0",
     "author": "Therp BV, "
+              "Tecnativa,"
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Hidden/Dependency",
@@ -35,12 +21,5 @@
     "qweb": [
         'static/src/xml/web_widget_x2many_2d_matrix.xml',
     ],
-    "test": [
-    ],
-    "auto_install": False,
     "installable": True,
-    "application": False,
-    "external_dependencies": {
-        'python': [],
-    },
 }

--- a/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
@@ -1,23 +1,6 @@
-//-*- coding: utf-8 -*-
-//############################################################################
-//
-//   OpenERP, Open Source Management Solution
-//   This module copyright (C) 2015 Therp BV <http://therp.nl>.
-//
-//   This program is free software: you can redistribute it and/or modify
-//   it under the terms of the GNU Affero General Public License as
-//   published by the Free Software Foundation, either version 3 of the
-//   License, or (at your option) any later version.
-//
-//   This program is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU Affero General Public License for more details.
-//
-//   You should have received a copy of the GNU Affero General Public License
-//   along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//
-//############################################################################
+/* Copyright 2015 Holger Brunn <hbrunn@therp.nl>
+ * Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
 openerp.web_widget_x2many_2d_matrix = function(instance)
 {
@@ -44,6 +27,8 @@ openerp.web_widget_x2many_2d_matrix = function(instance)
         show_column_totals: true,
         // this will be filled with the model's fields_get
         fields: {},
+        // Store fields used to fill HTML attributes
+        fields_att: {},
 
         // read parameters
         init: function(field_manager, node)
@@ -53,6 +38,12 @@ openerp.web_widget_x2many_2d_matrix = function(instance)
             this.field_label_x_axis = node.attrs.field_label_x_axis || this.field_x_axis;
             this.field_label_y_axis = node.attrs.field_label_y_axis || this.field_y_axis;
             this.field_value = node.attrs.field_value || this.field_value;
+            for (var property in node.attrs) {
+                if (property.startsWith("field_att_")) {
+                    this.fields_att[property.substring(10)] = node.attrs[property];
+                }
+            }
+            this.field_editability = node.attrs.field_editability || this.field_editability;
             this.show_row_totals = node.attrs.show_row_totals || this.show_row_totals;
             this.show_column_totals = node.attrs.show_column_totals || this.show_column_totals;
             return this._super.apply(this, arguments);
@@ -259,6 +250,20 @@ openerp.web_widget_x2many_2d_matrix = function(instance)
         get_xy_id: function(x, y)
         {
             return this.by_x_axis[x][y]['id'];
+        },
+
+        get_xy_att: function(x, y)
+        {
+            var vals = {};
+            for (var att in this.fields_att) {
+                var val = this.get_field_value(
+                    this.by_x_axis[x][y], this.fields_att[att]);
+                // Discard empty values
+                if (val) {
+                    vals[att] = val;
+                }
+            }
+            return vals;
         },
 
         // return the value of a coordinate

--- a/web_widget_x2many_2d_matrix/static/src/xml/web_widget_x2many_2d_matrix.xml
+++ b/web_widget_x2many_2d_matrix/static/src/xml/web_widget_x2many_2d_matrix.xml
@@ -16,7 +16,7 @@
                         <th><t t-esc="widget.get_y_axis_label(y)" /></th>
                         <td t-foreach="widget.get_x_axis_values()" t-as="x" t-att-class="'oe_list_field_cell' + (widget.is_numeric ? ' oe_number' : '')" t-att-data-x="x">
                             <span t-att-class="widget.get_xy_value_class()">
-                                <input class="edit" t-att-data-id="widget.get_xy_id(x, y)" t-att-value="widget.format_xy_value(widget.get_xy_value(x, y))" />
+                                <input class="edit" t-att-data-id="widget.get_xy_id(x, y)" t-att-value="widget.format_xy_value(widget.get_xy_value(x, y))" t-att="widget.get_xy_att(x, y)"/>
                                 <span class="read"><t t-esc="widget.format_xy_value(widget.get_xy_value(x, y))" /></span>
                             </span>
                         </td>


### PR DESCRIPTION
Adding this option to the widget, you can define a field in the x2many
model that is evaluated for enabling or not the field in the matrix.
With this, you have a way to control if some matrix combinations are
not allowed.

NOTE: This doesn't prevent to require to fill the full matrix with
all the combination records.
