### PR TITLE
[ADD][help_online] Add help online for kanban view

### DIFF
--- a/help_online/__openerp__.py
+++ b/help_online/__openerp__.py
@@ -28,6 +28,8 @@
     'depends': [
         'base',
         'website',
+        'web',
+        'web_kanban',
     ],
     'description': """
 Help Online

--- a/help_online/static/src/js/help_online.js
+++ b/help_online/static/src/js/help_online.js
@@ -41,6 +41,16 @@ openerp.help_online = function (instance) {
         },
     });
     
+    instance.web_kanban.KanbanView.include({
+        view_loading: function(r) {
+            var ret = this._super(r);
+            if(! _.isUndefined(this.ViewManager.load_help_buttons)){
+                this.ViewManager.load_help_buttons();
+            }
+            return ret
+        },
+    });
+    
     openerp.web.FormView.include({
         view_loading: function(r) {
             var ret = this._super(r);


### PR DESCRIPTION
Currently, if this is a kanban view as first view of an action, the help icon isn't displayed
