### PR TITLE
[IMP] Make web_environment_ribbon more generic

### DIFF
--- a/web_environment_ribbon/static/src/css/ribbon.css
+++ b/web_environment_ribbon/static/src/css/ribbon.css
@@ -3,7 +3,7 @@
 
 .test-ribbon{
     width: 200px;
-    top: 50px;
+    top: 25px;
     left: -50px;
     text-align: center;
     line-height: 50px;
@@ -14,10 +14,11 @@
     -moz-transform: rotate(-45deg);
     -o-transform: rotate(-45deg);
     transform: rotate(-45deg);
-    z-index: 1000;
+    z-index: 9999;
     position: fixed;
     box-shadow: 0 0 3px rgba(0,0,0,.3);
     background: rgba(255,0,0,.6);
+    pointer-events: none;
 }
 
 .test-ribbon b {

--- a/web_environment_ribbon/static/src/js/ribbon.js
+++ b/web_environment_ribbon/static/src/js/ribbon.js
@@ -27,35 +27,33 @@ function validStrColour(strToTest) {
 }
 
 core.bus.on('web_client_ready', null, function () {
-    var ribbon = $('.test-ribbon');
-    // If ribbon is found in DOM
-    if (ribbon.length) {
-        ribbon.hide();
-        model.call('get_param', ['ribbon.name']).then(
-            function (name) {
-                if (name && name != 'False') {
-                    ribbon.html(name);
-                    ribbon.show();
-                }
+    var ribbon = $('<div class="test-ribbon"/>');
+    $('body').append(ribbon);
+    ribbon.hide();
+    model.call('get_param', ['ribbon.name']).then(
+        function (name) {
+            if (name && name != 'False') {
+                ribbon.html(name);
+                ribbon.show();
             }
-        );
-        // Get ribbon color from system parameters
-        model.call('get_param', ['ribbon.color']).then(
-            function (strColor) {
-                if (strColor && validStrColour(strColor)) {
-                    ribbon.css('color', strColor);
-                }
+        }
+    );
+    // Get ribbon color from system parameters
+    model.call('get_param', ['ribbon.color']).then(
+        function (strColor) {
+            if (strColor && validStrColour(strColor)) {
+                ribbon.css('color', strColor);
             }
-        );
-        // Get ribbon background color from system parameters
-        model.call('get_param', ['ribbon.background.color']).then(
-            function (strBackgroundColor) {
-                if (strBackgroundColor && validStrColour(strBackgroundColor)) {
-                    ribbon.css('background-color', strBackgroundColor);
-                }
+        }
+    );
+    // Get ribbon background color from system parameters
+    model.call('get_param', ['ribbon.background.color']).then(
+        function (strBackgroundColor) {
+            if (strBackgroundColor && validStrColour(strBackgroundColor)) {
+                ribbon.css('background-color', strBackgroundColor);
             }
-        );
-    }
+        }
+    );
 });
 
 }); // odoo.define

--- a/web_environment_ribbon/view/base_view.xml
+++ b/web_environment_ribbon/view/base_view.xml
@@ -15,12 +15,4 @@
     </xpath>
 </template>
 
-<!-- Add ribbon to page -->
-<template id="body_with_ribbon_test" name="ribbon_test web.webclient_bootstrap"
-          inherit_id="web.webclient_bootstrap">
-    <xpath expr="//div[@class='openerp openerp_webclient_container oe_webclient']" position="before">
-        <div class="test-ribbon"/>
-    </xpath>
-</template>
-
 </odoo>


### PR DESCRIPTION
By creating the ribbon div on the fly in Javascript, this module doesn't depend anymore on the webclient structure. I made this change to make the module compatible with the enterprise web client, but this can also simplify migrations :)

I hope that proposing a change in the module to make it compatible with the enterprise web client is allowed, as long as there is no specific code for this web client.

The diff displayed in Github is a bit hard to read because of a full block deindent.
Prefer "git show -b 60f6adca59fe50515eb7eaf45d1e8c86cfd20213" to have an easily readable diff.
