### PR TITLE
web_m2x_options functionality aligned with the specification

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -184,15 +184,19 @@ openerp.web_m2x_options = function (instance) {
                 var raw_result = _(data.result).map(function (x) {
                     return x[1];
                 });
-                var no_quick_create = (
-                    self.options && (self.options.no_create ||
-                                     self.options.no_quick_create)
-                )
-                var m2x_create_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create'])
-                var m2x_create = self.view.ir_options['web_m2x_options.create'] == "True"
+                var can_quick_create = _.isUndefined(self.view.ir_options['web_m2x_options.create']) ||
+                                       (self.view.ir_options['web_m2x_options.create'].toLowerCase() == "true");
+                if (self.options) {
+                   if (typeof self.options.create === 'boolean') {
+                     // field value is stronger than global settings
+                     can_quick_create = self.options.create;
+                   } else if (self.options.no_create || self.options.no_quick_create) {
+                     // undocumented features, try to keep compatibility
+                     can_quick_create = false;
+                   }
+                }
 
-                if (!no_quick_create && ((m2x_create_undef && can_create) ||
-                                         m2x_create)) {
+                if (can_create && can_quick_create) {
 
                     if (search_val.length > 0 &&
                         !_.include(raw_result, search_val)) {
@@ -210,15 +214,19 @@ openerp.web_m2x_options = function (instance) {
                 }
 
                 // create...
-                var no_create_edit = (
-                    self.options && (self.options.no_create ||
-                                     self.options.no_create_edit)
-                )
-                var m2x_create_edit_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])
-                var m2x_create_edit = self.view.ir_options['web_m2x_options.create_edit'] == "True"
+                var can_create_edit = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit']) ||
+                                       ( self.view.ir_options['web_m2x_options.create_edit'].toLowerCase() == "true");
+                if (self.options) {
+                   if (typeof self.options.create_edit === 'boolean') {
+                     // field value is stronger than global settings
+                     can_create_edit = self.options.create_edit;
+                   } else if (self.options.no_create || self.options.no_create_edit) {
+                     // undocumented features, try to keep compatibility
+                     can_create_edit = false;
+                   }
+                }
 
-                if (!no_create_edit && ((m2x_create_edit_undef && can_create) ||
-                                        m2x_create_edit)) {
+                if (can_create && can_create_edit) {
 
                     values.push({
                         label: _t("Create and Edit..."),
@@ -326,14 +334,19 @@ openerp.web_m2x_options = function (instance) {
                     });
                 }
                 // quick create
-                var no_quick_create = (
-                    self.options && (self.options.no_create ||
-                                     self.options.no_quick_create)
-                )
-                var m2x_create_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create'])
-                var m2x_create = self.view.ir_options['web_m2x_options.create'] == "True"
+                var can_quick_create = _.isUndefined(self.view.ir_options['web_m2x_options.create']) ||
+                                       (self.view.ir_options['web_m2x_options.create'].toLowerCase() == "true");
+                if (self.options) {
+                   if (typeof self.options.create === 'boolean') {
+                     // field value is stronger than global settings
+                     can_quick_create = self.options.create;
+                   } else if (self.options.no_create || self.options.no_quick_create) {
+                     // undocumented features, try to keep compatibility
+                     can_quick_create = false;
+                   }
+                }
 
-                if (!no_quick_create && (m2x_create_undef || m2x_create)) {
+                if (can_quick_create) {
 
                     var raw_result = _(data.result).map(function(x) {return x[1];});
                     if (search_val.length > 0 && !_.include(raw_result, search_val)) {
@@ -349,14 +362,19 @@ openerp.web_m2x_options = function (instance) {
                 }
 
                 // create...
-                var no_create_edit = (
-                    self.options && (self.options.no_create ||
-                                     self.options.no_create_edit)
-                )
-                var m2x_create_edit_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit'])
-                var m2x_create_edit = self.view.ir_options['web_m2x_options.create_edit'] == "True"
+                var can_create_edit = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit']) ||
+                                       ( self.view.ir_options['web_m2x_options.create_edit'].toLowerCase() == "true");
+                if (self.options) {
+                   if (typeof self.options.create_edit === 'boolean') {
+                     // field value is stronger than global settings
+                     can_create_edit = self.options.create_edit;
+                   } else if (self.options.no_create || self.options.no_create_edit) {
+                     // undocumented features, try to keep compatibility
+                     can_create_edit = false;
+                   }
+                }
 
-                if (!no_create_edit && (m2x_create_edit_undef || m2x_create_edit)) {
+                if (can_create_edit) {
 
                     values.push({
                         label: _t("Create and Edit..."),


### PR DESCRIPTION
According to the module documentation https://www.odoo.com/apps/modules/8.0/web_m2x_options/
that there should be new options available at the field level called "create" and "create_edit", but there are none such used in the get_search_result(). Instead the function looks for no_create, no_create_edit and no_quick_create not mentioned in the documentation.
On top of it, the condition
if (!no_quick_create && ((m2x_create_undef && can_create) || m2x_create)) {
seems a bit odd to me as looks like the the m2x_create (self.view.ir_options['web_m2x_options.create'] == "True") entirely overrides the can_create parameter returned probably from the access right checking. That sounds quite dangerous to me.

We had been using this code on version 8.0 for more than half a year with no problems observed.
The code base of version 9.0 is slightly different but as the module is anyway listed in the "Unported addons" section of the 9.0 description I believe branch 8.0 is the right place to commit our changes 
