### PR TITLE
[MIG] Migrated web_environment_ribbon to v10.0

### DIFF
--- a/web_environment_ribbon/README.rst
+++ b/web_environment_ribbon/README.rst
@@ -34,7 +34,7 @@ ribbon will be visible on top left corner of every Odoo backend page
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/162/9.0
+   :target: https://runbot.odoo-community.org/runbot/162/10.0
 
 Bug Tracker
 ===========

--- a/web_environment_ribbon/__manifest__.py
+++ b/web_environment_ribbon/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     'name': "Web Environment Ribbon",
-    'version': '9.0.1.0.0',
+    'version': '10.0.1.0.0',
     'category': 'Web',
     'author': 'Francesco OpenCode Apruzzese, '
               'Tecnativa, '
@@ -22,5 +22,5 @@
     "update_xml": [],
     "demo_xml": [],
     "auto_install": False,
-    'installable': False
+    'installable': True
 }

--- a/web_environment_ribbon/static/src/js/ribbon.js
+++ b/web_environment_ribbon/static/src/js/ribbon.js
@@ -6,7 +6,7 @@
 odoo.define('web_environment_ribbon.ribbon', function(require) {
 "use strict";
 
-var $ = require('$');
+var $ = require('jquery');
 var Model = require('web.Model');
 var core = require('web.core');
 


### PR DESCRIPTION
The only thing to change for this migration cas the `require('$')` to replace by `require('jquery')`.

Tested with and without web_enterprise.
