### PR TITLE
[MIG] web_tree_many2one_clickable

### DIFF
--- a/web_tree_many2one_clickable/README.rst
+++ b/web_tree_many2one_clickable/README.rst
@@ -1,3 +1,8 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+========================================
 Clickable many2one fields for tree views
 ========================================
 
@@ -15,10 +20,9 @@ Install it the regular way.
 Configuration
 =============
 
-If you want to have all many2one and reference fields clickable by default, you
-have to define in *Configuration > Technical > Parameters > System parameters*,
-a new parameter with name `web_tree_many2one_clickable.default` and with value
-`true`.
+After installation, all many2one and reference fields will be clickable
+by default. You can change this in *Configuration > Technical > Parameters > System parameters*,
+parameter with name `web_tree_many2one_clickable.default` setting it to `false`.
 
 Usage
 =====
@@ -32,22 +36,21 @@ For example:
 
 will open the linked partner in a form view.
 
-Known issues / Roadmap
-======================
+If system parameter `web_tree_many2one_clickable.default` is `true` and you
+need to disable one field, then use `widget="many2one_unclickable"`
 
-* You cannot deactivate clickable behaviour for an specific many2one field if
-  you configure the system parameter.
-* The value of the system parameter is retrieved for each many2one field
-  present in the view instead of only once.
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/162/9.0
 
 
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/OCA/web/issues>`_.
-In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/web/issues/new?body=module:%20web_tree_many2one_clickable%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/web/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
 
 
 Credits
@@ -58,13 +61,14 @@ Contributors
 
 * Therp BV
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Antonio Espinosa <antonio.espinosa@tecnativa.com>
 
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
@@ -72,4 +76,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/web_tree_many2one_clickable/README.rst
+++ b/web_tree_many2one_clickable/README.rst
@@ -1,8 +1,8 @@
 Clickable many2one fields for tree views
 ========================================
 
-This addon provides a separate widget to allow many2one fields in a tree view
-open the linked resource when clicking on their name.
+This addon provides a separate widget to allow many2one or reference fields in
+a tree view open the linked resource when clicking on their name.
 
 You can also define a system parameter to have this behaviour for all the
 existing many2one fields in tree views.
@@ -15,9 +15,9 @@ Install it the regular way.
 Configuration
 =============
 
-If you want to have all many2one fields clickable by default, you have to
-define in *Configuration > Technical > Parameters > System parameters*, a new
-parameter with name `web_tree_many2one_clickable.default` and with value
+If you want to have all many2one and reference fields clickable by default, you
+have to define in *Configuration > Technical > Parameters > System parameters*,
+a new parameter with name `web_tree_many2one_clickable.default` and with value
 `true`.
 
 Usage

--- a/web_tree_many2one_clickable/__init__.py
+++ b/web_tree_many2one_clickable/__init__.py
@@ -1,20 +1,2 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2013 Therp BV (<http://therp.nl>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/web_tree_many2one_clickable/__openerp__.py
+++ b/web_tree_many2one_clickable/__openerp__.py
@@ -1,38 +1,26 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright
-#      (C) 2013 Therp BV (<http://therp.nl>).
-#      (c) 2015 Serv. Tecnol. Avanzados (http://www.serviciosbaeza.com)
-#               Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2013 Therp BV (<http://therp.nl>).
+# Copyright 2015 Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+# Copyright 2015 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 {
     "name": "Clickable many2one fields for tree views",
-    "version": "8.0.1.0.0",
+    "summary": "Open the linked resource when clicking on their name",
+    "version": "9.0.1.0.0",
+    "category": "Hidden",
+    "website": "https://odoo-community.org/",
     "author": "Therp BV, "
-              "Serv. Tecnol. Avanzados - Pedro M. Baeza, "
+              "Tecnativa, "
               "Odoo Community Association (OCA)",
-    "category": "Dependency",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
     "depends": [
         'web',
     ],
     "data": [
+        'data/ir_config_parameter.xml',
         'views/asset.xml',
     ],
-    'installable': False,
 }

--- a/web_tree_many2one_clickable/data/ir_config_parameter.xml
+++ b/web_tree_many2one_clickable/data/ir_config_parameter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo noupdate="1">
+
+<record id="default" model="ir.config_parameter">
+    <field name="key">web_tree_many2one_clickable.default</field>
+    <field name="value">true</field>
+</record>
+
+</odoo>

--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -59,11 +59,22 @@ openerp.web_tree_many2one_clickable = function(instance, local)
 
         _format: function (row_data, options)
         {
-            if (this.use_many2one_clickable) {
-                return _.str.sprintf('<a class="oe_form_uri" data-many2one-clickable-model="%s" data-many2one-clickable-id="%s">%s</a>',
-                    this.relation,
-                    row_data[this.id].value[0],
-                    _.escape(row_data[this.id].value[1] || options.value_if_empty));
+            if (this.use_many2one_clickable && !!row_data[this.id]) {
+                var values = {
+                    model: this.relation,
+                    id: row_data[this.id].value[0],
+                    name: _.escape(row_data[this.id].value[1] || options.value_if_empty),
+                }
+                if(this.type == 'reference' && !!row_data[this.id + '__display'])
+                {
+                    values.model = row_data[this.id].value.split(',', 1)[0];
+                    values.id = row_data[this.id].value.split(',', 2)[1];
+                    values.name = _.escape(row_data[this.id + '__display'].value || options.value_if_empty);
+                }
+                return _.str.sprintf(
+                    '<a class="oe_form_uri" data-many2one-clickable-model="%(model)s" data-many2one-clickable-id="%(id)s">%(name)s</a>',
+                    values
+                );
             }
             else {
                 return this._super(row_data, options);

--- a/web_tree_many2one_clickable/views/asset.xml
+++ b/web_tree_many2one_clickable/views/asset.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<!-- Copyright 2015 Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
 
-        <template id="assets_backend" name="Many2one clickable assets" inherit_id="web.assets_backend">
-            <xpath expr="." position="inside">
-                <script type="text/javascript" src="/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js"></script>
-            </xpath>
-        </template>
+<template id="assets_backend" name="Many2one clickable assets" inherit_id="web.assets_backend">
+    <xpath expr="." position="inside">
+        <script type="text/javascript"
+                src="/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js"/>
+    </xpath>
+</template>
 
-    </data>
-</openerp>
+</odoo>


### PR DESCRIPTION
Addon migrated to v9

Changes:
- Migrated to new JS API
- Now all many2one are clickable by default when installing this addon.
- Read system parameter `web_tree_many2one_clickable.default` only once per view.
- Allow to disable just one field with `widget="many2one_unclickable"`
