### PR TITLE
[8.0][IMP][web_dashboard_tile] Added groups to control who can see the tile.

### DIFF
--- a/web_dashboard_tile/README.rst
+++ b/web_dashboard_tile/README.rst
@@ -1,17 +1,22 @@
 Dashboard Tiles
 ===============
 
-Adds a dashboard where you can configure tiles from any view
-and add them as short cut.
+Adds a dashboard where you can configure tiles from any view and add them as short cut.
 
-* Tile can be:
-    * Displayed only for a user.
-    * Global for all users (In that case, some tiles will be hidden if
-      the current user doesn't have access to the given model).
-* The tile displays items count of a given model restricted to a given domain.
-* Optionally, the tile can display the result of a function of a field
-    * Function is one of sum/avg/min/max/median.
-    * Field must be integer or float.
+The tile displays items count of a given model restricted to a given domain.
+
+Tile can be:
+
+- Displayed only for a user.
+- Global for all users.
+- Restricted to some groups.
+
+*Note: The tile will be hidden if the current user doesn't have access to the given model.*
+
+Optionally, the tile can display the result of a function of a field.
+
+- Function is one of sum/avg/min/max/median.
+- Field must be integer or float.
 
 Usage
 =====

--- a/web_dashboard_tile/__openerp__.py
+++ b/web_dashboard_tile/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Dashboard Tile",
     "summary": "Add Tiles to Dashboard",
-    "version": "8.0.1.1.0",
+    "version": "8.0.2.0.0",
     "depends": [
         'web',
         'board',

--- a/web_dashboard_tile/models/tile_tile.py
+++ b/web_dashboard_tile/models/tile_tile.py
@@ -46,6 +46,13 @@ class TileTile(models.Model):
     background_color = fields.Char(default='#0E6C7E', oldname='color')
     font_color = fields.Char(default='#FFFFFF')
 
+    group_ids = fields.Many2many(
+        'res.groups',
+        string='Groups',
+        help='If this field is set, only users of this group can view this '
+             'tile. Please note that it will only work for global tiles '
+             '(that is, when User field is left empty)')
+
     model_id = fields.Many2one('ir.model', 'Model', required=True)
     domain = fields.Text(default='[]')
     action_id = fields.Many2one('ir.actions.act_window', 'Action')

--- a/web_dashboard_tile/security/rules.xml
+++ b/web_dashboard_tile/security/rules.xml
@@ -8,11 +8,11 @@
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field name="domain_force">
         [
-            '|'
+            '|',
             ('user_id','=',user.id),
             ('user_id','=',False),
             '|',
-            ('group_ids','=',False)
+            ('group_ids','=',False),
             ('group_ids','in',[g.id for g in user.groups_id]),
         ]
         </field>

--- a/web_dashboard_tile/security/rules.xml
+++ b/web_dashboard_tile/security/rules.xml
@@ -6,7 +6,16 @@
         <field name="name">tile.owner</field>
         <field name="model_id" ref="model_tile_tile" />
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
-        <field name="domain_force">[('user_id','in',[False,user.id])]</field>
+        <field name="domain_force">
+        [
+            '|'
+            ('user_id','=',user.id),
+            ('user_id','=',False),
+            '|',
+            ('group_ids','=',False)
+            ('group_ids','in',[g.id for g in user.groups_id]),
+        ]
+        </field>
     </record>
 
 </data>

--- a/web_dashboard_tile/views/tile.xml
+++ b/web_dashboard_tile/views/tile.xml
@@ -39,6 +39,11 @@
                             <field name="field_id"/>
                             <field name="helper" colspan="4"/>
                         </group>
+                        <notebook>
+                            <page string="Groups">
+                                <field name="group_ids"/>
+                            </page>
+                        </notebook>
                     </sheet>
                 </form>
             </field>


### PR DESCRIPTION
This PR adds a new field `group_ids`.

If this field is set, only users of this group can view this tile. 
Please note that it will only work for global tiles (that is, when User field is left empty)

**This allows to share tiles with a specific groups of users.**


ping @legalsylvain 