### PR TITLE
[8.0][FIX] web_dashboard_tile security rule

### DIFF
--- a/web_dashboard_tile/__openerp__.py
+++ b/web_dashboard_tile/__openerp__.py
@@ -5,7 +5,7 @@
 {
     "name": "Dashboard Tile",
     "summary": "Add Tiles to Dashboard",
-    "version": "8.0.3.0.0",
+    "version": "8.0.4.0.0",
     "depends": [
         'web',
         'board',

--- a/web_dashboard_tile/migrations/8.0.4.0/post-migration.py
+++ b/web_dashboard_tile/migrations/8.0.4.0/post-migration.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# © 2016 Iván Todorovich <ivan.todorovich@gmail.com>
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+
+def migrate(cr, version):
+    if version is None:
+        return
+
+    # Update ir.rule
+    cr.execute("""
+        SELECT res_id FROM ir_model_data
+        WHERE name = 'model_tile_rule'
+        AND module = 'web_dashboard_tile'""")
+    rule_id = cr.fetchone()[0]
+    new_domain = """[
+        "|",
+        ("user_id","=",user.id),
+        ("user_id","=",False),
+        "|",
+        ("group_ids","=",False),
+        ("group_ids","in",[g.id for g in user.groups_id]),
+        ]"""
+    cr.execute("""
+        UPDATE ir_rule SET domain_force = '%(domain)s'
+        WHERE id = '%(id)s' """ % {'domain': new_domain, 'id': rule_id})


### PR DESCRIPTION
Rule was not being updated because of `<data noupdate="1">`, hence the groups field of the tile was not working.

This is something I missed in https://github.com/OCA/web/pull/476, and didn't realize up until now. 
Sorry for this.