### PR TITLE
Scroll control panel with page using CSS instead of jQuery.

### DIFF
--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -88,12 +88,6 @@ odoo.define('web_responsive', function(require) {
                                 'a.oe_logo, ' +
                                 'i.oe_logo_edit'
                                 );
-            $('.o_content').scroll(function() {
-                $('.o_control_panel').css(
-                    'margin-top',
-                    -$(this).scrollTop() + 'px'
-                );
-            });
             $clickZones.click($.proxy(this.handleClickZones, this));
             core.bus.on('resize', this, this.handleWindowResize);
             core.bus.on('keydown', this, this.handleNavKeys);

--- a/web_responsive/static/src/less/main.less
+++ b/web_responsive/static/src/less/main.less
@@ -44,3 +44,15 @@ main {
 .o_tooltip.active {
     z-index: 1051;
 }
+
+.o_web_client {
+    >.o_main {
+        overflow: auto;
+        > .o_main_content {
+            overflow: initial;
+            > .o_content {
+                overflow: initial;
+            }
+        }
+    }
+}


### PR DESCRIPTION
jQuery scrolling caused scrollbar malfunction.

Scrollbar incresing size while scrolling down and shaking at the end of scroll.