### PR TITLE
[9.0][FIX][web_export_view] ReferenceError: instance is not defined

### DIFF
--- a/web_export_view/__openerp__.py
+++ b/web_export_view/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Export Current View',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Web',
     'author': "Agile Business Group,Odoo Community Association (OCA)",
     'website': 'http://www.agilebg.com',

--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -7,6 +7,7 @@ odoo.define('web_export_view.Sidebar', function (require) {
 "use strict";
 
 var core = require('web.core');
+var formats = require('web.formats');
 var Sidebar = require('web.Sidebar');
 
 var _t = core._t;
@@ -75,7 +76,9 @@ Sidebar.include({
                     var cell = $row.find('td[data-field="' + this + '"]').get(0);
                     var text = cell.text || cell.textContent || cell.innerHTML || "";
                     if (cell.classList.contains("oe_list_field_float")) {
-                        export_row.push(instance.web.parse_value(text, {'type': "float"}));
+                        export_row.push(
+                            formats.parse_value(text, {'type': "float"})
+                        );
                     }
                     else if (cell.classList.contains("oe_list_field_boolean")) {
                         var data_id = $('<div>' + cell.innerHTML + '</div>');
@@ -90,7 +93,10 @@ Sidebar.include({
                         var tmp2 = text;
                         do {
                             tmp = tmp2;
-                            tmp2 = tmp.replace(instance.web._t.database.parameters.thousands_sep, "");
+                            tmp2 = tmp.replace(
+                                _t.database.parameters.thousands_sep,
+                                ""
+                            );
                         } while (tmp !== tmp2);
 
                         export_row.push(parseInt(tmp2));
@@ -116,4 +122,3 @@ Sidebar.include({
 
 });
 });
-


### PR DESCRIPTION
There was a bug that could be easily reproduced by:

1. Go to *Sales > Products*.
2. Choose list view.
3. Select all.
4. *Export current view > Excel*.

It raised this message to the user:

    ReferenceError: instance is not defined

This is all due to a wrong migration from v8 code. `instance` exists no more in
v9, instead we need to use some methods and variables from correct modules.

@Tecnativa