### PR TITLE
[FIX] web_responsive: fix for the double scrollbar

### DIFF
--- a/web_responsive/static/src/less/main.less
+++ b/web_responsive/static/src/less/main.less
@@ -25,3 +25,15 @@ main {
 div.oe_footer {
     display: none;
 }
+
+.o_web_client {
+    >.o_main {
+        overflow: auto;
+        > .o_main_content {
+            overflow: initial;
+            > .o_content {
+                overflow: initial;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Scroll control panel with page using CSS instead of jQuery.

jQuery scrolling caused scrollbar malfunction.

Blindly backported from https://github.com/OCA/web/pull/511, but it should work I think.