### PR TITLE
[FIX][web_responsive] Remove hidden floating input over images

### DIFF
--- a/web_responsive/static/src/less/form_view.less
+++ b/web_responsive/static/src/less/form_view.less
@@ -82,6 +82,9 @@
         display: block;
         opacity: 0.7;
     }
+    .oe_hidden_input_file {
+        display: none;
+    }
 
     // Adapt chatter widget to small viewports
     .oe_chatter {


### PR DESCRIPTION
Without this patch, when you clicked on a partner's name field next to its image, it asked you to change its image.

See attached video for the fixed behavior.
[Screencast_25-01-17_14:22:12.zip](https://github.com/OCA/web/files/729777/Screencast_25-01-17_14.22.12.zip)

@Tecnativa