### PR TITLE
[FIX][web_responsive] Show upload control in binary widgets.

### DIFF
--- a/web_responsive/static/src/less/form_view.less
+++ b/web_responsive/static/src/less/form_view.less
@@ -81,9 +81,10 @@
     .oe_form_field_image > .oe_form_field_image_controls {
         display: block;
         opacity: 0.7;
-    }
-    .oe_hidden_input_file {
-        display: none;
+
+        .oe_hidden_input_file {
+            display: none;
+        }
     }
 
     // Adapt chatter widget to small viewports


### PR DESCRIPTION
We only want to hide it in image widgets, to avoid breaking binary widgets.

This is how they were before:

![captura de pantalla de 2017-02-01 09-27-53](https://cloud.githubusercontent.com/assets/973709/22501467/d2425028-e860-11e6-9252-e3104b7cc050.png)

And after the fix:

![captura de pantalla de 2017-02-01 09-28-28](https://cloud.githubusercontent.com/assets/973709/22501473/d67efefc-e860-11e6-8419-b2ad35db4214.png)

@Tecnativa