### PR TITLE
[9.0][FIX]web_m2x_options: s/ev.handleObj.selector/currentTarget

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -412,7 +412,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             var open = (self.options && self.is_option_set(self.options.open));
             if(open){
                 self.mutex.exec(function(){
-                    var id = parseInt($(ev.handleObj.selector).attr('data-id'));
+                    var id = parseInt($(ev.currentTarget).data('id'));
                     self.do_action({
                         type: 'ir.actions.act_window',
                         res_model: self.field.relation,


### PR DESCRIPTION
The current behavior in the Many2many widget with `options={'open': true}`, when clicking on the selected elements, always the first element is the one opening. this done by `var id = parseInt($(ev.handleObj.selector).attr('data-id'));`.
With this fix the right id will be returned and the popup will open the right one.