### PR TITLE
[9.0][MIG] web_widget_datepicker_options: Upgrade to v9

### DIFF
--- a/web_widget_datepicker_options/README.rst
+++ b/web_widget_datepicker_options/README.rst
@@ -17,7 +17,7 @@ Usage
 You must pass all options through the "datepicker" field in the options::
 
     ...
-    <field name="date" options="{'datepicker':{'yearRange': 'c-100:c+0'}}"/>
+    <field name="date" options='{"datepicker":{"yearRange": "c-100:c+0"}}'/>
     ...
 
 Known issues / Roadmap

--- a/web_widget_datepicker_options/README.rst
+++ b/web_widget_datepicker_options/README.rst
@@ -1,6 +1,8 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License: AGPL-3
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+=========================
 Datepicker Widget Options
 =========================
 
@@ -9,7 +11,6 @@ the datepicker widget. The option are passed as-is and are not validated.
 
 To see all supported options, see the `API documentation
 <http://api.jqueryui.com/datepicker/>`_.
-
 
 Usage
 =====
@@ -20,11 +21,15 @@ You must pass all options through the "datepicker" field in the options::
     <field name="date" options='{"datepicker":{"yearRange": "c-100:c+0"}}'/>
     ...
 
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/162/9.0
+
+
 Known issues / Roadmap
 ======================
 
 * Absolutely no validation on options.
-
 
 Bug Tracker
 ===========
@@ -34,9 +39,13 @@ In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
 `here <https://github.com/OCA/web/issues/new?body=module:%20web_widget_datepicker_options%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
-
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------

--- a/web_widget_datepicker_options/__init__.py
+++ b/web_widget_datepicker_options/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution

--- a/web_widget_datepicker_options/__init__.py
+++ b/web_widget_datepicker_options/__init__.py
@@ -1,21 +1,3 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Savoir-faire Linux
-#    (<http://www.savoirfairelinux.com>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Savoir-faire Linux
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/web_widget_datepicker_options/__openerp__.py
+++ b/web_widget_datepicker_options/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
@@ -22,16 +22,17 @@
 
 {
     "name": 'web_widget_datepicker_options',
-    "version": "8.0.1.0.0",
+    "version": "9.0.1.0.0",
     "depends": [
         'base',
         'web',
     ],
     "data": [
         'view/qweb.xml',
+        'demo/web_widget_datepicker_options_demo.xml'
     ],
     "author": "Vincent Vinet, "
               "Odoo Community Association (OCA)",
-    'installable': False,
-    "active": False,
+    "license": "AGPL-3",
+    'installable': True,
 }

--- a/web_widget_datepicker_options/__openerp__.py
+++ b/web_widget_datepicker_options/__openerp__.py
@@ -1,24 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Savoir-faire Linux
-#    (<http://www.savoirfairelinux.com>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Savoir-faire Linux
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": 'web_widget_datepicker_options',

--- a/web_widget_datepicker_options/demo/web_widget_datepicker_options_demo.xml
+++ b/web_widget_datepicker_options/demo/web_widget_datepicker_options_demo.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<openerp>
+    <data>
+        <record id="datepicker_options" model="ir.ui.view">
+            <field name="name">datepicker_options</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='access_rights']" position="inside">
+                    <h2>Datepicker Demo</h2>
+                    <label for="date"/>
+                    <field name="date" options='{"datepicker": {"calendarWeeks": false}}'/><br/>
+                    <label for="create_date"/>
+                    <field name="create_date" options="{'datepicker':{'calendarWeeks': false}}"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/web_widget_datepicker_options/demo/web_widget_datepicker_options_demo.xml
+++ b/web_widget_datepicker_options/demo/web_widget_datepicker_options_demo.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<openerp>
-    <data>
-        <record id="datepicker_options" model="ir.ui.view">
-            <field name="name">datepicker_options</field>
-            <field name="model">res.users</field>
-            <field name="inherit_id" ref="base.view_users_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//page[@name='access_rights']" position="inside">
-                    <h2>Datepicker Demo</h2>
-                    <label for="date"/>
-                    <field name="date" options='{"datepicker": {"calendarWeeks": false}}'/><br/>
-                    <label for="create_date"/>
-                    <field name="create_date" options="{'datepicker':{'calendarWeeks': false}}"/>
-                </xpath>
-            </field>
-        </record>
-    </data>
-</openerp>
+<odoo>
+    <record id="datepicker_options" model="ir.ui.view">
+        <field name="name">datepicker_options</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='access_rights']" position="inside">
+                <h2>Datepicker Demo</h2>
+                <label for="date"/>
+                <field name="date" options='{"datepicker": {"calendarWeeks": false}}'/><br/>
+                <label for="create_date"/>
+                <field name="create_date" options="{'datepicker':{'calendarWeeks': false}}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/web_widget_datepicker_options/static/src/js/datepicker.js
+++ b/web_widget_datepicker_options/static/src/js/datepicker.js
@@ -34,6 +34,8 @@ odoo.define('web_widget_datepicker_options', function (require) {
             if (this.__parentedParent.options.datepicker) {
                 var options = this.__parentedParent.options.datepicker;
                 $.each(options, function(value, key) {
+                    self.options[value] = key;
+                    self.picker[value] = key;
                     self.picker.options[value] = key;
                 });
             }
@@ -47,6 +49,8 @@ odoo.define('web_widget_datepicker_options', function (require) {
             if (this.__parentedParent.options.datepicker) {
                 var options = this.__parentedParent.options.datepicker;
                 $.each(options, function(value, key) {
+                    self.options[value] = key;
+                    self.picker[value] = key;
                     self.picker.options[value] = key;
                 });
             }

--- a/web_widget_datepicker_options/static/src/js/datepicker.js
+++ b/web_widget_datepicker_options/static/src/js/datepicker.js
@@ -18,36 +18,39 @@
 */
 /*global openerp, _, $ */
 
-openerp.web_widget_datepicker_options = function (instance) {
+odoo.define('web_widget_datepicker_options', function (require) {
 
     "use strict";
 
-    instance.web.form.FieldDatetime.include({
-        initialize_content: function() {
-            this._super();
+    var core = require('web.core');
+
+    var DateTimeWidget = require('web.datepicker').DateTimeWidget;
+    var DateWidget = require('web.datepicker').DateWidget;
+
+    DateTimeWidget.include({
+        start: function(parent, options) {
+            this._super.apply(this, arguments);
             var self = this;
-            if (this.datewidget) {
-                if (typeof this.options.datepicker === 'object') {
-                    $.map(this.options.datepicker, function(value, key) {
-                        self.datewidget.picker('option', key, value);
-                    });
-                }
+            if (this.__parentedParent.options.datepicker) {
+                var options = this.__parentedParent.options.datepicker;
+                $.each(options, function(value, key) {
+                    self.picker.options[value] = key;
+                });
             }
-        }
+        },
     });
 
-    instance.web.form.FieldDate.include({
-        initialize_content: function() {
-            this._super();
+    DateWidget.include({
+        start: function(parent, options) {
+            this._super.apply(this, arguments);
             var self = this;
-            if (this.datewidget) {
-                if (typeof this.options.datepicker === 'object') {
-                    $.map(this.options.datepicker, function(value, key) {
-                        self.datewidget.picker('option', key, value);
-                    });
-                }
+            if (this.__parentedParent.options.datepicker) {
+                var options = this.__parentedParent.options.datepicker;
+                $.each(options, function(value, key) {
+                    self.picker.options[value] = key;
+                });
             }
-        }
+        },
     });
-};
 
+});

--- a/web_widget_datepicker_options/view/qweb.xml
+++ b/web_widget_datepicker_options/view/qweb.xml
@@ -1,10 +1,8 @@
-<openerp>
-    <data>
-        <template id="assets_backend" name="web_widget_datepicker_options assets" inherit_id="web.assets_backend">
-            <xpath expr="." position="inside">
-                <script type="text/javascript" src="/web_widget_datepicker_options/static/src/js/datepicker.js"></script>
-            </xpath>
-        </template>
-    </data>
-</openerp>
+<odoo>
+    <template id="assets_backend" name="web_widget_datepicker_options assets" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/web_widget_datepicker_options/static/src/js/datepicker.js"></script>
+        </xpath>
+    </template>
+</odoo>
 

--- a/web_widget_datepicker_options/view/qweb.xml
+++ b/web_widget_datepicker_options/view/qweb.xml
@@ -1,6 +1,6 @@
 <openerp>
     <data>
-       <template id="assets_backend" name="web_widget_datepicker_options assets" inherit_id="web.assets_backend">
+        <template id="assets_backend" name="web_widget_datepicker_options assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
                 <script type="text/javascript" src="/web_widget_datepicker_options/static/src/js/datepicker.js"></script>
             </xpath>


### PR DESCRIPTION
Migrates web_widget_datepicker_options to v9. You can see the demo by going to Settings --> Users, selecting a user, and scrolling down to the "Datepicker Demo." The fields at the bottom have the attribute options='{"datepicker": {"calendarWeeks": false}}, which hides the number of weeks in the year in the calendar.

Before (no options added, number of weeks visible):
![demo](https://cloud.githubusercontent.com/assets/18649466/22569944/4a9cb138-e94e-11e6-859a-cd0945ad7cca.png)

After (options added, number of weeks hidden):
![after](https://cloud.githubusercontent.com/assets/18649466/22569924/368a37f6-e94e-11e6-8b3e-251c61f7cc73.png)
