### PR TITLE
[9.0][FIX]web_m2x_options: prevent popup to open web badger is deleted

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -411,15 +411,17 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             var self = this;
             var open = (self.options && self.is_option_set(self.options.open));
             if(open){
-                self.mutex.exec(function(){
-                    var id = parseInt($(ev.currentTarget).data('id'));
-                    self.do_action({
-                        type: 'ir.actions.act_window',
-                        res_model: self.field.relation,
-                        views: [[false, 'form']],
-                        res_id: id,
-                        target: "new"
-                    });
+                this.mutex.exec(function(){
+                    var id = parseInt($(ev.target).data('id'));
+                    if(id){
+                        self.do_action({
+                            type: 'ir.actions.act_window',
+                            res_model: self.field.relation,
+                            views: [[false, 'form']],
+                            res_id: id,
+                            target: "new"
+                        });
+                    }
                 }.bind(this));
             }else{
                 self.open_color_picker(ev);


### PR DESCRIPTION
The **current behavior** is when you try deleting an element from a `many2many_tag` that has `options={'open': true}` the popup still show up even the element is deleted.
The `$(ev.currentTarget).data('id')` always returns a valid ID, hence the action is executed.
With this fix I've used the `($(ev.target).data('id')` instead and checked wether I've a value in `id` or not.
So the expected bahavior now: when deleting the tag the popup should no show up any more.
