### PR TITLE
[FIX][web_m2x_options] Fix Qweb templates.

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -116,7 +116,7 @@ Your XML form view definition could contain::
 Known issues
 ============
 
-Double check that you have no inherited view that remove ``options`` you set on a field ! 
+Double check that you have no inherited view that remove ``options`` you set on a field !
 If nothing works, add a debugger in the first line of ``get_search_result method`` and enable debug mode in Odoo. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
 
 Roadmap
@@ -146,6 +146,7 @@ Contributors
 * Nicolas JEUDY <nicolas@sudokeys.com>
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
 * Zakaria Makrelouf <z.makrelouf@gmail.com>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -2,7 +2,7 @@
 
 {
     "name": 'web_m2x_options',
-    "version": "9.0.1.0.1",
+    "version": "9.0.1.1.0",
     "depends": [
         'base',
         'web',

--- a/web_m2x_options/__openerp__.py
+++ b/web_m2x_options/__openerp__.py
@@ -2,7 +2,7 @@
 
 {
     "name": 'web_m2x_options',
-    "version": "9.0.1.0.0",
+    "version": "9.0.1.0.1",
     "depends": [
         'base',
         'web',
@@ -12,6 +12,7 @@
     ],
     'license': 'AGPL-3',
     'data': ['views/view.xml'],
-    "author": "ACSONE SA/NV, 0k.io,Odoo Community Association (OCA)",
+    "author": "ACSONE SA/NV, 0k.io, Tecnativa, "
+              "Odoo Community Association (OCA)",
     'installable': True,
 }

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -260,13 +260,9 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
     });
 
     form_relational.FieldMany2ManyTags.include({
-        events: {
-            'click .o_delete': function(e) {
-                this.remove_id($(e.target).parent().data('id'));
-            },
-            'click .badge': 'open_badge',
-            'mousedown .o_colorpicker span': 'update_color',
-            'focusout .o_colorpicker': 'close_color_picker',
+        init: function () {
+            this.events["click .badge"] = "open_badge";
+            return this._super.apply(this, arguments);
         },
         show_error_displayer: function () {
             if ((typeof this.options.m2o_dialog === 'undefined' && this.can_create) ||

--- a/web_m2x_options/static/src/xml/base.xml
+++ b/web_m2x_options/static/src/xml/base.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
 <templates xml:space="preserve">
-<t t-extend="FieldMany2One">
-    <t t-jquery="a.oe_m2o_cm_button">
-        jQuery(this).attr('t-if', '!(widget.options.no_open || widget.options.no_open_edit)');
+    <t t-extend="FieldMany2One">
+        <t t-jquery=".oe_m2o_cm_button" t-operation="attributes">
+            <attribute name="t-if">!(widget.options.no_open || widget.options.no_open_edit)</attribute>
+        </t>
     </t>
-</t>
-<t t-extend="FieldMany2ManyTag">
-    <t t-jquery="span.badge">
-        jQuery(this).attr('t-att-data-id', 'el[0]');
+    <t t-extend="FieldMany2ManyTag">
+        <t t-jquery="span[t-attf-class^='badge ']" t-operation="attributes">
+            <attribute name="t-att-data-id">el[0]</attribute>
+        </t>
     </t>
-</t>
 </templates>

--- a/web_m2x_options/static/src/xml/base.xml
+++ b/web_m2x_options/static/src/xml/base.xml
@@ -8,9 +8,4 @@
             <attribute name="t-if">!(widget.options.no_open || widget.options.no_open_edit)</attribute>
         </t>
     </t>
-    <t t-extend="FieldMany2ManyTag">
-        <t t-jquery="span[t-attf-class^='badge ']" t-operation="attributes">
-            <attribute name="t-att-data-id">el[0]</attribute>
-        </t>
-    </t>
 </templates>


### PR DESCRIPTION
They were trying to replace non-existing elements, and this was being logged to console:

    Can't find "a.oe_m2o_cm_button" when extending template FieldMany2One
    Can't find "span.badge" when extending template FieldMany2ManyTag

@Tecnativa