### PR TITLE
[FIX][web_responsive] Make calendar invitations work again

### DIFF
--- a/web_responsive/views/web.xml
+++ b/web_responsive/views/web.xml
@@ -27,14 +27,13 @@
 
             <t t-set="body_classname" t-value="'drawer drawer--left o_web_client'" />
 
-            <header role="banner">
+            <header role="banner" groups="base.group_user,base.group_portal">
                 <nav id="odooAppDrawer" class="app-drawer-nav drawer-nav" role="navigation">
                     <t t-call="web.menu" />
                 </nav>
 
                 <nav class="navbar navbar-default main-nav"
                      role="navigation"
-                     groups="base.group_user,base.group_portal"
                      >
                     <div class="container-fluid">
 


### PR DESCRIPTION
This patch displays the event acceptance template to the end user without failing with a server error.

Before this patch:

1. Create a calendar event.
2. Invite Mr. Foo.
3. Enter Mr. Foo's mail inbox.
4. Press "Accept" in the invitation email.
5. Get a beautiful `Internal Server Error`.

After this patch, replace step 5 by "See the accepted event details".

This is the **real** fix for https://github.com/odoo/odoo/pull/15762.
@Tecnativa