### PR TITLE
[FIX][web_export_view] Make it usable when int fields are present

### DIFF
--- a/web_export_view/README.rst
+++ b/web_export_view/README.rst
@@ -47,11 +47,12 @@ Credits
 Contributors
 ------------
 
- * Simone Orsi <simone.orsi@camptocamp.com>
- * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
- * Stefan Rijnhart <stefan@therp.nl>
- * Leonardo Pistone <leonardo.pistone@camptocamp.com>
- * Rodney Vargas <rodney.vargas@clearcorp.cr>
+* Simone Orsi <simone.orsi@camptocamp.com>
+* Lorenzo Battistini <lorenzo.battistini@agilebg.com>
+* Stefan Rijnhart <stefan@therp.nl>
+* Leonardo Pistone <leonardo.pistone@camptocamp.com>
+* Rodney Vargas <rodney.vargas@clearcorp.cr>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/web_export_view/__openerp__.py
+++ b/web_export_view/__openerp__.py
@@ -5,7 +5,7 @@
 
 {
     'name': 'Export Current View',
-    'version': '9.0.1.0.1',
+    'version': '9.0.1.0.2',
     'category': 'Web',
     'author': "Agile Business Group,Odoo Community Association (OCA)",
     'website': 'http://www.agilebg.com',

--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -1,7 +1,7 @@
-//# -*- coding: utf-8 -*-
-//# © 2012 Agile Business Group
-//# © 2012 Therp BV
-//# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+// -*- coding: utf-8 -*-
+// © 2012 Agile Business Group
+// © 2012 Therp BV
+// License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 odoo.define('web_export_view.Sidebar', function (require) {
 "use strict";
@@ -90,7 +90,7 @@ Sidebar.include({
                         }
                     }
                     else if (cell.classList.contains("oe_list_field_integer")) {
-                        var tmp2 = text;
+                        var tmp, tmp2 = text;
                         do {
                             tmp = tmp2;
                             tmp2 = tmp.replace(


### PR DESCRIPTION
To reproduce the problem, you just had to:

1. Go to *Settings > Technical > User Interface > Views*.
2. Press *Export Current View > Excel*.

You got this:

```
ReferenceError: assignment to undeclared variable tmp

http://localhost:9069/web_export_view/static/src/js/web_export_view.js:95 Traceback:
.on_sidebar_export_view_xls/</<@http://localhost:9069/web_export_view/static/src/js/web_export_view.js:95:29
.each@http://localhost:9069/web/static/lib/jquery/jquery.js:383:49
.on_sidebar_export_view_xls/<@http://localhost:9069/web_export_view/static/src/js/web_export_view.js:75:17
.each@http://localhost:9069/web/static/lib/jquery/jquery.js:383:49
.on_sidebar_export_view_xls@http://localhost:9069/web_export_view/static/src/js/web_export_view.js:68:9
Sidebar<.start/<@http://localhost:9069/web/static/src/js/widgets/sidebar.js:46:17
jQuery.event.dispatch@http://localhost:9069/web/static/lib/jquery/jquery.js:4640:50
jQuery.event.add/elemData.handle@http://localhost:9069/web/static/lib/jquery/jquery.js:4309:41
```

Strict mode was preventing usage of an undeclared variable. Now it's declared.

I took the chance to fix some wrong formattings found here and there.

@Tecnativa