### PR TITLE
[FIX] web_responsive: Change edit accesskey

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016 LasLabs Inc.
+# Copyright 2016-2017 LasLabs Inc.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 {
@@ -18,5 +18,8 @@
     "data": [
         'views/assets.xml',
         'views/web.xml',
+    ],
+    'qweb': [
+        'static/src/xml/form_view.xml',
     ],
 }

--- a/web_responsive/static/src/xml/form_view.xml
+++ b/web_responsive/static/src/xml/form_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2017 LasLabs Inc.
+    License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+-->
+
+<templates id="form_view" xml:space="preserve">
+
+    <t t-extend="FormView.buttons">
+        <t t-jquery="button[accesskey='a']" t-operation="attributes">
+            <attribute name="accesskey">e</attribute>
+        </t>
+    </t>
+
+</templates>


### PR DESCRIPTION
* Change accesskey for `edit` in form view back to `e` to fix #587 

Disclaimer - I haven't actually tested this yet. I'll update tag with a Ready for Review once I have (after Runbot build)