### PR TITLE
[FIX][web_export_view] Remove monetary formatting

### DIFF
--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -73,23 +73,24 @@ Sidebar.include({
             var checked = $row.find(row_selector).is(':checked');
             if (children && checked === true) {
                 $.each(export_columns_keys, function () {
-                    var cell = $row.find('td[data-field="' + this + '"]').get(0);
-                    var text = cell.text || cell.textContent || cell.innerHTML || "";
-                    if (cell.classList.contains("oe_list_field_float")) {
+                    var $cell = $row.find('td[data-field="' + this + '"]');
+                    var text = $cell.text();
+                    if ($cell.hasClass("oe_list_field_monetary")) {
+                        // Remove all but digits, dots and commas
+                        text = text.replace(/[^\d\.,]/g, "");
+                        export_row.push(
+                            formats.parse_value(text, {"type": "monetary"})
+                        );
+                    } else if ($cell.hasClass("oe_list_field_float")) {
                         export_row.push(
                             formats.parse_value(text, {'type': "float"})
                         );
-                    }
-                    else if (cell.classList.contains("oe_list_field_boolean")) {
-                        var data_id = $('<div>' + cell.innerHTML + '</div>');
-                        if (data_id.find('input').get(0).checked) {
-                            export_row.push(_t("True"));
-                        }
-                        else {
-                            export_row.push(_t("False"));
-                        }
-                    }
-                    else if (cell.classList.contains("oe_list_field_integer")) {
+                    } else if ($cell.hasClass("oe_list_field_boolean")) {
+                        export_row.push(
+                            $cell.is(':has(input:checked)')
+                            ? _t("True") : _t("False")
+                        );
+                    } else if ($cell.hasClass("oe_list_field_integer")) {
                         var tmp, tmp2 = text;
                         do {
                             tmp = tmp2;
@@ -100,8 +101,7 @@ Sidebar.include({
                         } while (tmp !== tmp2);
 
                         export_row.push(parseInt(tmp2));
-                    }
-                    else {
+                    } else {
                         export_row.push(text.trim());
                     }
                 });


### PR DESCRIPTION
Monetary fields were hard to work with in Excel after exporting because having the currency symbol made Excel treat those cells as text.

This patch removes those symbols and thus allows Excel to treat those values as numbers, allowing easier management.

It works no matter the symbol is before or after the value, so in any case it fixes #558.

Took the chance to make this code chunk a little bit easier with jQuery.

@Tecnativa @DarkChamp