### PR TITLE
[FIX][web_export_view] Remove monetary formatting

### DIFF
--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -74,7 +74,7 @@ odoo.define('web_export_view', function (require) {
                                     // Always use a `.` as decimal separator
                                     .replace(_t.database.parameters.decimal_point, ".")
                                     // Remove non-numeric characters
-                                    .replace(/[^\d\.-]/g, "");
+                                    .replace(/[^\d\.-]/g, "")
                                 ));
                             }
                             else {


### PR DESCRIPTION
Monetary fields were being exported empty because the parsing failed.

In the way of correctly exporting them as numbers, this chunk of code's performance has been improved.

This is a forward-port of #592.

@Tecnativa