### PR TITLE
[FIX] we need to parse the parameter to an int

### DIFF
--- a/web_menu_navbar_needaction/static/src/js/web_menu_navbar_needaction.js
+++ b/web_menu_navbar_needaction/static/src/js/web_menu_navbar_needaction.js
@@ -36,7 +36,7 @@ openerp.web_menu_navbar_needaction = function(instance)
         },
         refresh_navbar_needaction: function(timeout)
         {
-            if(parseInt(timeout))
+            if(parseInt(timeout, 10))
             {
                 setTimeout(this.proxy(this.refresh_navbar_needaction), timeout, timeout);
             }

--- a/web_menu_navbar_needaction/static/src/js/web_menu_navbar_needaction.js
+++ b/web_menu_navbar_needaction/static/src/js/web_menu_navbar_needaction.js
@@ -36,7 +36,7 @@ openerp.web_menu_navbar_needaction = function(instance)
         },
         refresh_navbar_needaction: function(timeout)
         {
-            if(timeout)
+            if(parseInt(timeout))
             {
                 setTimeout(this.proxy(this.refresh_navbar_needaction), timeout, timeout);
             }


### PR DESCRIPTION
without this, configuring '0' triggers an infinite loop on some browsers