### PR TITLE
[FIX][web_responsive] Make it compatible with l10n_es_toponyms

### DIFF
--- a/web_responsive/static/src/less/form_view.less
+++ b/web_responsive/static/src/less/form_view.less
@@ -32,8 +32,6 @@
     }
     .o_group {
         &.o_inner_group > tbody > tr > td {
-            // prevent td content from breaking into lines
-            white-space: nowrap;
             .note-editor > .note-toolbar {
                 // prevent wysiwyg editor buttons from expanding the screen
                 white-space: initial;


### PR DESCRIPTION
Before this patch, there was an incompatibility between this addon and l10n_es_toponyms, caused by the lack of wrapping of the special address field that was being added:

![captura de pantalla de 2017-05-15 14-51-21](https://cloud.githubusercontent.com/assets/973709/26058388/064c15de-397e-11e7-8550-204ac2ac72ce.png)


Now layout works as expected in that case. In any other case, it seems sensible to wrap inputs so no more weird overflows happen and less chances of needing horizontal scrolling happen:

![captura de pantalla de 2017-05-15 14-51-31](https://cloud.githubusercontent.com/assets/973709/26058398/0da6f98e-397e-11e7-8f2a-c3a7d2d52158.png)

@Tecnativa