### PR TITLE
[9.0] [IMP] Web Environment Ribbon: support variables in ribbon name (eg db_name)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.eggs
 
 # Installer logs
 pip-log.txt

--- a/web_environment_ribbon/README.rst
+++ b/web_environment_ribbon/README.rst
@@ -53,6 +53,7 @@ Contributors
 * Francesco Apruzzese <cescoap@gmail.com>
 * Javi Melendez <javimelex@gmail.com>
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
+* Thomas Binsfeld <thomas.binsfeld@acsone.eu>
 
 Maintainer
 ----------

--- a/web_environment_ribbon/README.rst
+++ b/web_environment_ribbon/README.rst
@@ -25,6 +25,8 @@ Configuration
 * You can customize the ribbon color and background color through system
   parameters: "ribbon.color", "ribbon.background.color". Fill with valid CSS
   colors or just set to "False" to use default values.
+* You can add the database name in the ribbon by adding "{db_name}" in the
+  system parameter "ribbon.name".
 
 Usage
 =====

--- a/web_environment_ribbon/__init__.py
+++ b/web_environment_ribbon/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Francesco OpenCode Apruzzese <cescoap@gmail.com>
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# Copyright 2017 Thomas Binsfeld <thomas.binsfeld@acsone.eu>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import models

--- a/web_environment_ribbon/__openerp__.py
+++ b/web_environment_ribbon/__openerp__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Francesco OpenCode Apruzzese <cescoap@gmail.com>
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+# Copyright 2017 Thomas Binsfeld <thomas.binsfeld@acsone.eu>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
@@ -16,6 +17,7 @@
         'web',
         ],
     "data": [
+        'security/web_environment_ribbon_backend.xml',
         'view/base_view.xml',
         'data/ribbon_data.xml',
         ],

--- a/web_environment_ribbon/data/ribbon_data.xml
+++ b/web_environment_ribbon/data/ribbon_data.xml
@@ -6,7 +6,7 @@
 <!-- Add ribbon name default configuration parameter -->
 <record id="default_ribbon_name" model="ir.config_parameter">
     <field name="key">ribbon.name</field>
-    <field name="value">TEST</field>
+    <field name="value"><![CDATA[TEST<br/>({db_name})]]></field>
 </record>
 
 <!-- Add ribbon color configuration parameter -->

--- a/web_environment_ribbon/models/__init__.py
+++ b/web_environment_ribbon/models/__init__.py
@@ -1,0 +1,1 @@
+from . import web_environment_ribbon_backend

--- a/web_environment_ribbon/models/web_environment_ribbon_backend.py
+++ b/web_environment_ribbon/models/web_environment_ribbon_backend.py
@@ -11,16 +11,20 @@ class WebEnvironmentRibbonBackend(models.Model):
     _description = 'Web Environment Ribbon Backend'
 
     @api.model
+    def _prepare_ribbon_name(self):
+        db_name = self.env.cr.dbname
+        name = self.env['ir.config_parameter'].get_param('ribbon.name')
+        name = name.format(db_name=db_name)
+        return name
+
+    @api.model
     def get_environment_ribbon(self):
         """
         This method returns the ribbon data from ir config parameters
         :return: dictionary
         """
         ir_config_model = self.env['ir.config_parameter']
-        # Add the database name to the ribbon name
-        db_name = self.env.cr.dbname
-        name = u"{name}<br/>({db_name})".format(
-            name=ir_config_model.get_param('ribbon.name'), db_name=db_name)
+        name = self._prepare_ribbon_name()
         return {
             'name': name,
             'color': ir_config_model.get_param('ribbon.color'),

--- a/web_environment_ribbon/models/web_environment_ribbon_backend.py
+++ b/web_environment_ribbon/models/web_environment_ribbon_backend.py
@@ -17,8 +17,12 @@ class WebEnvironmentRibbonBackend(models.Model):
         :return: dictionary
         """
         ir_config_model = self.env['ir.config_parameter']
+        # Add the database name to the ribbon name
+        db_name = self.env.cr.dbname
+        name = u"{name}<br/>({db_name})".format(
+            name=ir_config_model.get_param('ribbon.name'), db_name=db_name)
         return {
-            'name': ir_config_model.get_param('ribbon.name'),
+            'name': name,
             'color': ir_config_model.get_param('ribbon.color'),
             'background_color': ir_config_model.get_param(
                 'ribbon.background.color'),

--- a/web_environment_ribbon/models/web_environment_ribbon_backend.py
+++ b/web_environment_ribbon/models/web_environment_ribbon_backend.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, models
+
+
+class WebEnvironmentRibbonBackend(models.Model):
+
+    _name = 'web.environment.ribbon.backend'
+    _description = 'Web Environment Ribbon Backend'
+
+    @api.model
+    def get_environment_ribbon(self):
+        """
+        This method returns the ribbon data from ir config parameters
+        :return: dictionary
+        """
+        ir_config_model = self.env['ir.config_parameter']
+        return {
+            'name': ir_config_model.get_param('ribbon.name'),
+            'color': ir_config_model.get_param('ribbon.color'),
+            'background_color': ir_config_model.get_param(
+                'ribbon.background.color'),
+        }

--- a/web_environment_ribbon/security/web_environment_ribbon_backend.xml
+++ b/web_environment_ribbon/security/web_environment_ribbon_backend.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.model.access" id="web_environment_ribbon_backend_access_name">
+        <field name="name">web.environment.ribbon.backend access name</field>
+        <field name="model_id" ref="model_web_environment_ribbon_backend"/>
+        <field name="group_id" ref="base.group_user"/>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_create" eval="0"/>
+        <field name="perm_write" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+    </record>
+
+</odoo>

--- a/web_environment_ribbon/static/src/css/ribbon.css
+++ b/web_environment_ribbon/static/src/css/ribbon.css
@@ -3,11 +3,12 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
 .test-ribbon{
-    width: 200px;
+    width: 300px;
     top: 25px;
-    left: -50px;
+    left: -100px;
     text-align: center;
-    line-height: 50px;
+    padding: 10px;
+    line-height: 20px;
     letter-spacing: 1px;
     color: #f0f0f0;
     -webkit-transform: rotate(-45deg);

--- a/web_environment_ribbon/static/src/css/ribbon.css
+++ b/web_environment_ribbon/static/src/css/ribbon.css
@@ -1,4 +1,5 @@
 /* Copyright 2015 Francesco OpenCode Apruzzese <cescoap@gmail.com>
+   Copyright 2017 Thomas Binsfeld <thomas.binsfeld@acsone.eu>
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
 .test-ribbon{

--- a/web_environment_ribbon/static/src/js/ribbon.js
+++ b/web_environment_ribbon/static/src/js/ribbon.js
@@ -1,6 +1,7 @@
 /* Copyright 2015 Sylvain Calador <sylvain.calador@akretion.com>
    Copyright 2015 Javi Melendez <javi.melendez@algios.com>
    Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
+   Copyright 2017 Thomas Binsfeld <thomas.binsfeld@acsone.eu>
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
 odoo.define('web_environment_ribbon.ribbon', function(require) {
@@ -10,7 +11,7 @@ var $ = require('$');
 var Model = require('web.Model');
 var core = require('web.core');
 
-var model = new Model('ir.config_parameter');
+var backend_model = new Model('web.environment.ribbon.backend');
 
 // Code from: http://jsfiddle.net/WK_of_Angmar/xgA5C/
 function validStrColour(strToTest) {
@@ -30,27 +31,21 @@ core.bus.on('web_client_ready', null, function () {
     var ribbon = $('<div class="test-ribbon"/>');
     $('body').append(ribbon);
     ribbon.hide();
-    model.call('get_param', ['ribbon.name']).then(
-        function (name) {
-            if (name && name != 'False') {
-                ribbon.html(name);
+    // Get ribbon data from backend
+    backend_model.call('get_environment_ribbon').then(
+        function (ribbon_data) {
+            // Ribbon name
+            if (ribbon_data.name && ribbon_data.name != 'False') {
+                ribbon.html(ribbon_data.name);
                 ribbon.show();
             }
-        }
-    );
-    // Get ribbon color from system parameters
-    model.call('get_param', ['ribbon.color']).then(
-        function (strColor) {
-            if (strColor && validStrColour(strColor)) {
-                ribbon.css('color', strColor);
+            // Ribbon color
+            if (ribbon_data.color && validStrColour(ribbon_data.color)) {
+                ribbon.css('color', ribbon_data.color);
             }
-        }
-    );
-    // Get ribbon background color from system parameters
-    model.call('get_param', ['ribbon.background.color']).then(
-        function (strBackgroundColor) {
-            if (strBackgroundColor && validStrColour(strBackgroundColor)) {
-                ribbon.css('background-color', strBackgroundColor);
+            // Ribbon background color
+            if (ribbon_data.background_color && validStrColour(ribbon_data.background_color)) {
+                ribbon.css('background-color', ribbon_data.background_color);
             }
         }
     );


### PR DESCRIPTION
- Add a simple backend to `web_environment_ribbon`
- The new method `get_environment_ribbon()` can be overridden to change the standard behavior
- The database name is now displayed under the name, in the ribbon (can be changed by overriding the method)

![screenshot from 2017-05-16 10-07-25](https://cloud.githubusercontent.com/assets/16916103/26095874/892aceea-3a1f-11e7-8cdd-f5c3170f0ad9.png)
_(Preview on Odoo 9.0 Enterprise)_


------------------
This PR is an other solution for #588 