### PR TITLE
Fix [8.0] Perf issue with web_m2x_options #615 

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -40,12 +40,17 @@ openerp.web_m2x_options = function (instance) {
         },
 
         is_option_set: function(option) {
-            //return option in ('True', 'true', true)
-            return {
-                'true': true,
-                'True': true,
-                true: true,
-            }[option] || false;
+            if (_.isUndefined(option)) {
+                return false
+            }
+            var is_string = typeof option === 'string'
+            var is_bool = typeof option === 'boolean'
+            if (is_string) {
+                return option === 'true' || option === 'True'
+            } else if (is_bool) {
+                return option
+            }
+            return false
         },
 
         show_error_displayer: function () {


### PR DESCRIPTION
Before : 
if no options specified after each keystroke, a call to disable_quick_create and/or check_access_rights are made

After:
a call is done once per field

Each request saved improves perf for user and load on the server.

Extra
+ some fixes on `parseInt` : always specify a radix
+ refactor  `is_option_set` 

Fixes #615 