### PR TITLE
[FIX] Search more always visible even if results below limit

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -186,7 +186,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                     search_more_undef = _.isUndefined(self.options.search_more) && _.isUndefined(self.view.ir_options['web_m2x_options.search_more']),
                     search_more = self.is_option_set(self.view.ir_options['web_m2x_options.search_more']);
 
-                if ((values.length > self.limit && (can_search_more || search_more_undef || search_more)) || search_more) {
+                if ((values.length > self.limit && (can_search_more || search_more_undef)) || search_more) {
                     values = values.slice(0, self.limit);
                     values.push({
                         label: _t("Search More..."),

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -186,7 +186,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                     search_more_undef = _.isUndefined(self.options.search_more) && _.isUndefined(self.view.ir_options['web_m2x_options.search_more']),
                     search_more = self.is_option_set(self.view.ir_options['web_m2x_options.search_more']);
 
-                if (values.length > self.limit && (can_search_more || search_more_undef || search_more)) {
+                if ((values.length > self.limit && (can_search_more || search_more_undef || search_more)) || search_more) {
                     values = values.slice(0, self.limit);
                     values.push({
                         label: _t("Search More..."),


### PR DESCRIPTION
**Current behaviour:**

- With `web_m2x_options.search_more: True` set, _Search more..._ option will be available only if the results of the query are above `web_m2x_options.limit` (or Odoo's default).

**Expected behaviour:**

- With `web_m2x_options.search_more: True` set, _Search more..._ option should be always visible no matter how many ocurrences found in the field.

cc @Tecnativa