### PR TITLE
[10.0] web_widget_x2many_2d_matrix: update README

### DIFF
--- a/web_widget_x2many_2d_matrix/README.rst
+++ b/web_widget_x2many_2d_matrix/README.rst
@@ -40,7 +40,14 @@ This assumes that my_field refers to a model with the fields `x`, `y` and
 `value`. If your fields are named differently, pass the correct names as
 attributes::
 
-<field name="my_field" widget="x2many_2d_matrix" field_x_axis="my_field1" field_y_axis="my_field2" field_value="my_field3" />
+ <field name="my_field" widget="x2many_2d_matrix" field_x_axis="my_field1" field_y_axis="my_field2" field_value="my_field3">
+     <tree>
+         <field name="my_field"/>
+         <field name="my_field1"/>
+         <field name="my_field2"/>
+         <field name="my_field3"/>
+     </tree>
+ </field>
 
 You can pass the following parameters:
 
@@ -107,7 +114,14 @@ the field in the default function::
 
 Now in our wizard, we can use::
 
-<field name="task_ids" widget="x2many_2d_matrix" field_x_axis="project_id" field_y_axis="user_id" field_value="planned_hours" />
+ <field name="task_ids" widget="x2many_2d_matrix" field_x_axis="project_id" field_y_axis="user_id" field_value="planned_hours">
+     <tree>
+         <field name="task_ids"/>
+         <field name="project_id"/>
+         <field name="user_id"/>
+         <field name="planned_hours"/>
+     </tree>
+ </field>
 
 Note that all values in the matrix must exist, so you need to create them
 previously if not present, but you can control visually the editability of


### PR DESCRIPTION
In V10.0 the widget need a view definition of the module displayed.

This avoid hack like https://github.com/OCA/product-variant/blob/10.0/sale_order_variant_mgmt/wizard/sale_manage_variant.py#L17

This PR update the README file to inform developpers

This fix the issue https://github.com/OCA/web/issues/625