### PR TITLE
[10.0] [FIX] [web_timeline] Correct write when grouped by

### DIFF
--- a/web_timeline/static/src/js/web_timeline.js
+++ b/web_timeline/static/src/js/web_timeline.js
@@ -285,7 +285,6 @@ odoo.define('web_timeline.TimelineView', function (require) {
             var data = [];
             var groups = [];
             this.grouped_by = group_bys
-
             _.each(events, function(event) {
                 if (event[self.date_start]){
                     data.push(self.event_data_transform(event));
@@ -399,7 +398,6 @@ odoo.define('web_timeline.TimelineView', function (require) {
             var start = item.start;
             var end = item.end;
             var group = false;
-
             if (item.group != -1) {
                 group = item.group;
             }
@@ -408,11 +406,9 @@ odoo.define('web_timeline.TimelineView', function (require) {
                 time.auto_date_to_str(start, self.fields[self.fields_view.arch.attrs.date_start].type);
             data[self.fields_view.arch.attrs.date_stop] =
                  time.auto_date_to_str(end, self.fields[self.fields_view.arch.attrs.date_stop].type);
-
             if(self.grouped_by){
                 data[self.grouped_by[0]] = group
             }
-
             var id = item.evt.id;
             this.dataset.write(id, data);
         },

--- a/web_timeline/static/src/js/web_timeline.js
+++ b/web_timeline/static/src/js/web_timeline.js
@@ -36,6 +36,7 @@ odoo.define('web_timeline.TimelineView', function (require) {
 
         init: function (parent, dataset, view_id, options) {
             this.permissions = {};
+            this.grouped_by = false;
             return this._super.apply(this, arguments);
         },
 
@@ -283,6 +284,8 @@ odoo.define('web_timeline.TimelineView', function (require) {
             var self = this;
             var data = [];
             var groups = [];
+            this.grouped_by = group_bys
+
             _.each(events, function(event) {
                 if (event[self.date_start]){
                     data.push(self.event_data_transform(event));
@@ -396,6 +399,7 @@ odoo.define('web_timeline.TimelineView', function (require) {
             var start = item.start;
             var end = item.end;
             var group = false;
+
             if (item.group != -1) {
                 group = item.group;
             }
@@ -404,7 +408,11 @@ odoo.define('web_timeline.TimelineView', function (require) {
                 time.auto_date_to_str(start, self.fields[self.fields_view.arch.attrs.date_start].type);
             data[self.fields_view.arch.attrs.date_stop] =
                  time.auto_date_to_str(end, self.fields[self.fields_view.arch.attrs.date_stop].type);
-            data[self.fields_view.arch.attrs.default_group_by] = group;
+
+            if(self.grouped_by){
+                data[self.grouped_by[0]] = group
+            }
+
             var id = item.evt.id;
             this.dataset.write(id, data);
         },

--- a/web_timeline/static/src/js/web_timeline.js
+++ b/web_timeline/static/src/js/web_timeline.js
@@ -284,7 +284,7 @@ odoo.define('web_timeline.TimelineView', function (require) {
             var self = this;
             var data = [];
             var groups = [];
-            this.grouped_by = group_bys
+            this.grouped_by = group_bys;
             _.each(events, function(event) {
                 if (event[self.date_start]){
                     data.push(self.event_data_transform(event));
@@ -406,8 +406,8 @@ odoo.define('web_timeline.TimelineView', function (require) {
                 time.auto_date_to_str(start, self.fields[self.fields_view.arch.attrs.date_start].type);
             data[self.fields_view.arch.attrs.date_stop] =
                  time.auto_date_to_str(end, self.fields[self.fields_view.arch.attrs.date_stop].type);
-            if(self.grouped_by){
-                data[self.grouped_by[0]] = group
+            if (self.grouped_by){
+                data[self.grouped_by[0]] = group;
             }
             var id = item.evt.id;
             this.dataset.write(id, data);


### PR DESCRIPTION
When you are working with the timeline view and you have grouped your items, you can extend or reduce the time duration of each item, but also change the group they belong, by dragging up or down the record.

I think that changing the group does not work as it should, since is writing the record but having as reference the "default_group_by" defined in the view attrs, instead of the current "group_by" condition defined in the search view box.

I've made a fix and tested myself but just for a while. Hope is useful