### PR TITLE
FIX: allow clickable references

### DIFF
--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -44,7 +44,7 @@ ListView.Column.include({
         }
     },
     _format: function (row_data, options) {
-        if (this.type == 'many2one' &&
+        if ((this.type == 'many2one' || this.type == 'reference') &&
             (this.widget == 'many2one_unclickable' || this.use_many2one_clickable) &&
             !!row_data[this.id]) {
             var value = row_data[this.id].value;


### PR DESCRIPTION
with this addition in the if statement, fields of type 'reference' are also clickable