### PR TITLE
[8.0][FIX] help_online: XMLRPC Call problem

### DIFF
--- a/help_online/models/import_help_wizard.py
+++ b/help_online/models/import_help_wizard.py
@@ -47,3 +47,4 @@ class ImportHelpWizard(models.TransientModel):
                                    mode='init',
                                    noupdate=False,
                                    report=None)
+        return True


### PR DESCRIPTION
The import method has no return value so it is not possible to call the import wizard from XMLRPC.