### PR TITLE
[10.0][FIX] web_access_rule_buttons

### DIFF
--- a/web_access_rule_buttons/models.py
+++ b/web_access_rule_buttons/models.py
@@ -25,6 +25,17 @@ def check_access_rule_all(self, operations=None):
             # operations
             result[operation] = True
             continue
+        # If we're writing on a new o2m, m2m or m2o record related to a new
+        # record (for example an invoice line created altogether with the
+        # invoice to which it belongs), ids contains a string. Calling
+        # check_access_rule() in this condition will crash, so we just
+        # blindly allow the operations.
+        try:
+            for id in self.ids:
+                int(id)
+        except Exception:
+            result[operation] = True
+            continue
         try:
             self.check_access_rule(operation)
         except exceptions.AccessError:


### PR DESCRIPTION
This fixes a bug occurring when creating, with the same operation, a record plus one or more _o2m_, _m2m_ or _m2o_ records related to it. In this scenario, invoking _check_access_rule()_ will crash reporting an error like _DataError: Invalid input syntax for integer "one2many_v_id_42"_ trying to execute a query using a string instead of an integer.