### PR TITLE
[FIX] [10.0] 2d widget fixes

### DIFF
--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "2D matrix for x2many fields",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Therp BV, "
               "Tecnativa,"
               "Odoo Community Association (OCA)",

--- a/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
@@ -131,7 +131,7 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 })
                 .then(function()
                 {
-                    return self.dataset.read_ids(self.dataset.ids).then(function(rows)
+                    return self.dataset.read_ids(self.dataset.ids, self.fields).then(function(rows)
                     {
                         // setup data structure
                         _.each(rows, function(row)

--- a/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
@@ -382,7 +382,7 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
         effective_readonly_change: function()
         {
             this.$el
-            .find('tbody .read')
+            .find('tbody .edit')
             .toggle(!this.get('effective_readonly'));
             this.$el
             .find('tbody .read')

--- a/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
@@ -404,6 +404,8 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
             return $.when(result).then(function()
             {
                 self.renderElement();
+                self.$el.find('.edit').on(
+                        'change', self.proxy(self.xy_value_change));
             });
         },
     });

--- a/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
@@ -369,6 +369,7 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 $this.val(this.format_xy_value(value));
 
                 this.dataset.write($this.data('id'), data);
+                this.by_id[$this.data('id')][this.field_value] = value;
                 $this.parent().removeClass('oe_form_invalid');
                 this.compute_totals();
             }
@@ -404,6 +405,7 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
             return $.when(result).then(function()
             {
                 self.renderElement();
+                self.compute_totals();
                 self.$el.find('.edit').on(
                         'change', self.proxy(self.xy_value_change));
             });

--- a/web_widget_x2many_2d_matrix/static/src/xml/web_widget_x2many_2d_matrix.xml
+++ b/web_widget_x2many_2d_matrix/static/src/xml/web_widget_x2many_2d_matrix.xml
@@ -16,8 +16,8 @@
                         <th><t t-esc="widget.get_y_axis_label(y)" /></th>
                         <td t-foreach="widget.get_x_axis_values()" t-as="x" t-att-class="'' + (widget.is_numeric ? ' oe_number' : '')" t-att-data-x="x">
                             <span t-att-class="widget.get_xy_value_class()">
-                                <input class="edit o_form_input" t-att-data-id="widget.get_xy_id(x, y)" t-att-value="widget.format_xy_value(widget.get_xy_value(x, y))" t-att="widget.get_xy_att(x, y)"/>
-                                <span class="read"><t t-esc="widget.format_xy_value(widget.get_xy_value(x, y))" /></span>
+                                <input class="edit o_form_input oe_edit_only" t-att-data-id="widget.get_xy_id(x, y)" t-att-value="widget.format_xy_value(widget.get_xy_value(x, y))" t-att="widget.get_xy_att(x, y)"/>
+                                <span class="read oe_read_only"><t t-esc="widget.format_xy_value(widget.get_xy_value(x, y))" /></span>
                             </span>
                         </td>
                         <td t-if="widget.show_row_totals" class="row_total oe_number" t-att-data-y="y"/>


### PR DESCRIPTION
Fixes display and input bugs in 2d widgets.

- dataset.read_ids needs fields otherwise it returns no data
- renderElement was loosing the change event handler
- add standard odoo classes for read / edit mode hiding of alternate values
- effective_readonly_change was switching same nodes twice