### PR TITLE
[FIX][web_advanced_search_x2x] Fix "false" label

### DIFF
--- a/web_advanced_search_x2x/__manifest__.py
+++ b/web_advanced_search_x2x/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Search x2x fields",
-    "version": "10.0.2.0.0",
+    "version": "10.0.2.0.1",
     "author": "Therp BV, "
               "Tecnativa, "
               "Odoo Community Association (OCA)",

--- a/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
+++ b/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
@@ -172,6 +172,9 @@ odoo.define('web_advanced_search_x2x.search_filters', function (require) {
 
         get_value: function () {
             try {
+                if (!this.x2x_widget_name()) {
+                    throw "No x2x widget, fallback to default";
+                }
                 return this._x2x_field.get_value();
             } catch (error) {
                 return this._super.apply(this, arguments);


### PR DESCRIPTION
When you were adding a custom filter in a x2x field using "contains", it always became "contains 'false'". Now it is fixed.

Fixes #717 

@Tecnativa