### PR TITLE
[FIX] web_widget_domain_v11: Allow to change operator

### DIFF
--- a/web_widget_domain_v11/static/src/copied-css/domain_selector.less
+++ b/web_widget_domain_v11/static/src/copied-css/domain_selector.less
@@ -9,10 +9,6 @@
     }
 
     &.o_domain_tree {
-        .o_domain_tree_operator_caret::after {
-            .o-caret-down();
-        }
-
         > .o_domain_node_children_container {
             padding-left: @o-domain-selector-indent;
 

--- a/web_widget_domain_v11/static/src/copied-js/domain_selector.js
+++ b/web_widget_domain_v11/static/src/copied-js/domain_selector.js
@@ -84,10 +84,10 @@ var DomainNode = Widget.extend({
 var DomainTree = DomainNode.extend({
     template: "DomainTree",
     events: _.extend({}, DomainNode.prototype.events, {
-        "click .o_domain_tree_operator_selector > ul > li > a": function (e) {
+        "change .o_domain_tree_operator_selector": function (e) {
             e.preventDefault();
             e.stopPropagation();
-            this.changeOperator($(e.target).data("operator"));
+            this.changeOperator($(e.target).val());
         },
     }),
     custom_events: {

--- a/web_widget_domain_v11/static/src/copied-xml/templates.xml
+++ b/web_widget_domain_v11/static/src/copied-xml/templates.xml
@@ -26,16 +26,11 @@
     </div>
 </t>
 <t t-name="DomainTree.OperatorSelector">
-    <div t-if="!widget.readonly" class="btn-group o_domain_tree_operator_selector">
-        <button class="btn btn-xs btn-primary o_domain_tree_operator_caret" data-toggle="dropdown">
-            <t t-if="widget.operator === '&amp;'">All</t>
-            <t t-if="widget.operator === '|'">Any</t>
-            <t t-if="widget.operator === '!'">None</t>
-        </button>
-        <ul class="dropdown-menu">
-            <li><a href="#" data-operator="&amp;">All</a></li>
-            <li><a href="#" data-operator="|">Any</a></li>
-        </ul>
+    <div t-if="!widget.readonly" class="btn-group">
+        <select class="o_domain_tree_operator_selector">
+            <option value="&amp;" t-att-selected="widget.operator === '&amp;' ? 'selected' : null">All</option>
+            <option value="|" t-att-selected="widget.operator === '|' ? 'selected' : null">Any</option>
+        </select>
     </div>
     <strong t-else="">
         <t t-if="widget.operator === '&amp;'">ALL</t>


### PR DESCRIPTION
Previously, a Bootstrap dropdown was being used to choose the domain operator.

It was not working due to a problem that doesn't allow to have nested dropdowns in Odoo 10.0 search views, but possibly yes in the intermediate version where this addon was backported.

![screenshot-2017-10-19 apps - odoo](https://user-images.githubusercontent.com/973709/31770078-931a8a58-b4d6-11e7-97f2-23e9de58e16c.png)


To get this working, the BS dropdown is replaced by a standard select element, so no more conflicts.

![captura de pantalla de 2017-10-19 14-05-44](https://user-images.githubusercontent.com/973709/31770124-bb4c5a88-b4d6-11e7-8d59-697fef92d52f.png)


@Tecnativa