### PR TITLE
[FIX] web_advanced_search_x2x: Allow to combine multiple domains

### DIFF
--- a/web_advanced_search_x2x/__manifest__.py
+++ b/web_advanced_search_x2x/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Search x2x fields",
-    "version": "10.0.2.0.1",
+    "version": "10.0.2.0.2",
     "author": "Therp BV, "
               "Tecnativa, "
               "Odoo Community Association (OCA)",

--- a/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
+++ b/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
@@ -153,11 +153,15 @@ odoo.define('web_advanced_search_x2x.search_filters', function (require) {
                 var domain = new data.CompoundDomain(),
                     name = this.field.name;
                 $.map(value, function (el) {
-                    domain.add([[
-                        _.str.sprintf("%s.%s", name, el[0]),
-                        el[1],
-                        el[2],
-                    ]]);
+                    var leaf = el;
+                    if (typeof el !== "string") {
+                        leaf = [
+                            _.str.sprintf("%s.%s", name, el[0]),
+                            el[1],
+                            el[2],
+                        ];
+                    }
+                    domain.add([leaf]);
                 });
                 return domain;
             } else {


### PR DESCRIPTION
Before this patch, when a domain leaf was a string (such as `&`, `|` or `!`), it was being treated as an array. This was leading to errors such as this one:

```
2017-10-19 11:22:01,578 1 ERROR devel odoo.http: Exception during JSON request handling.
Traceback (most recent call last):
    File "/opt/odoo/custom/src/odoo/odoo/http.py", line 640, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
    File "/opt/odoo/custom/src/odoo/odoo/http.py", line 677, in dispatch
    result = self._call_function(**self.params)
    File "/opt/odoo/custom/src/odoo/odoo/http.py", line 333, in _call_function
    return checked_call(self.db, *args, **kwargs)
    File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 101, in wrapper
    return f(dbname, *args, **kwargs)
    File "/opt/odoo/custom/src/odoo/odoo/http.py", line 326, in checked_call
    result = self.endpoint(*a, **kw)
    File "/opt/odoo/custom/src/odoo/odoo/http.py", line 935, in __call__
    return self.method(*args, **kw)
    File "/opt/odoo/custom/src/odoo/odoo/http.py", line 506, in response_wrap
    response = f(*args, **kw)
    File "/opt/odoo/auto/addons/web/controllers/main.py", line 827, in search_read
    return self.do_search_read(model, fields, offset, limit, domain, sort)
    File "/opt/odoo/auto/addons/web/controllers/main.py", line 849, in do_search_read
    offset=offset or 0, limit=limit or False, order=sort or False)
    File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4733, in search_read
    records = self.search(domain or [], offset=offset, limit=limit, order=order)
    File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1559, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
    File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4275, in _search
    query = self._where_calc(args)
    File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4074, in _where_calc
    e = expression.expression(domain, self)
    File "/opt/odoo/custom/src/odoo/odoo/osv/expression.py", line 640, in __init__
    self.expression = distribute_not(normalize_domain(domain))
    File "/opt/odoo/custom/src/odoo/odoo/osv/expression.py", line 289, in distribute_not
    elif token in DOMAIN_OPERATORS_NEGATION:
TypeError: unhashable type: 'list'
```

Now they are treated specifically and the problem is fixed. 😎 

@Tecnativa