### PR TITLE
[FIX] Ensure that domain field can be evaluated before creating x2x field

### DIFF
--- a/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
+++ b/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
@@ -12,6 +12,7 @@ odoo.define('web_advanced_search_x2x.search_filters', function (require) {
     var SearchView = require('web.SearchView');
     var data = require('web.data');
     var core = require('web.core');
+    var pyeval = require('web.pyeval');
 
     var X2XAdvancedSearchPropositionMixin = {
         template: "web_advanced_search_x2x.proposition",
@@ -83,6 +84,16 @@ odoo.define('web_advanced_search_x2x.search_filters', function (require) {
             }
             var widget = this.x2x_widget();
             if (!widget) return;
+
+            var field_domain = this.field.domain;
+            if (typeof field_domain === 'string') {
+                try {
+                    pyeval.eval('domain', field_domain);
+                } catch(e) {
+                    this.field.domain = "[]";
+                }
+            }
+
             this._x2x_field = new widget(
                 this,
                 this.x2x_field_create_options()


### PR DESCRIPTION
If a domain has been declared on a field (in python) and if this domain depends on an other model field, there will be an error when trying to perform ```name_search```. 

Example:
```python
partner_id = fields.Many2one(...)
invoice_id = fields.Many2one(..., domain="[('partner_id', '=', partner_id)]")
```
To fix this, we try to evaluate given domain and if it crash, we override it.