### PR TITLE
[FIX] web_m2x_options: Compatibilize with web_advanced_search_x2x

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -127,12 +127,20 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             var blacklist = this.get_search_blacklist();
             this.last_query = search_val;
 
-            var search_result = this.orderer.add(dataset.name_search(
-                search_val,
-                new data.CompoundDomain(
-                    self.build_domain(), [["id", "not in", blacklist]]),
-                'ilike', this.limit + 1,
-                self.build_context()));
+            function searcher (domain) {
+                return self.orderer.add(dataset.name_search(
+                    search_val,
+                    domain,
+                    'ilike', self.limit + 1,
+                    self.build_context()));
+                }
+            try {
+                var search_result = searcher(new data.CompoundDomain(
+                    self.build_domain(), [["id", "not in", blacklist]]));
+            // In search views sometimes the field domain cannot be evaluated
+            } catch (error) {
+                var search_result = searcher([["id", "not in", blacklist]]);
+            }
 
             if (!(self.options && (self.is_option_set(self.options.create) || self.is_option_set(self.options.create_edit)))) {
                 this.create_rights = this.create_rights || (function(){


### PR DESCRIPTION
`web_m2x_options` is supposed to render fields in the context of a form or tree view, where domains can safely be applied because there's a main record that includes a context.

However, when installing along with `web_advanced_search_x2x`, they produce an incompatibility when a x2x field's domain is defined and depends on the current record's context, because a search view has no notion of a *current record*.

The fix is simple: try to do as usual, and if it fails, try without the field's domain.

Without this patch, an exception like this would be raised, i.e. when both addons are installed and you are trying to search project tasks by stage:

``` Error: NameError: name 'project_id' is not defined
http://localhost/web/static/lib/py.js/lib/py.js:370# Traceback:# Changes to be committed:
PY_ensurepy@http://localhost/web/static/lib/py.js/lib/py.js:370:19# modified: static/src/js/form.js
py.evaluate@http://localhost/web/static/lib/py.js/lib/py.js:1340:20#
py.evaluate@http://localhost/web/static/lib/py.js/lib/py.js:1397:35
py.evaluate@http://localhost/web/static/lib/py.js/lib/py.js:1409:34
py.eval@http://localhost/web/static/lib/py.js/lib/py.js:1453:16
eval_domains/<@http://localhost/web/static/src/js/framework/pyeval.js:869:39
_.forEach@http://localhost/web/static/lib/underscore/underscore.js:145:9
_.mixin/</_.prototype[name]@http://localhost/web/static/lib/underscore/underscore.js:1484:29
eval_domains@http://localhost/web/static/src/js/framework/pyeval.js:860:5
eval_domains/<@http://localhost/web/static/src/js/framework/pyeval.js:873:39
_.forEach@http://localhost/web/static/lib/underscore/underscore.js:145:9
_.mixin/</_.prototype[name]@http://localhost/web/static/lib/underscore/underscore.js:1484:29
eval_domains@http://localhost/web/static/src/js/framework/pyeval.js:860:5
eval_domains/<@http://localhost/web/static/src/js/framework/pyeval.js:873:39
_.forEach@http://localhost/web/static/lib/underscore/underscore.js:145:9
_.mixin/</_.prototype[name]@http://localhost/web/static/lib/underscore/underscore.js:1484:29
eval_domains@http://localhost/web/static/src/js/framework/pyeval.js:860:5
pyeval@http://localhost/web/static/src/js/framework/pyeval.js:977:16
eval_arg@http://localhost/web/static/src/js/framework/pyeval.js:988:16
ensure_evaluated@http://localhost/web/static/src/js/framework/pyeval.js:1011:21
call@http://localhost/web/static/src/js/framework/data_model.js:56:9
name_search@http://localhost/web/static/src/js/framework/data.js:537:16
get_search_result@http://localhost/web_m2x_options/static/src/js/form.js:130:50
OdooClass.extend/Class.include/</prototype[name]</<@http://localhost/web/static/src/js/framework/class.js:122:35
source@http://localhost/web/static/src/js/views/form_relational_widgets.js:271:17
_search@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:6823:3
$.widget/</proxiedPrototype[prop]</<@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:415:19
search@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:6815:10
$.widget/</proxiedPrototype[prop]</<@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:415:19
$.widget.bridge/$.fn[name]/<@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:508:19
each@http://localhost/web/static/lib/jquery/jquery.js:383:49
each@http://localhost/web/static/lib/jquery/jquery.js:136:24
$.widget.bridge/$.fn[name]@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:494:4
render_editable/<@http://localhost/web/static/src/js/views/form_relational_widgets.js:189:21
dispatch@http://localhost/web/static/lib/jquery/jquery.js:4640:50
add/elemData.handle@http://localhost/web/static/lib/jquery/jquery.js:4309:41
```

@Tecnativa