### PR TITLE
[10.0] Fix Export Window that breaks when made draggable (and fix a minor documentation error)

### DIFF
--- a/web_dialog_size/README.rst
+++ b/web_dialog_size/README.rst
@@ -8,9 +8,8 @@ It does also add draggable support to the dialogs.
 Configuration
 =============
 
-By default, the module respects the caller's `dialog_size` option. If you want
-to override this and have all dialogs maximized by default, set the configuration
-parameter `web_dialog_size.default_maximize` to `1`.
+The only current option is to have every window maximized by default with
+the configuration parameter `web_dialog_size.default_maximize` to `1`.
 
 Credits
 =======

--- a/web_dialog_size/__manifest__.py
+++ b/web_dialog_size/__manifest__.py
@@ -17,7 +17,7 @@
 
     'website': "http://acsone.eu",
     'category': 'web',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'license': 'AGPL-3',
 
     'depends': [

--- a/web_dialog_size/static/src/js/web_dialog_size.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.js
@@ -32,8 +32,11 @@ Dialog.include({
 
     close: function() {
         var draggable = this.$modal.draggable( "instance" );
-        if (draggable)
-            this.$modal.draggable("destroy");
+        // Export Window breaks if made draggable
+        if(this.$el.getAttributes()['class'].indexOf('o_export') == -1) {
+            if (draggable)
+                this.$modal.draggable("destroy");
+        }
         var res = this._super.apply(this, arguments);
         return res;
     },

--- a/web_dialog_size/static/src/js/web_dialog_size.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.js
@@ -24,19 +24,19 @@ Dialog.include({
 
     open: function() {
         var res = this._super.apply(this, arguments);
-        this.$modal.draggable({
-            handle: "div.modal-header",
-        });
+        /* Export Window breaks if made draggable */
+        if(this.$el.getAttributes()['class'].indexOf('o_export') == -1) {
+            this.$modal.draggable({
+                handle: "div.modal-header",
+            });
+        };
         return res;
     },
 
     close: function() {
         var draggable = this.$modal.draggable( "instance" );
-        // Export Window breaks if made draggable
-        if(this.$el.getAttributes()['class'].indexOf('o_export') == -1) {
-            if (draggable)
-                this.$modal.draggable("destroy");
-        }
+        if (draggable)
+            this.$modal.draggable("destroy");
         var res = this._super.apply(this, arguments);
         return res;
     },


### PR DESCRIPTION
Fix problem with export window that break orribly when made draggable (verified
only with 10.0 branch)