### PR TITLE
[ADD] [web_export_view] export all records if all checkbox is selected

### DIFF
--- a/web_export_view/__openerp__.py
+++ b/web_export_view/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     'name': 'Export Current View',
-    'version': '8.0.1.2.0',
+    'version': '8.0.1.3.0',
     'category': 'Web',
     'author': "Agile Business Group,Odoo Community Association (OCA)",
     'website': 'http://www.agilebg.com',


### PR DESCRIPTION
this allows to export all records when the all records checkbox is selected.

I wasn't very happy with the implementation choice of fishing out the data from the DOM, that's why I changed this to read from the underlying dataset. Commit 5ca37d4 contains a version that manipulates the DOM to do what we want, but that's slow and very unwieldy. What do @eLBati @simahawk @StefanRijnhart @lepistone (current contributors) think?