### PR TITLE
[FIX] Fixed navigation error after using x2x advanced search

### DIFF
--- a/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
+++ b/web_advanced_search_x2x/static/src/js/web_advanced_search_x2x.js
@@ -38,9 +38,11 @@ odoo.define('web_advanced_search_x2x.search_filters', function (require) {
                 'value': 'domain', 'text': core._lt('is in selection'),
             });
             // Avoid hiding filter when using special widgets
-            this.events["click"] = function (event) {
-                event.stopPropagation();
-            }
+            this.events = $.extend({}, this.events, {
+                click: function (event) {
+                    event.stopPropagation();
+                },
+            });
             return this._super.apply(this, arguments);
         },
 


### PR DESCRIPTION
After using the advanced search features, huge bugs are created.
1) Unable to open "Action" and "Print" dropdowns on a list view
2) Unable to switch notebook pages on a form view
3) And maybe others which were not discovered yet.

Steps to reproduce:
1) Go on the "Customer" action.
2) Use advanced search on a many2one field (for example company), select the company using a click action.
3) Switch to the list view, select some records and try to open "Print" and "Action" dropdowns -> nothing happens
4) Go on an other action (for example "sales order"), open the form view and try to open a notebook page -> nothing happens

More of that, after selecting a value in the many2one widget, you can't reselect one (or execute search more action). You must close the filter dropdown and reopen it in order to select a new value.

This PR corrects this behavior but add a regression of https://github.com/OCA/web/issues/703 (corrected by https://github.com/OCA/web/pull/704).

We must find a proper way to fix mentioned issue, but we can't accept the current behavior because it affects lots of action and users have to refresh browser page to correct this issue.

@Yajo Could you please check? I don't understand why at the moment, but the lines I removed seem to affect window's events instead of the current widget. I guess this behavior comes from the fact that ```X2XAdvancedSearchPropositionMixin``` dictionnary is evaluated during the page loading, and at this moment, ```this``` is not the current widget.