### PR TITLE
[FIX] web_export_view: Error when export a view with a many2many field.

### DIFF
--- a/web_export_view/__openerp__.py
+++ b/web_export_view/__openerp__.py
@@ -21,7 +21,7 @@
 
 {
     'name': 'Export Current View',
-    'version': '8.0.1.3.0',
+    'version': '8.0.1.3.1',
     'category': 'Web',
     'author': "Agile Business Group,Odoo Community Association (OCA)",
     'website': 'http://www.agilebg.com',

--- a/web_export_view/controllers/controllers.py
+++ b/web_export_view/controllers/controllers.py
@@ -40,7 +40,14 @@ class ExcelExportView(ExcelExport):
         data = json.loads(data)
         model = data.get('model', [])
         columns_headers = data.get('headers', [])
-        rows = data.get('rows', [])
+        rows = []
+        for row in data.get('rows', []):
+            row = [
+                ', '.join(map(lambda c: c.name_get()[0][1], request.env[cell['relation']].browse(cell['ids'])))
+                if isinstance(cell, dict) else cell
+                for cell in row
+            ]
+            rows.append(row)
 
         return request.make_response(
             self.from_data(columns_headers, rows),

--- a/web_export_view/controllers/controllers.py
+++ b/web_export_view/controllers/controllers.py
@@ -43,7 +43,12 @@ class ExcelExportView(ExcelExport):
         rows = []
         for row in data.get('rows', []):
             row = [
-                ', '.join(map(lambda c: c.name_get()[0][1], request.env[cell['relation']].browse(cell['ids'])))
+                ', '.join(
+                    map(
+                        lambda c: c.name_get()[0][1],
+                        request.env[cell['relation']].browse(cell['ids'])
+                    )
+                )
                 if isinstance(cell, dict) else cell
                 for cell in row
             ]

--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -85,12 +85,20 @@ openerp.web_export_view = function (instance) {
                     var export_row = [],
                         record = new instance.web.list.Record(record).toForm();
                     $.each(view.visible_columns, function() {
-                        export_row.push(
-                            this.type != 'integer' && this.type != 'float' ?
-                            this.format(
-                                record.data, {process_modifiers: false}
-                            ) : record.data[this.id].value
-                        );
+                        if(this.type != 'many2many'){
+                            export_row.push(
+                                this.type != 'integer' && this.type != 'float' ?
+                                this.format(
+                                    record.data, {process_modifiers: false}
+                                ) : record.data[this.id].value
+                            );
+                        }
+                        else{
+                            export_row.push({
+                                ids: record.data[this.id].value,
+                                relation: this.relation
+                            })
+                        }
                     })
                     export_rows.push(export_row);
                 });


### PR DESCRIPTION
Hello,
With the latest version when you try to export a current view where is a m2m field we get an error.
To reproduce go to Sales --> Products --> Product variants, select any number of records and 'Export Current View', then:
![export_current_view_error](https://user-images.githubusercontent.com/5578568/33271143-b1dda71c-d386-11e7-82f4-f7e45c107d53.png)
(Tryed on runbot)
To fix this we implemented a case in the web_export_view.js for the m2m fields and in the controller.py we get the correct value acording to the m2m values.