### PR TITLE
[10] [web responsive]: hide header when print directly from browser

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Web Responsive",
     "summary": "It provides a mobile compliant interface for Odoo Community "
                "web",
-    "version": "10.0.1.2.1",
+    "version": "10.0.1.2.2",
     "category": "Website",
     "website": "https://laslabs.com/",
     "author": "LasLabs, Tecnativa, Odoo Community Association (OCA)",

--- a/web_responsive/static/src/less/navbar.less
+++ b/web_responsive/static/src/less/navbar.less
@@ -4,6 +4,10 @@
 header {
     margin: 0;
     padding: 0;
+    
+    @media print {
+        display: none;
+    }
 
     > .main-nav {
         display: block;


### PR DESCRIPTION
for version 10.0, same issue as with https://github.com/OCA/web/issues/808