### PR TITLE
[8.0] web_export_view: Various fixes

### DIFF
--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -87,9 +87,9 @@ openerp.web_export_view = function (instance) {
                     $.each(view.visible_columns, function() {
                         export_row.push(
                             this.type != 'integer' && this.type != 'float' ?
-                            this.format(
+                            jQuery('<div/>').html(this.format(
                                 record.data, {process_modifiers: false}
-                            ) : record.data[this.id].value
+                            )).text() : record.data[this.id].value
                         );
                     })
                     export_rows.push(export_row);

--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -77,7 +77,12 @@ openerp.web_export_view = function (instance) {
             else {
                 deferred = view.dataset.read_slice(export_columns_keys);
                 export_columns_names.push(
-                    String(view.dataset.domain || _('All records'))
+                    _t('Selected records:') + ' ' +
+                    String(
+                        _(view.ViewManager.searchview.query.pluck('values'))
+                        .chain().flatten(true).pluck('label').value()
+                        .join('; ') || _('All records')
+                    )
                 );
             }
             var x2many = _(export_columns_keys).filter(function(field) {


### PR DESCRIPTION
We need to encode html entities now we read directly from the dataset, and treat x2many fields specially.

Then when we export all records, show the domain in an actually human readable form