### PR TITLE
[10.0][FIX] web_widget_x2many_2d_matrix: Styles

### DIFF
--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "2D matrix for x2many fields",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "author": "Therp BV, "
               "Tecnativa,"
               "Odoo Community Association (OCA)",

--- a/web_widget_x2many_2d_matrix/static/src/css/web_widget_x2many_2d_matrix.css
+++ b/web_widget_x2many_2d_matrix/static/src/css/web_widget_x2many_2d_matrix.css
@@ -1,8 +1,4 @@
-.oe_form_field_x2many_2d_matrix th.oe_link
+.o_form_field_x2many_2d_matrix th.oe_link
 {
     cursor: pointer;
-}
-.oe_form_field_x2many_2d_matrix .oe_list_content > tbody > tr > td.oe_list_field_cell
-{
-    white-space: normal;
 }

--- a/web_widget_x2many_2d_matrix/static/src/css/web_widget_x2many_2d_matrix.css
+++ b/web_widget_x2many_2d_matrix/static/src/css/web_widget_x2many_2d_matrix.css
@@ -2,3 +2,9 @@
 {
     cursor: pointer;
 }
+
+/* Reset the background color of disabled input fields in the matrix. */
+.o_form_field_x2many_2d_matrix input.o_form_input:disabled
+{
+    background-color: lightgrey;
+}

--- a/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
@@ -14,7 +14,7 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
 
     var WidgetX2Many2dMatrix = FieldOne2Many.extend({
         template: 'FieldX2Many2dMatrix',
-        widget_class: 'oe_form_field_x2many_2d_matrix',
+        widget_class: 'o_form_field_x2many_2d_matrix',
 
         // those will be filled with rows from the dataset
         by_x_axis: {},
@@ -145,7 +145,6 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                             self.setup_many2one_axes();
                             self.$el.find('.edit').on(
                                 'change', self.proxy(self.xy_value_change));
-                            self.effective_readonly_change();
                         }
                     });
                 });
@@ -207,13 +206,27 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 this.field_label_y_axis, true);
         },
 
-        // return the class(es) the inputs should have
+        // return the class(es) inputs should have
         get_xy_value_class: function()
         {
-            var classes = 'oe_form_field oe_form_required';
-            if(this.is_numeric)
-            {
-                classes += ' oe_form_field_float';
+            var classes = 'edit o_form_input o_form_required oe_edit_only';
+            if (this.is_numeric) {
+                classes += ' o_form_field_number';
+            }
+            return classes;
+        },
+
+        // return the class(es) read-only inputs should have
+        get_xy_value_read_only_class: function()
+        {
+            var classes = 'read o_form_input';
+            if (this.is_numeric) {
+                classes += ' o_form_field_number';
+            }
+            if (!this.get('effective_readonly')) {
+                // When the whole matrix is read-only but shown inside of an editable form, don't
+                // add "oe_read_only" so our read-only <span>s always show up.
+                classes += ' oe_read_only';
             }
             return classes;
         },
@@ -350,9 +363,6 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 'change', self.proxy(this.xy_value_change));
             this.compute_totals();
             this.setup_many2one_axes();
-            this.on("change:effective_readonly",
-                    this, this.proxy(this.effective_readonly_change));
-            this.effective_readonly_change();
             return this._super();
         },
 
@@ -378,17 +388,6 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 $this.parent().addClass('oe_form_invalid');
             }
 
-        },
-
-        effective_readonly_change: function()
-        {
-            this.$el
-            .find('tbody .edit')
-            .toggle(!this.get('effective_readonly'));
-            this.$el
-            .find('tbody .read')
-            .toggle(this.get('effective_readonly'));
-            this.$el.find('.edit').first().focus();
         },
 
         is_syntax_valid: function()

--- a/web_widget_x2many_2d_matrix/static/src/xml/web_widget_x2many_2d_matrix.xml
+++ b/web_widget_x2many_2d_matrix/static/src/xml/web_widget_x2many_2d_matrix.xml
@@ -15,7 +15,7 @@
                     <tr t-foreach="widget.get_y_axis_values()" t-as="y" t-att-data-y="y">
                         <th><t t-esc="widget.get_y_axis_label(y)" /></th>
                         <td t-foreach="widget.get_x_axis_values()" t-as="x" t-att-data-x="x" t-att-class="'' + (widget.is_numeric ? ' o_list_number' : '')">
-                            <input t-att-class="widget.get_xy_value_class()"
+                            <input type="text" t-att-class="widget.get_xy_value_class()"
                                 t-att-data-id="widget.get_xy_id(x, y)"
                                 t-att-value="widget.format_xy_value(widget.get_xy_value(x, y))"
                                 t-att="widget.get_xy_att(x, y)"

--- a/web_widget_x2many_2d_matrix/static/src/xml/web_widget_x2many_2d_matrix.xml
+++ b/web_widget_x2many_2d_matrix/static/src/xml/web_widget_x2many_2d_matrix.xml
@@ -14,20 +14,22 @@
                 <tbody>
                     <tr t-foreach="widget.get_y_axis_values()" t-as="y" t-att-data-y="y">
                         <th><t t-esc="widget.get_y_axis_label(y)" /></th>
-                        <td t-foreach="widget.get_x_axis_values()" t-as="x" t-att-class="'' + (widget.is_numeric ? ' oe_number' : '')" t-att-data-x="x">
-                            <span t-att-class="widget.get_xy_value_class()">
-                                <input class="edit o_form_input oe_edit_only" t-att-data-id="widget.get_xy_id(x, y)" t-att-value="widget.format_xy_value(widget.get_xy_value(x, y))" t-att="widget.get_xy_att(x, y)"/>
-                                <span class="read oe_read_only"><t t-esc="widget.format_xy_value(widget.get_xy_value(x, y))" /></span>
-                            </span>
+                        <td t-foreach="widget.get_x_axis_values()" t-as="x" t-att-data-x="x" t-att-class="'' + (widget.is_numeric ? ' o_list_number' : '')">
+                            <input t-att-class="widget.get_xy_value_class()"
+                                t-att-data-id="widget.get_xy_id(x, y)"
+                                t-att-value="widget.format_xy_value(widget.get_xy_value(x, y))"
+                                t-att="widget.get_xy_att(x, y)"
+                                t-if="!widget.get('effective_readonly')" />
+                            <span t-att-class="widget.get_xy_value_read_only_class()"><t t-esc="widget.format_xy_value(widget.get_xy_value(x, y))" /></span>
                         </td>
-                        <td t-if="widget.show_row_totals" class="row_total oe_number" t-att-data-y="y"/>
+                        <td t-if="widget.show_row_totals" class="row_total o_form_field_number" t-att-data-y="y"/>
                     </tr>
                 </tbody>
                 <tfoot t-if="widget.show_column_totals">
                     <tr>
                         <th>Total</th>
-                        <td t-foreach="widget.get_x_axis_values()" t-as="x" class="oe_list_footer oe_number column_total" t-att-data-x="x" />
-                        <td class="grand_total oe_number" />
+                        <td t-foreach="widget.get_x_axis_values()" t-as="x" class="oe_list_footer o_form_field_number column_total" t-att-data-x="x" />
+                        <td class="grand_total o_form_field_number" />
                     </tr>
                 </tfoot>
             </table>


### PR DESCRIPTION
Hi,

I set out by wondering why cells in the matrix widget were no longer showing up with their blue "required field" background color: It appears various CSS classes (but not all of them) have been renamed in Odoo 10.

I then looked into other CSS classes used by the `web_widget_x2many_2d_matrix` addon and made them match regular Odoo lists.
In editable mode, we are still quite far from editable lists which put `input` fields inside a fake `div` so as to simulate an actual `form`, but styles do match now at least.

Don't hesitate to shout if anything is broken - I will be using this widget quite a bit so I will try to watch for issues reported in here.

Commit message:

Update CSS classes used by the "web_widget_x2many_2d_matrix" widget to
match base Odoo ones.

In particular, cells now show up with a "required field" style (as
intended).

Remove custom read-only field management in the process that was no
longer working and is not needed anymore (all handled via CSS classes).