### PR TITLE
[10.0] Allow complex color expressions in web_timeline

### DIFF
--- a/web_timeline/README.rst
+++ b/web_timeline/README.rst
@@ -59,7 +59,7 @@ Example:
                           default_group_by="user_id"
                           event_open_popup="true"
                           zoomKey="ctrlKey"
-                          colors="#ec7063:user_id == false;#2ecb71:kanban_state=='done';">
+                          colors="#ec7063:user_id == False;#2ecb71:kanban_state=='done';">
                     <field name="user_id"/>
                     <field name="kanban_state"/>
                 </timeline>

--- a/web_timeline/README.rst
+++ b/web_timeline/README.rst
@@ -38,7 +38,8 @@ the possible attributes for the tag:
   in a popup. If not (default value), the record is edited changing to form
   view.
 * colors (optional): it allows to set certain specific colors if the expressed
-  condition (JS syntax) is met.
+  condition (Python syntax) is met. Fields used in calculation must be declared
+  in the node.
 
 You also need to declare the view in an action window of the involved model.
 
@@ -59,6 +60,8 @@ Example:
                           event_open_popup="true"
                           zoomKey="ctrlKey"
                           colors="#ec7063:user_id == false;#2ecb71:kanban_state=='done';">
+                    <field name="user_id"/>
+                    <field name="kanban_state"/>
                 </timeline>
             </field>
         </record>

--- a/web_timeline/__manifest__.py
+++ b/web_timeline/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': "Web timeline",
     'summary': "Interactive visualization chart to show events in time",
-    "version": "10.0.1.2.1",
+    "version": "10.0.1.2.3",
     'author': 'ACSONE SA/NV, '
               'Tecnativa, '
               'Monk Software, '

--- a/web_timeline/static/src/js/web_timeline.js
+++ b/web_timeline/static/src/js/web_timeline.js
@@ -243,16 +243,18 @@ odoo.define('web_timeline.TimelineView', function (require) {
             } else {
                 group = -1;
             }
-            for (var i = 0, len = this.colors.length; i < len; ++i) {
-                var context = _.extend({}, evt, {
-                    uid: session.uid,
-                    current_date: moment().format('YYYY-MM-DD')
-                });
-                var pair = this.colors[i],
-                    color = pair[0],
-                    expression = pair[1];
-                if (py.PY_isTrue(py.evaluate(expression, context))) {
-                    self.color = color;
+            if (this.colors !== undefined) {
+                for (var i = 0, len = this.colors.length; i < len; ++i) {
+                    var context = _.extend({}, evt, {
+                        uid: session.uid,
+                        current_date: moment().format('YYYY-MM-DD')
+                    });
+                    var pair = this.colors[i],
+                        color = pair[0],
+                        expression = pair[1];
+                    if (py.PY_isTrue(py.evaluate(expression, context))) {
+                        self.color = color;
+                    }
                 }
             }
             var r = {


### PR DESCRIPTION
Current implementation of `colors` only allows for simple evaluation of kind ` field operator value` and does not work for more complex conditions such as `a != value1 and b in (value2, value3)`.

This PR reimplements the colors evaluation the same way as in tree views.

Drawback is that fields used in complex conditions must be declared, like in a kanban view. However, fields in a simple `field operator value` are still fetched automatically for backward compatibility.