### PR TITLE
[8.0][FIX] ActWindow from Python Method after Popup

### DIFF
--- a/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
+++ b/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
@@ -78,6 +78,29 @@ openerp.web_ir_actions_act_window_message = function(instance)
                             {
                                 if(_.isObject(result))
                                 {
+                                    if (! ('views' in result) && 'view_mode' in result){
+                                        types = result.view_mode.split(",");
+                                        if (types.length > 1){
+                                            if (types.includes('tree') && types.includes('form')){
+                                                if (types[0] === "tree"){
+                                                    views = [[false, "list"], [false, types[1]]];
+                                                    result.view_mode = "list" + ',' + types[1];
+                                                }
+                                                else {
+                                                    views = [[false, types[0]], [false, "list"]];
+                                                    result.view_mode = types[0] + ',' + "list";
+                                                }
+                                            }
+                                        }
+                                        else if (result.view_mode === 'form'){
+                                            views = [[false, "form"]];
+                                        }
+                                        else if (result.view_mode === 'tree'){
+                                            views = [[false, "list"]];
+                                            result.view_mode = 'list';
+                                        }
+                                        result.views = views;
+                                    }
                                     self.do_action(result);
                                 }
                                 else


### PR DESCRIPTION
Allow python methods called from an ir.action.act_window.message
action to return window actions without specifying the ``views``
key, as they would be if called from a button defined in xml.
``view_mode`` key is used for creating the views array as it is required anyway.

### Problem:

* After calling a popup message defined like


        confirmation = {
            'type': 'ir.actions.act_window.message',
            'title': conf_vals['title'],
            'message': conf_vals['message'],
            'close_button_title': conf_vals['close_title'],
            'buttons': [
                {
                    'type': 'method',
                    'name': conf_vals['accept_title'],
                    'model': self._name,
                    'method': 'apply_method',
                    'args': [self.ids, expenses.ids],
                }
            ]
        }
        return confirmation

the action returned from the method `apply_method` which was something like

        action = {
            'name': 'Moves',
            'type': 'ir.actions.act_window',
            'res_model': 'account.move',
            'view_type': 'form',
            'view_mode': 'tree,form',
            'target': 'current',
        }

ended up in a JS error.
![image](https://user-images.githubusercontent.com/28577666/35284548-e13b15fa-0039-11e8-8337-6da2a295d7d0.png)
