### PR TITLE
[IMP] Taking into account core options:

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -125,6 +125,7 @@ Known issues
 
 Double check that you have no inherited view that remove ``options`` you set on a field !
 If nothing works, add a debugger in the first line of ``get_search_result method`` and enable debug mode in Odoo. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
+``create_edit`` and ``create`` are now supported by default in Odoo's core (``no_create_edit``, ``no_create``). So, these keywords should be removed when migrating to 11.0 (we keep them in version 10.0 to preserve the compatibility with the previous 10.0 versions of this module)
 
 Roadmap
 =======

--- a/web_m2x_options/__manifest__.py
+++ b/web_m2x_options/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": 'web_m2x_options',
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.1.1",
     "depends": [
         'base',
         'web',

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -239,12 +239,23 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                     }
                 }
 
+                // TODO: Remove create_edit,create,no_create_edit and no_create options when migrating to 11.0 -> Odoo's core already support them by default
                 // create...
                 var create_edit = self.is_option_set(self.options.create) || self.is_option_set(self.options.create_edit),
-                    create_edit_undef = _.isUndefined(self.options.create) && _.isUndefined(self.options.create_edit),
+                    create_edit_undef = _.isUndefined(self.options.create) && _.isUndefined(self.options.create_edit) && _.isUndefined(self.options.no_create) && _.isUndefined(self.options.no_create_edit),
                     m2x_create_edit_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit']),
-                    m2x_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
-                var show_create_edit = (!self.options && (m2x_create_edit_undef || m2x_create_edit)) || (self.options && (create_edit || (create_edit_undef && (m2x_create_edit_undef || m2x_create_edit))));
+                    m2x_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']),
+                    no_create_edit = self.is_option_set(self.options.no_create) || self.is_option_set(self.options.no_create_edit),
+                    no_create_edit_undef = _.isUndefined(self.options.no_create) && _.isUndefined(self.options.no_create_edit);
+
+                var show_create_edit = (!self.options && (m2x_create_edit_undef || m2x_create_edit));
+                if (!show_create_edit) {
+                    if (no_create_edit_undef) {
+                        show_create_edit = (self.options && (create_edit || (create_edit_undef && (m2x_create_edit_undef || m2x_create_edit))));
+                    } else {
+                        show_create_edit = (self.options && !no_create_edit);
+                    }
+                }
                 if (self.can_create && show_create_edit){
                     values.push({
                         label: _t("Create and Edit..."),
@@ -389,12 +400,22 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                     }
                 }
 
+                // TODO: Remove create_edit,create,no_create_edit and no_create options when migrating to 11.0 -> Odoo's core already support them by default
                 // create...
                 var create_edit = self.is_option_set(self.options.create) || self.is_option_set(self.options.create_edit),
                     create_edit_undef = _.isUndefined(self.options.create) && _.isUndefined(self.options.create_edit),
                     m2x_create_edit_undef = _.isUndefined(self.view.ir_options['web_m2x_options.create_edit']),
-                    m2x_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']);
-                var show_create_edit = (!self.options && (m2x_create_edit_undef || m2x_create_edit)) || (self.options && (create_edit || (create_edit_undef && (m2x_create_edit_undef || m2x_create_edit))));
+                    m2x_create_edit = self.is_option_set(self.view.ir_options['web_m2x_options.create_edit']),
+                    no_create_edit = self.is_option_set(self.options.no_create) || self.is_option_set(self.options.no_create_edit),
+                    no_create_edit_undef = _.isUndefined(self.options.no_create) && _.isUndefined(self.options.no_create_edit);
+                var show_create_edit = (!self.options && (m2x_create_edit_undef || m2x_create_edit))
+                if (!show_create_edit) {
+                    if (no_create_edit_undef) {
+                        show_create_edit = (self.options && (create_edit || (create_edit_undef && (m2x_create_edit_undef || m2x_create_edit))));
+                    } else {
+                        show_create_edit = (self.options && !no_create_edit);
+                    }
+                }
                 if (show_create_edit){
 
                     values.push({


### PR DESCRIPTION
- In Odoo 10.0 the flags 'no_create_edit' and 'no_create' can be used. Without this improvement, they are ignored, and all the views which use this flags are ignored