### PR TITLE
[FIX] web_m2x_options: fix ignored field options

### DIFF
--- a/web_m2x_options/__manifest__.py
+++ b/web_m2x_options/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     "name": 'web_m2x_options',
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.1.1",
     "depends": [
         'base',
         'web',

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -142,7 +142,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                 var search_result = searcher([["id", "not in", blacklist]]);
             }
 
-            if (!(self.options && (self.is_option_set(self.options.create) || self.is_option_set(self.options.create_edit)))) {
+            if (self.options && (self.is_option_set(self.options.create) || self.is_option_set(self.options.create_edit))) {
                 this.create_rights = this.create_rights || (function(){
                 return new Model(self.field.relation).call(
                     "check_access_rights", ["create", false]);


### PR DESCRIPTION
The module was ignoring the local field options 'create' and 'create_edit'.
For example, specifying options="{'create': true, 'create_edit': true}" on a
field would not override the web_m2x_options system parameters.

Replaces PR #858 