### PR TITLE
[FIX] web_tree_many2one_clickable: Check if the node is a field

### DIFF
--- a/web_tree_many2one_clickable/__manifest__.py
+++ b/web_tree_many2one_clickable/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Clickable many2one fields for tree views",
     "summary": "Open the linked resource when clicking on their name",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Hidden",
     "website": "https://github.com/OCA/web",
     "author": "Therp BV, "

--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -10,7 +10,9 @@ odoo.define('web_tree_many2one_clickable.many2one_clickable', function (require)
 
     ListRenderer.include({
         _renderBodyCell: function (record, node, colIndex, options) {
-            if (!node.attrs.widget && this.state.fields[node.attrs.name].type === 'many2one') {
+            if (!node.attrs.widget && node.attrs.name &&
+                this.state.fields[node.attrs.name] &&
+                this.state.fields[node.attrs.name].type === 'many2one') {
                 // no explicit widget provided on a many2one field,
                 // force `many2one` widget
                 node.attrs.widget = 'many2one';


### PR DESCRIPTION
If a list contains a node which is not a field (e.g. a button), it will
not be found in the fields so we'll have an error trying to get 'type'
from undefined.