### PR TITLE
Fix several issues in web_tree_dynamic_colored_field

### DIFF
--- a/web_tree_dynamic_colored_field/README.rst
+++ b/web_tree_dynamic_colored_field/README.rst
@@ -25,13 +25,13 @@ Features
 Usage
 =====
 
-* In the tree view declaration, put ``options='"bg_color": "red: customer==True"`` attribute in the ``field`` tag::
+* In the tree view declaration, put ``options='{"bg_color": "red: customer==True"}`` attribute in the ``field`` tag::
 
     ...
     <field name="arch" type="xml">
         <tree string="View name">
             ...
-            <field name="name" options='"bg_color": "red: customer == True"'/>
+            <field name="name" options='{"bg_color": "red: customer == True"}'/>
             ...
         </tree>
     </field>
@@ -39,13 +39,13 @@ Usage
     
     With this example, column which renders 'name' field will have its background colored in red.
 
-* In the tree view declaration, put ``options='"fg_color": "white:customer == True"'`` attribute in the ``field`` tag::
+* In the tree view declaration, put ``options='{"fg_color": "white:customer == True"}'`` attribute in the ``field`` tag::
 
     ...
     <field name="arch" type="xml">
         <tree string="View name">
             ...
-            <field name="name" 'options="fg_color": "white:customer == True"'/>
+            <field name="name" options='{"fg_color": "white:customer == True"}'/>
             ...
         </tree>
     </field>
@@ -90,6 +90,7 @@ Contributors
 * Damien Crier <damien.crier@camptocamp.com>
 * Holger Brunn <hbrunn@therp.nl>
 * Artem Kostyuk <a.kostyuk@mobilunity.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
 
 Maintainer
 ----------

--- a/web_tree_dynamic_colored_field/__manifest__.py
+++ b/web_tree_dynamic_colored_field/__manifest__.py
@@ -4,7 +4,7 @@
     'name': 'Colorize field in tree views',
     'summary': 'Allows you to dynamically color fields on tree views',
     'category': 'Hidden/Dependency',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'depends': ['web'],
     'author': "Camptocamp, Therp BV, Odoo Community Association (OCA)",
     'license': 'AGPL-3',

--- a/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
+++ b/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
@@ -12,20 +12,21 @@ odoo.define('web_tree_dynamic_colored_field', function (require) {
          */
         _renderBody: function () {
             if (this.arch.attrs.colors) {
-                var colorField = this.arch.attrs.colors.split(';')
-                .filter(color => color.trim().startsWith('color_field'))[0]
-                .split(':')[1]
-                .trim();
-                // validate the presence of that field in tree view
-                var fieldNames = _(this.columns).map(
-                    (value) => { return value.attrs.name; }
-                );
-                if (fieldNames.indexOf(colorField) === -1) {
-                    console.warn(
-                        "No field named '" + colorField + "' present in view."
+                var colorAttr = this.arch.attrs.colors.split(';')
+                    .filter(color => color.trim().startsWith('color_field'));
+                if (colorAttr.length > 0) {
+                    var colorField = colorAttr[0].split(':')[1].trim();
+                    // validate the presence of that field in tree view
+                    var fieldNames = _(this.columns).map(
+                        (value) => { return value.attrs.name; }
                     );
-                } else {
-                    this.colorField = colorField;
+                    if (fieldNames.indexOf(colorField) === -1) {
+                        console.warn(
+                            "No field named '" + colorField + "' present in view."
+                        );
+                    } else {
+                        this.colorField = colorField;
+                    }
                 }
             }
             return this._super();

--- a/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
+++ b/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
@@ -56,7 +56,11 @@ odoo.define('web_tree_dynamic_colored_field', function (require) {
             }
             // apply <field>'s own `options`
             if (!node.attrs.options) { return; }
-            var nodeOptions = JSON.parse(node.attrs.options);
+            if (node.tag !== 'field') { return; }
+            var nodeOptions = node.attrs.options;
+            if (!_.isObject(nodeOptions)) {
+                nodeOptions = pyeval.py_eval(nodeOptions);
+            }
             this.applyColorizeHelper($td, nodeOptions, node, 'fg_color', 'color', ctx);
             this.applyColorizeHelper($td, nodeOptions, node, 'bg_color', 'background-color', ctx);
         },


### PR DESCRIPTION
* Parse node options only if not already object 
* Assume that a color in <tree> is not always starting with `color_field`, it can be a color (such as `red:procure_recommended_qty &gt; 0`
* Parse field options with pyeval instead of JSON (<field> are py, <button> are json...)
* Correct examples in readme