### PR TITLE
[FIX] web_dashboard_tile clean group_by from tile view

### DIFF
--- a/web_dashboard_tile/models/tile_tile.py
+++ b/web_dashboard_tile/models/tile_tile.py
@@ -259,7 +259,7 @@ class TileTile(models.Model):
             'view_id': [False],
             'res_model': self.model_id.model,
             'type': 'ir.actions.act_window',
-            'context': self.env.context,
+            'context': dict(self.env.context, group_by=False),
             'nodestroy': True,
             'target': 'current',
             'domain': self.domain,


### PR DESCRIPTION
When use a group by filter in the dashboard and try to click a tile an error raise and do not let me to get to the tile destination

This happens because context is set with a group_by key that is not related with the destination model.
This change will clean the context to do not extend this info to the next view.

Here is a [video](https://youtu.be/-tuIuFU_5j0) showing what happens when I not use a group by and the error when I do. Also here is the log error

```bash

Odoo Server Error
Traceback (most recent call last):
  File "/.repo_requirements/odoo/openerp/http.py", line 650, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/.repo_requirements/odoo/openerp/http.py", line 687, in dispatch
    result = self._call_function(**self.params)
  File "/.repo_requirements/odoo/openerp/http.py", line 323, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/.repo_requirements/odoo/openerp/service/model.py", line 118, in wrapper
    return f(dbname, *args, **kwargs)
  File "/.repo_requirements/odoo/openerp/http.py", line 316, in checked_call
    result = self.endpoint(*a, **kw)
  File "/.repo_requirements/odoo/openerp/http.py", line 966, in __call__
    return self.method(*args, **kw)
  File "/.repo_requirements/odoo/openerp/http.py", line 516, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/odoo-9.0/addons/web/controllers/main.py", line 895, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/odoo-9.0/addons/web/controllers/main.py", line 887, in _call_kw
    return getattr(request.registry.get(model), method)(request.cr, request.uid, *args, **kwargs)
  File "/.repo_requirements/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/.repo_requirements/odoo/openerp/models.py", line 2070, in read_group
    for gb in groupby_list
  File "/.repo_requirements/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/.repo_requirements/odoo/openerp/api.py", line 354, in old_api
    result = method(recs, *args, **kwargs)
  File "/.repo_requirements/odoo/openerp/models.py", line 1932, in _read_group_process_groupby
    field_type = self._fields[split[0]].type
KeyError: u'action_id'
```

With this change the errors disappears 