### PR TITLE
[FIX] web_notify.WebClient: return WebClient reference

### DIFF
--- a/web_notify/static/src/js/web_client.js
+++ b/web_notify/static/src/js/web_client.js
@@ -50,4 +50,6 @@ WebClient.include({
     }
 });
 
+return WebClient;
+
 });


### PR DESCRIPTION
This file does not return a reference to the WebClient class it extends. 
Returning a reference to WebClient allows further extensions of this class building on top of the changes in web_notify.