### PR TITLE
[11.0] x2m matrix widget: Fix display of widget when called in onchange

### DIFF
--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "2D matrix for x2many fields",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "Therp BV, "
               "Tecnativa, "
               "Camptocamp, "

--- a/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
@@ -9,6 +9,8 @@ odoo.define('web_widget_x2many_2d_matrix.X2Many2dMatrixRenderer', function (requ
   var config = require('web.config');
   var field_utils = require('web.field_utils');
   var utils = require('web.utils');
+  var core = require('web.core');
+  var _t = core._t
   var FIELD_CLASSES = {
     // copied from ListRenderer
     float: 'o_list_number',
@@ -37,9 +39,14 @@ odoo.define('web_widget_x2many_2d_matrix.X2Many2dMatrixRenderer', function (requ
     _renderView: function () {
       var self = this;
 
-      this.$el
-        .removeClass('table-responsive')
-        .empty();
+      // Display a nice message if there's no data to display
+      this.$el.empty();
+      if (!self.rows.length){
+        var $alert = $('<div>', {'class': 'alert alert-info'});
+        $alert.text(_t('Sorry no matrix data to display.'));
+        this.$el.append($alert);
+        return this._super();
+      }
 
       var $table = $('<table>').addClass('o_list_view table table-condensed table-striped');
       this.$el

--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -55,7 +55,7 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
         this.field_editability = node.field_editability || this.field_editability;
         this.show_row_totals = this.parse_boolean(node.show_row_totals || '1');
         this.show_column_totals = this.parse_boolean(node.show_column_totals || '1');
-        this.init_matrix();
+
     },
     /**
      * Initializes the Value matrix.
@@ -64,6 +64,9 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
     init_matrix: function(){
       var self = this,
           records = self.recordData[this.name].data;
+      // Wipe the content if something still exists
+      this.by_x_axis = {};
+      this.by_y_axis = {};
       _.each(records, function(record) {
         var x = record.data[self.field_x_axis],
             y = record.data[self.field_y_axis];
@@ -150,6 +153,8 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
       if (!this.view) {
         return this._super();
       }
+      // Ensure widget is re initiated when rendering
+      this.init_matrix();
       var arch = this.view.arch,
           viewType = 'list';
       this.renderer = new X2Many2dMatrixRenderer(this, this.value, {
@@ -159,7 +164,10 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
           matrix_data: this.matrix_data
       });
       this.$el.addClass('o_field_x2many o_field_x2many_2d_matrix');
+      // Remove previous rendered and add the newly created one
+      this.$el.find('div:not(.o_x2m_control_panel)').remove();
       return this.renderer.appendTo(this.$el);
+
     }
 
   });


### PR DESCRIPTION
The widget was not rendered correctly when it was initiated without data, and the data was added to the model afterwards in an onchange. e.g : https://github.com/Eficent/ddmrp/pull/50/files#diff-b28dd7ee0a2c2dcda88ef92e5730f58aR82

#And add nicer message when there are no values to display :
![screenshot-2018-4-19 inventory - odoo](https://user-images.githubusercontent.com/778828/39003563-6192fbbe-43fb-11e8-8491-2a3e29e8270a.png)
