### PR TITLE
[11.0][FIX] Make matrix editable depending of the status of the parent

### DIFF
--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "2D matrix for x2many fields",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "author": "Therp BV, "
               "Tecnativa, "
               "Camptocamp, "

--- a/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
@@ -238,7 +238,7 @@ odoo.define('web_widget_x2many_2d_matrix.X2Many2dMatrixRenderer', function (requ
       if (modifiers.invisible && !(options && options.renderInvisible)) {
           return $td;
       }
-      options.mode = 'edit';  // enforce edit mode
+      options.mode = this.getParent().mode;  // enforce mode of the parent
       var widget = this._renderFieldWidget(node, record, _.pick(options, 'mode'));
       this._handleAttributes(widget.$el, node);
       return $td.append(widget.$el);


### PR DESCRIPTION
It doesn't make sense to always have the matrix in edit mode. Obviously, if you have the matrix in a wizard, it always will be in edit mode. But if you put the matrix in a normal model (not transient), then the expected behavior is that the matrix is editable if you are in edit mode and the matrix is not editable if you are in read mode. 