### PR TITLE
[8.0][FIX] web_ir_actions_act_window_message

### DIFF
--- a/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
+++ b/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
@@ -80,7 +80,13 @@ openerp.web_ir_actions_act_window_message = function(instance)
                                 {
                                     // clean the action as it is done in the method ``fix_view_modes``
                                     // in the main controller of the web module
+                                    // only if the action is an Act Window
                                     action = result;
+                                    if (action.type != 'ir.actions.act_window') {
+                                        self.do_action(action);
+                                        close_func();
+                                        return;
+                                    }
                                     if ( ! ('views' in action) ){
                                         view_id = action.view_id || false;
                                         if ( view_id instanceof Array ){


### PR DESCRIPTION
Pull Request #846 was aimed to allow devs to return window actions from
python code without specifying the views, but introduced a bug when the
action was not of type window. This commit pretends to fix that.