### PR TITLE
encoding declaration to avoid syntax error

### DIFF
--- a/web_timeline/models/__init__.py
+++ b/web_timeline/models/__init__.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 # © 2016 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 


### PR DESCRIPTION
We need to declare encoding in the __init__.py of the web_timeline module to avoid this error : 

"SyntaxError: Non-ASCII character '\xc2' in file web_timeline/models/__init__.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details