### PR TITLE
[FIX] web_m2x_options: fix ignored field options (again)

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -142,16 +142,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                 var search_result = searcher([["id", "not in", blacklist]]);
             }
 
-            if (!(self.options && (self.is_option_set(self.options.create) || self.is_option_set(self.options.create_edit)))) {
-                this.create_rights = this.create_rights || (function(){
-                return new Model(self.field.relation).call(
-                    "check_access_rights", ["create", false]);
-                })();
-            }
-
-            $.when(search_result, this.create_rights).then(function (data, can_create) {
-
-                self.can_create = can_create;  // for ``.show_error_displayer()``
+            $.when(search_result).then(function (data) {
                 self.last_search = data;
                 // possible selections for the m2o
                 var values = _.map(data, function (x) {


### PR DESCRIPTION
System parameter m2x options work just fine, but setting
`options={...}` does not work for `create` and `create_edit` keys.
This change removes the faulty logic and uses the core Odoo logic
for `can_create` on the field.