### PR TITLE
[FIX] Error when using Quick Create on many2many_tags_multiselection widget

### DIFF
--- a/web_widget_many2many_tags_multi_selection/__manifest__.py
+++ b/web_widget_many2many_tags_multi_selection/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Tags multiple selection',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'author': 'Akretion, Odoo Community Association (OCA), Jamin Shah',
     'depends': [
         'web',

--- a/web_widget_many2many_tags_multi_selection/static/src/js/view_form.js
+++ b/web_widget_many2many_tags_multi_selection/static/src/js/view_form.js
@@ -19,7 +19,7 @@ odoo.define('web_widget_many2many_tags_multi_selection.multiple_tags', function 
                 }
             }
 
-            new dialogs.SelectCreateDialog(self, _.extend({}, self.nodeOptions, {
+            return new dialogs.SelectCreateDialog(self, _.extend({}, self.nodeOptions, {
                 res_model: self.field.relation,
                 domain: domain,
                 context: _.extend({}, self.record.getContext(self.recordParams), context || {}),


### PR DESCRIPTION
Missing `return` statement, fixes #939 