### PR TITLE
[11.0][FIX] web_timeline: Make colors attribute optional

### DIFF
--- a/web_timeline/__manifest__.py
+++ b/web_timeline/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': "Web timeline",
     'summary': "Interactive visualization chart to show events in time",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     'author': 'ACSONE SA/NV, '
               'Tecnativa, '
               'Monk Software, '

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -148,6 +148,8 @@ odoo.define('web_timeline.TimelineView', function (require) {
                         'value': temp.expressions[1].value
                     };
                 }).value();
+            } else {
+                this.colors = [];
             }
         },
 


### PR DESCRIPTION
> * colors (optional): it allows to set certain specific colors if the expressed
>   condition (JS syntax) is met.

In the current situation the colors attribute is not optional. You'll get an error when it's not provided.

![image](https://user-images.githubusercontent.com/10028499/41978521-574e2806-7a22-11e8-9aab-f2d5df30ad9e.png)
