### PR TITLE
[10.0] web_notify: interactive notifications

### DIFF
--- a/web_notify/README.rst
+++ b/web_notify/README.rst
@@ -50,7 +50,12 @@ The action can be used using the ``action`` keyword:
         'res_id': self.id,
         'views': [(False, 'form')],
     })
-   self.env.user.notify_info('My information message', action=action)
+   self.env.user.notify_info(
+       'My information message',
+       action=action,
+       # optional
+       action_link_name='Open Sale',
+   )
 
 
 Installation

--- a/web_notify/README.rst
+++ b/web_notify/README.rst
@@ -33,12 +33,25 @@ or
 The notifications can optionally have some action buttons.
 
 * One allowing to refresh the active view
+* Another allowing to send a window / client action
 
-It is activated when sending the notification with:
+The reload button is activated when sending the notification with:
 
 .. code-block:: python
   
    self.env.user.notify_info('My information message', show_reload=True)
+
+The action can be used using the ``action`` keyword:
+
+.. code-block:: python
+
+    action = self.env.ref('sale.action_orders').read()[0]
+    action.update({
+        'res_id': self.id,
+        'views': [(False, 'form')],
+    })
+   self.env.user.notify_info('My information message', action=action)
+
 
 Installation
 ============

--- a/web_notify/README.rst
+++ b/web_notify/README.rst
@@ -30,7 +30,7 @@ or
    :scale: 80 %
    :alt: Sample notifications
 
-The notifications can optionally have some action buttons.
+The notifications can bring interactivity with some buttons.
 
 * One allowing to refresh the active view
 * Another allowing to send a window / client action
@@ -54,7 +54,7 @@ The action can be used using the ``action`` keyword:
        'My information message',
        action=action,
        # optional
-       action_link_name='Open Sale',
+       action_link_name=_('Open Sale'),
    )
 
 
@@ -92,6 +92,7 @@ Contributors
 
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Serpent Consulting Services Pvt. Ltd.<jay.vora@serpentcs.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
 
 Maintainer
 ----------

--- a/web_notify/README.rst
+++ b/web_notify/README.rst
@@ -30,6 +30,16 @@ or
    :scale: 80 %
    :alt: Sample notifications
 
+The notifications can optionally have some action buttons.
+
+* One allowing to refresh the active view
+
+It is activated when sending the notification with:
+
+.. code-block:: python
+  
+   self.env.user.notify_info('My information message', show_reload=True)
+
 Installation
 ============
 

--- a/web_notify/__manifest__.py
+++ b/web_notify/__manifest__.py
@@ -18,6 +18,9 @@
     'data': [
         'views/web_notify.xml'
     ],
+    'qweb': [
+        'static/src/xml/*.xml',
+    ],
     'demo': [
     ],
     'installable': True,

--- a/web_notify/models/res_users.py
+++ b/web_notify/models/res_users.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models, _
+from odoo.addons.web.controllers.main import clean_action
 
 
 class ResUsers(models.Model):
@@ -24,26 +25,31 @@ class ResUsers(models.Model):
 
     @api.multi
     def notify_info(self, message, title=None, sticky=False,
-                    show_reload=False):
+                    show_reload=False, action=None):
         title = title or _('Information')
         self._notify_channel(
-            'notify_info_channel_name', message, title, sticky, show_reload)
+            'notify_info_channel_name', message, title,
+            sticky, show_reload, action)
 
     @api.multi
     def notify_warning(self, message, title=None, sticky=False,
-                       show_reload=False):
+                       show_reload=False, action=None):
         title = title or _('Warning')
         self._notify_channel(
-            'notify_warning_channel_name', message, title, sticky, show_reload)
+            'notify_warning_channel_name', message, title,
+            sticky, show_reload, action)
 
     @api.multi
     def _notify_channel(self, channel_name_field, message, title, sticky,
-                        show_reload):
+                        show_reload, action):
+        if action:
+            action = clean_action(action)
         bus_message = {
             'message': message,
             'title': title,
             'sticky': sticky,
             'show_reload': show_reload,
+            'action': action,
         }
         notifications = [(getattr(record, channel_name_field), bus_message)
                          for record in self]

--- a/web_notify/models/res_users.py
+++ b/web_notify/models/res_users.py
@@ -23,23 +23,27 @@ class ResUsers(models.Model):
         compute='_compute_channel_names')
 
     @api.multi
-    def notify_info(self, message, title=None, sticky=False):
+    def notify_info(self, message, title=None, sticky=False,
+                    show_reload=False):
         title = title or _('Information')
         self._notify_channel(
-            'notify_info_channel_name', message, title, sticky)
+            'notify_info_channel_name', message, title, sticky, show_reload)
 
     @api.multi
-    def notify_warning(self, message, title=None, sticky=False):
+    def notify_warning(self, message, title=None, sticky=False,
+                       show_reload=False):
         title = title or _('Warning')
         self._notify_channel(
-            'notify_warning_channel_name', message, title, sticky)
+            'notify_warning_channel_name', message, title, sticky, show_reload)
 
     @api.multi
-    def _notify_channel(self, channel_name_field, message, title, sticky):
+    def _notify_channel(self, channel_name_field, message, title, sticky,
+                        show_reload):
         bus_message = {
             'message': message,
             'title': title,
-            'sticky': sticky
+            'sticky': sticky,
+            'show_reload': show_reload,
         }
         notifications = [(getattr(record, channel_name_field), bus_message)
                          for record in self]

--- a/web_notify/models/res_users.py
+++ b/web_notify/models/res_users.py
@@ -25,32 +25,35 @@ class ResUsers(models.Model):
 
     @api.multi
     def notify_info(self, message, title=None, sticky=False,
-                    show_reload=False, action=None):
+                    show_reload=False, action=None,
+                    action_link_name=None, **options):
         title = title or _('Information')
         self._notify_channel(
             'notify_info_channel_name', message, title,
-            sticky, show_reload, action)
+            sticky=sticky, show_reload=show_reload, action=action,
+            action_link_name=action_link_name, **options
+        )
 
     @api.multi
     def notify_warning(self, message, title=None, sticky=False,
-                       show_reload=False, action=None):
+                       show_reload=False, action=None,
+                       action_link_name=None, **options):
         title = title or _('Warning')
         self._notify_channel(
             'notify_warning_channel_name', message, title,
-            sticky, show_reload, action)
+            sticky=sticky, show_reload=show_reload, action=action,
+            action_link_name=action_link_name, **options
+        )
 
     @api.multi
-    def _notify_channel(self, channel_name_field, message, title, sticky,
-                        show_reload, action):
-        if action:
-            action = clean_action(action)
+    def _notify_channel(self, channel_name_field, message, title, **options):
+        if options.get('action'):
+            options['action'] = clean_action(options['action'])
         bus_message = {
             'message': message,
             'title': title,
-            'sticky': sticky,
-            'show_reload': show_reload,
-            'action': action,
         }
+        bus_message.update(options)
         notifications = [(getattr(record, channel_name_field), bus_message)
                          for record in self]
         self.env['bus.bus'].sendmany(notifications)

--- a/web_notify/static/src/css/notification.less
+++ b/web_notify/static/src/css/notification.less
@@ -1,5 +1,5 @@
 .o_notification {
-    .o_notification_reload {
+    .o_notification_action {
         padding: 10px;
     }
 }

--- a/web_notify/static/src/css/notification.less
+++ b/web_notify/static/src/css/notification.less
@@ -1,0 +1,5 @@
+.o_notification {
+    .o_notification_reload {
+        padding: 10px;
+    }
+}

--- a/web_notify/static/src/js/notification.js
+++ b/web_notify/static/src/js/notification.js
@@ -1,0 +1,38 @@
+odoo.define('web_notify.notification', function (require) {
+    "use strict";
+
+    var base_notification = require('web.notification'),
+        WebClient = require('web.WebClient'),
+        Notification = base_notification.Notification,
+        Warning = base_notification.Warning;
+
+    Notification.include({
+        events: _.extend(
+            {},
+            Notification.prototype.events,
+            {'click .o_view_reload': function(e){
+                e.preventDefault();
+                this.reload_active_view();
+            }
+            }
+        ),
+        init: function(parent, title, text, sticky, options) {
+            this._super.apply(this, arguments);
+            this.options = options || {};
+        },
+        reload_active_view: function() {
+            this.trigger_up('reload_active_view');
+        },
+    });
+
+    base_notification.NotificationManager.include({
+        notify: function(title, text, sticky, options) {
+            return this.display(new Notification(this, title, text, sticky, options));
+        },
+        warn: function(title, text, sticky, options) {
+            return this.display(new Warning(this, title, text, sticky, options));
+        },
+
+    });
+
+});

--- a/web_notify/static/src/js/notification.js
+++ b/web_notify/static/src/js/notification.js
@@ -6,7 +6,8 @@ odoo.define('web_notify.notification', function (require) {
         Notification = base_notification.Notification,
         Warning = base_notification.Warning;
 
-    Notification.include({
+    var InteractiveNotification = Notification.extend({
+        template: 'InteractiveNotification',
         events: _.extend(
             {},
             Notification.prototype.events,
@@ -21,7 +22,7 @@ odoo.define('web_notify.notification', function (require) {
             }
         ),
         init: function(parent, title, text, sticky, options) {
-            this._super.apply(this, arguments);
+            this._super.apply(this, [parent, title, text, sticky]);
             this.options = options || {};
         },
         reload_active_view: function() {
@@ -33,14 +34,23 @@ odoo.define('web_notify.notification', function (require) {
         }
     });
 
+    var InteractiveWarning = InteractiveNotification.extend({
+        template: 'InteractiveWarning',
+    });
+
     base_notification.NotificationManager.include({
-        notify: function(title, text, sticky, options) {
-            return this.display(new Notification(this, title, text, sticky, options));
+        interactive_notify(title, text, sticky, options) {
+            return this.display(new InteractiveNotification(this, title, text, sticky, options));
         },
-        warn: function(title, text, sticky, options) {
-            return this.display(new Warning(this, title, text, sticky, options));
-        },
+        interactive_warn(title, text, sticky, options) {
+            return this.display(new InteractiveWarning(this, title, text, sticky, options));
+        }
 
     });
+
+    return {
+        InteractiveNotification: InteractiveNotification,
+        InteractiveWarning: InteractiveWarning
+    };
 
 });

--- a/web_notify/static/src/js/notification.js
+++ b/web_notify/static/src/js/notification.js
@@ -10,10 +10,14 @@ odoo.define('web_notify.notification', function (require) {
         events: _.extend(
             {},
             Notification.prototype.events,
-            {'click .o_view_reload': function(e){
+            {'click .o_notification_reload_view': function(e){
                 e.preventDefault();
                 this.reload_active_view();
-            }
+            },
+             'click .o_notification_do_action': function(e){
+                 e.preventDefault();
+                 this.button_do_action();
+             }
             }
         ),
         init: function(parent, title, text, sticky, options) {
@@ -23,6 +27,10 @@ odoo.define('web_notify.notification', function (require) {
         reload_active_view: function() {
             this.trigger_up('reload_active_view');
         },
+        button_do_action: function() {
+            console.log(this.options.action);
+            this.getParent().do_action(this.options.action);
+        }
     });
 
     base_notification.NotificationManager.include({

--- a/web_notify/static/src/js/notification.js
+++ b/web_notify/static/src/js/notification.js
@@ -3,8 +3,7 @@ odoo.define('web_notify.notification', function (require) {
 
     var base_notification = require('web.notification'),
         WebClient = require('web.WebClient'),
-        Notification = base_notification.Notification,
-        Warning = base_notification.Warning;
+        Notification = base_notification.Notification;
 
     var InteractiveNotification = Notification.extend({
         template: 'InteractiveNotification',
@@ -21,15 +20,15 @@ odoo.define('web_notify.notification', function (require) {
              }
             }
         ),
-        init: function(parent, title, text, sticky, options) {
-            this._super.apply(this, [parent, title, text, sticky]);
+        init: function(parent, title, text, options) {
             this.options = options || {};
+            var sticky = this.options.sticky;
+            this._super.apply(this, [parent, title, text, sticky]);
         },
         reload_active_view: function() {
             this.trigger_up('reload_active_view');
         },
         button_do_action: function() {
-            console.log(this.options.action);
             this.getParent().do_action(this.options.action);
         }
     });
@@ -39,11 +38,11 @@ odoo.define('web_notify.notification', function (require) {
     });
 
     base_notification.NotificationManager.include({
-        interactive_notify(title, text, sticky, options) {
-            return this.display(new InteractiveNotification(this, title, text, sticky, options));
+        interactive_notify(title, text, options) {
+            return this.display(new InteractiveNotification(this, title, text, options));
         },
-        interactive_warn(title, text, sticky, options) {
-            return this.display(new InteractiveWarning(this, title, text, sticky, options));
+        interactive_warn(title, text, options) {
+            return this.display(new InteractiveWarning(this, title, text, options));
         }
 
     });

--- a/web_notify/static/src/js/web_client.js
+++ b/web_notify/static/src/js/web_client.js
@@ -8,11 +8,17 @@ var core = require('web.core'),
 
 
 Widget.include({
-    do_notify: function(title, message, sticky, options) {
-        this.trigger_up('notification', {title: title, message: message, sticky: sticky, options: options});
+    do_interactive_notify: function(title, message, sticky, options) {
+        this.trigger_up(
+            'interactive_notification',
+            {title: title, message: message,
+             sticky: sticky, options: options});
     },
-    do_warn: function(title, message, sticky, options) {
-        this.trigger_up('warning', {title: title, message: message, sticky: sticky, options: options});
+    do_interactive_warn: function(title, message, sticky, options) {
+        this.trigger_up(
+            'interactive_warning',
+            {title: title, message: message,
+             sticky: sticky, options: options});
     },
 });
 
@@ -22,14 +28,20 @@ WebClient.include({
         {},
         WebClient.prototype.custom_events,
         {reload_active_view: 'reload_active_view',
-         notification: function (e) {
+         interactive_notification: function (e) {
              if(this.notification_manager) {
-                 this.notification_manager.notify(e.data.title, e.data.message, e.data.sticky, e.data.options);
+                 this.notification_manager.interactive_notify(
+                     e.data.title, e.data.message,
+                     e.data.sticky, e.data.options
+                 );
              }
          },
-         warning: function (e) {
+         interactive_warning: function (e) {
              if(this.notification_manager) {
-                 this.notification_manager.warn(e.data.title, e.data.message, e.data.sticky, e.data.options);
+                 this.notification_manager.interactive_warn(
+                     e.data.title, e.data.message,
+                     e.data.sticky, e.data.options
+                 );
              }
          }
         }
@@ -79,12 +91,16 @@ WebClient.include({
     },
     on_message_warning: function(message){
         if(this.notification_manager) {
-            this.notification_manager.do_warn(message.title, message.message, message.sticky, message);
+            this.notification_manager.do_interactive_warn(
+                message.title, message.message, message.sticky, message
+            );
         }
     },
     on_message_info: function(message){
         if(this.notification_manager) {
-            this.notification_manager.do_notify(message.title, message.message, message.sticky, message);
+            this.notification_manager.do_interactive_notify(
+                message.title, message.message, message.sticky, message
+            );
         }
     }
 });

--- a/web_notify/static/src/js/web_client.js
+++ b/web_notify/static/src/js/web_client.js
@@ -8,17 +8,15 @@ var core = require('web.core'),
 
 
 Widget.include({
-    do_interactive_notify: function(title, message, sticky, options) {
+    do_interactive_notify: function(title, message, options) {
         this.trigger_up(
             'interactive_notification',
-            {title: title, message: message,
-             sticky: sticky, options: options});
+            {title: title, message: message, options: options});
     },
-    do_interactive_warn: function(title, message, sticky, options) {
+    do_interactive_warn: function(title, message, options) {
         this.trigger_up(
             'interactive_warning',
-            {title: title, message: message,
-             sticky: sticky, options: options});
+            {title: title, message: message, options: options});
     },
 });
 
@@ -31,16 +29,14 @@ WebClient.include({
          interactive_notification: function (e) {
              if(this.notification_manager) {
                  this.notification_manager.interactive_notify(
-                     e.data.title, e.data.message,
-                     e.data.sticky, e.data.options
+                     e.data.title, e.data.message, e.data.options
                  );
              }
          },
          interactive_warning: function (e) {
              if(this.notification_manager) {
                  this.notification_manager.interactive_warn(
-                     e.data.title, e.data.message,
-                     e.data.sticky, e.data.options
+                     e.data.title, e.data.message, e.data.options
                  );
              }
          }
@@ -92,14 +88,14 @@ WebClient.include({
     on_message_warning: function(message){
         if(this.notification_manager) {
             this.notification_manager.do_interactive_warn(
-                message.title, message.message, message.sticky, message
+                message.title, message.message, message
             );
         }
     },
     on_message_info: function(message){
         if(this.notification_manager) {
             this.notification_manager.do_interactive_notify(
-                message.title, message.message, message.sticky, message
+                message.title, message.message, message
             );
         }
     }

--- a/web_notify/static/src/xml/notification.xml
+++ b/web_notify/static/src/xml/notification.xml
@@ -2,9 +2,17 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="Notification.reload">
-    <div class="o_notification_reload" t-if="widget.options.show_reload">
-        <a href="#" class="o_view_reload">
+    <div class="o_notification_action" t-if="widget.options.show_reload">
+        <a href="#" class="o_notification_reload_view">
             <span class="fa fa-refresh"/> Reload current view
+        </a>
+    </div>
+</t>
+
+<t t-name="Notification.do_action">
+    <div class="o_notification_action" t-if="widget.options.action">
+        <a href="#" class="o_notification_do_action">
+            <span class="fa fa-arrow-circle-left"/> Open
         </a>
     </div>
 </t>
@@ -12,12 +20,14 @@
 <t t-extend="Notification">
     <t t-jquery=".o_notification_content" t-operation="after">
         <t t-call="Notification.reload"/>
+        <t t-call="Notification.do_action"/>
     </t>
 </t>
 
 <t t-extend="Warning">
     <t t-jquery=".o_notification_content" t-operation="after">
         <t t-call="Notification.reload"/>
+        <t t-call="Notification.do_action"/>
     </t>
 </t>
 

--- a/web_notify/static/src/xml/notification.xml
+++ b/web_notify/static/src/xml/notification.xml
@@ -12,7 +12,11 @@
 <t t-name="Notification.do_action">
     <div class="o_notification_action" t-if="widget.options.action">
         <a href="#" class="o_notification_do_action">
-            <span class="fa fa-arrow-circle-left"/> Open
+            <span t-att-class="'fa ' + (widget.options.action_fa_icon ? widget.options.action_fa_icon : 'fa-arrow-circle-left')"/>
+            <t t-if="widget.options.action_link_name">
+                <t t-esc="widget.options.action_link_name"/>
+            </t>
+            <t t-else="">Open</t>
         </a>
     </div>
 </t>

--- a/web_notify/static/src/xml/notification.xml
+++ b/web_notify/static/src/xml/notification.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+<t t-name="Notification.reload">
+    <div class="o_notification_reload" t-if="widget.options.show_reload">
+        <a href="#" class="o_view_reload">
+            <span class="fa fa-refresh"/> Reload current view
+        </a>
+    </div>
+</t>
+
+<t t-extend="Notification">
+    <t t-jquery=".o_notification_content" t-operation="after">
+        <t t-call="Notification.reload"/>
+    </t>
+</t>
+
+<t t-extend="Warning">
+    <t t-jquery=".o_notification_content" t-operation="after">
+        <t t-call="Notification.reload"/>
+    </t>
+</t>
+
+</templates>

--- a/web_notify/static/src/xml/notification.xml
+++ b/web_notify/static/src/xml/notification.xml
@@ -17,14 +17,14 @@
     </div>
 </t>
 
-<t t-extend="Notification">
+<t t-name="InteractiveNotification" t-extend="Notification">
     <t t-jquery=".o_notification_content" t-operation="after">
         <t t-call="Notification.reload"/>
         <t t-call="Notification.do_action"/>
     </t>
 </t>
 
-<t t-extend="Warning">
+<t t-name="InteractiveWarning" t-extend="Warning">
     <t t-jquery=".o_notification_content" t-operation="after">
         <t t-call="Notification.reload"/>
         <t t-call="Notification.do_action"/>

--- a/web_notify/views/web_notify.xml
+++ b/web_notify/views/web_notify.xml
@@ -3,7 +3,9 @@
     <data>
         <template id="assets_backend" name="web_noify assets" inherit_id="web.assets_backend">
             <xpath expr="." position="inside">
+                <link rel="stylesheet" href="/web_notify/static/src/css/notification.less"/>
                 <script type="text/javascript" src="/web_notify/static/src/js/web_client.js"/>
+                <script type="text/javascript" src="/web_notify/static/src/js/notification.js"/>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
* You can have a simple link to refresh the active view
* Or an action (client, window, ...)

I'm annoyed that I had to inherit all the chain in javascript to add the
options argument, and started to wonder if we should not create new
Notification classes and new methods for these use cases. But in any case,
let's see your ideas and interest before going further.

* [x] adapt and add tests
* [x] new Notification classes?

![Screencast of the interactive notifications](https://user-images.githubusercontent.com/417223/41979744-18df6d5c-7a25-11e8-855d-566014251f21.gif)
