### PR TITLE
[11.0][IMP] web_timeline templates like kanban view

### DIFF
--- a/web_timeline/README.rst
+++ b/web_timeline/README.rst
@@ -19,8 +19,8 @@ the possible attributes for the tag:
 
 * date_start (required): it defines the name of the field of type date that
   contains the start of the event.
-* date_end (optional): it defines the name of the field of type date that
-  contains the end of the event. The date_end can be equal to the attribute
+* date_stop (optional): it defines the name of the field of type date that
+  contains the end of the event. The date_stop can be equal to the attribute
   date_start to display events has 'point' on the Timeline (instantaneous event)
 * date_delay (optional): it defines the name of the field of type float/integer
   that contain the duration in hours of the event, default = 1
@@ -59,6 +59,14 @@ Example:
                           event_open_popup="true"
                           zoomKey="ctrlKey"
                           colors="#ec7063:user_id == false;#2ecb71:kanban_state=='done';">
+                    <field name="user_id"/>
+                    <templates>
+                        <div t-name="timeline-item">
+                            <div t-esc="record.display_name"/>
+                            Assigned to:
+                            <span t-esc="record.user_id[1]"/>
+                        </div>
+                    </templates>
                 </timeline>
             </field>
         </record>
@@ -135,6 +143,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
 * Leonardo Donelli <donelli@webmonks.it>
 * Adrien Didenot <adrien.didenot@horanet.com>
+* Dennis Sluijk <d.sluijk@onestein.nl>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/web_timeline/__manifest__.py
+++ b/web_timeline/__manifest__.py
@@ -4,10 +4,11 @@
 {
     'name': "Web timeline",
     'summary': "Interactive visualization chart to show events in time",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.1.1",
     'author': 'ACSONE SA/NV, '
               'Tecnativa, '
               'Monk Software, '
+              'Onestein, '
               'Odoo Community Association (OCA)',
     "category": "web",
     "license": "AGPL-3",

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -68,6 +68,17 @@ odoo.define('web_timeline.TimelineView', function (require) {
                     fieldNames.push(fieldName);
                 }
             });
+
+            var archFieldNames = _.map(_.filter(this.arch.children, function(item) {
+                return item.tag === 'field';
+            }), function(item) {
+                return item.attrs.name;
+            });
+            fieldNames = _.union(
+                fieldNames,
+                archFieldNames
+            );
+
             this.parse_colors();
             for (var i=0; i<this.colors.length; i++) {
                 fieldNames.push(this.colors[i].field);


### PR DESCRIPTION
This PR extends the web_timeline module with custom templates. 
You can define a custom template like you do in a kanban view:

```
                <timeline date_start="date_start"
                          date_stop="date_end"
                          string="Tasks"
                          default_group_by="user_id"
                          event_open_popup="true"
                          zoomKey="ctrlKey"
                          colors="#ec7063:user_id == false;#2ecb71:kanban_state=='done';">
                    <field name="user_id"/>
                    <templates>
                        <div t-name="timeline-item">
                            <div t-esc="record.display_name"/>
                            Assigned to:
                            <span t-esc="record.user_id[1]"/>
                        </div>
                    </templates>
                </timeline>
```
A custom template is optional.

Example:
![image](https://user-images.githubusercontent.com/10028499/43257972-87085d1c-90d1-11e8-8402-49f6c6238d04.png)
