### PR TITLE
[web_shortcut] don't destroy debug mode; allow opening shortcut in new tab

### DIFF
--- a/web_shortcut/static/src/js/web_shortcut.js
+++ b/web_shortcut/static/src/js/web_shortcut.js
@@ -88,6 +88,7 @@ odoo.define('web.shortcut', function (require) {
                     return item instanceof ShortcutMenu;
                 });
             }
+            return this._super.apply(this, arguments);
         },
         show_application: function () {
             var self = this;

--- a/web_shortcut/static/src/js/web_shortcut.js
+++ b/web_shortcut/static/src/js/web_shortcut.js
@@ -26,7 +26,9 @@ odoo.define('web.shortcut', function (require) {
             var self = this;
             this._super();
             this.trigger('load');
-            this.$el.on('click', '.oe_systray_shortcut_menu a', function () {
+            this.$el.on('click', '.oe_systray_shortcut_menu a', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
                 self.click($(this));
             });
         },

--- a/web_shortcut/static/src/xml/web_shortcut.xml
+++ b/web_shortcut/static/src/xml/web_shortcut.xml
@@ -10,7 +10,7 @@
     </t>
     <t t-name="Systray.ShortcutMenu.Item">
         <li>
-            <a href="#" t-att-data-id="shortcut.menu_id[0]" t-att-data-shortcut-id="shortcut.id">
+            <a t-attf-href="/web#menu_id={{shortcut.menu_id[0]}}" t-att-data-id="shortcut.menu_id[0]" t-att-data-shortcut-id="shortcut.id">
                 <t t-esc="shortcut.name"/>
             </a>
         </li>


### PR DESCRIPTION
without this, we don't see the interesting debug mode features like editing the current view or action