### PR TITLE
[11.0] [ADD] web_timeline: Dependency arrows 

### DIFF
--- a/web_timeline/README.rst
+++ b/web_timeline/README.rst
@@ -39,9 +39,11 @@ the possible attributes for the tag:
   view.
 * colors (optional): it allows to set certain specific colors if the expressed
   condition (JS syntax) is met.
-  
-Optionally you can declare a custom template, which will be used to render the 
-timeline items. You have to name the template 'timeline-item'. 
+* dependency_arrow (optional): set this attribute to a x2many field to draw
+  arrows between the records referenced in the x2many field.
+
+Optionally you can declare a custom template, which will be used to render the
+timeline items. You have to name the template 'timeline-item'.
 These are the variables available in template rendering:
 
 * ``record``: to access the fields values selected in the timeline definition.
@@ -65,7 +67,8 @@ Example:
                           default_group_by="user_id"
                           event_open_popup="true"
                           zoomKey="ctrlKey"
-                          colors="#ec7063:user_id == false;#2ecb71:kanban_state=='done';">
+                          colors="#ec7063:user_id == false;#2ecb71:kanban_state=='done';"
+                          dependency_arrow="task_dependency_ids">
                     <field name="user_id"/>
                     <templates>
                         <div t-name="timeline-item">

--- a/web_timeline/__manifest__.py
+++ b/web_timeline/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': "Web timeline",
     'summary': "Interactive visualization chart to show events in time",
-    "version": "11.0.1.2.1",
+    "version": "11.0.1.3.0",
     'author': 'ACSONE SA/NV, '
               'Tecnativa, '
               'Monk Software, '

--- a/web_timeline/models/__init__.py
+++ b/web_timeline/models/__init__.py
@@ -1,4 +1,4 @@
-# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2016 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import ir_view

--- a/web_timeline/static/src/css/web_timeline.css
+++ b/web_timeline/static/src/css/web_timeline.css
@@ -20,3 +20,12 @@
 .oe_timeline_view .vlabel .inner:hover{
     cursor: pointer;
 }
+
+.oe_timeline_view svg.oe_timeline_view_canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0px;
+    top: 0px;
+}

--- a/web_timeline/static/src/js/timeline_canvas.js
+++ b/web_timeline/static/src/js/timeline_canvas.js
@@ -1,0 +1,89 @@
+/* Copyright 2018 Onestein
+ * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+
+odoo.define('web_timeline.TimelineCanvas', function (require) {
+    "use strict";
+    var Widget = require('web.Widget');
+
+    var TimelineCanvas = Widget.extend({
+        template: 'TimelineView.Canvas',
+
+        clear: function() {
+            this.$el.find(' > :not(defs)').remove();
+        },
+
+        get_polyline_points: function(coordx1, coordy1, coordx2, coordy2, width1, height1, width2, height2, widthMarker, breakAt) {
+            var halfHeight1 = height1 / 2;
+            var halfHeight2 = height2 / 2;
+            var x1 = coordx1 - widthMarker;
+            var y1 = coordy1 + halfHeight1;
+            var x2 = coordx2 + width2;
+            var y2 = coordy2 + halfHeight2;
+            var xDiff = x1 - x2;
+            var yDiff = y1 - y2;
+            var threshold = breakAt + widthMarker;
+            var spaceY = halfHeight2 + 6;
+
+            var points = [[x1, y1]];
+            if (y1 !== y2) {
+                if (xDiff > threshold) {
+                    points.push([x1 - breakAt, y1]);
+                    points.push([x1 - breakAt, y1 - yDiff]);
+                } else if (xDiff <= threshold) {
+                    var yDiffSpace = yDiff > 0 ? spaceY : -spaceY;
+                    points.push([x1 - breakAt, y1]);
+                    points.push([x1 - breakAt, y2 + yDiffSpace]);
+                    points.push([x2 + breakAt, y2 + yDiffSpace]);
+                    points.push([x2 + breakAt, y2]);
+                }
+            } else if(x1 < x2) {
+                  points.push([x1 - breakAt, y1]);
+                  points.push([x1 - breakAt, y1 + spaceY]);
+                  points.push([x2 + breakAt, y2 + spaceY]);
+                  points.push([x2 + breakAt, y2]);
+            }
+            points.push([x2, y2]);
+
+            return points;
+        },
+
+        draw_arrow: function(from, to, color, width) {
+            return this.draw_line(from, to, color, width, '#arrowhead', 10, 12);
+        },
+
+        draw_line: function(from, to, color, width, markerStart, widthMarker, breakLineAt) {
+            var x1 = from.offsetLeft,
+                y1 = from.offsetTop + from.parentElement.offsetTop,
+                x2 = to.offsetLeft,
+                y2 = to.offsetTop + to.parentElement.offsetTop,
+                width1 = from.clientWidth,
+                height1 = from.clientHeight,
+                width2 = to.clientWidth,
+                height2 = to.clientHeight;
+
+            var points = this.get_polyline_points(
+                x1, y1, x2, y2, width1, height1, width2, height2, widthMarker, breakLineAt
+            );
+
+            var polyline_points = _.map(points, function(point) {
+                return point.join(',');
+            }).join();
+
+            var line = document.createElementNS(
+                'http://www.w3.org/2000/svg', 'polyline'
+            );
+            line.setAttribute('points', polyline_points);
+            line.setAttribute('stroke', color || '#000');
+            line.setAttribute('stroke-width', width || 1);
+            line.setAttribute('fill', 'none');
+            if (markerStart) {
+                line.setAttribute('marker-start', 'url(' + markerStart + ')');
+            }
+            this.$el.append(line);
+            return line;
+        }
+
+    });
+
+    return TimelineCanvas;
+});

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -84,11 +84,16 @@ odoo.define('web_timeline.TimelineView', function (require) {
                 fieldNames.push(this.colors[i].field);
             }
 
+            if (attrs.dependency_arrow) {
+                fieldNames.push(attrs.dependency_arrow);
+            }
+
             this.permissions = {};
             this.grouped_by = false;
             this.date_start = attrs.date_start;
             this.date_stop = attrs.date_stop;
             this.date_delay = attrs.date_delay;
+            this.dependency_arrow = attrs.dependency_arrow;
 
             this.no_period = this.date_start === this.date_stop;
             this.zoomKey = attrs.zoomKey || '';
@@ -125,6 +130,7 @@ odoo.define('web_timeline.TimelineView', function (require) {
             this.rendererParams.colors = this.colors;
             this.rendererParams.fieldNames = fieldNames;
             this.rendererParams.view = this;
+            this.rendererParams.dependency_arrow = this.dependency_arrow;
             this.loadParams.modelName = this.modelName;
             this.loadParams.fieldNames = fieldNames;
             this.controllerParams.open_popup_action = this.open_popup_action;

--- a/web_timeline/static/src/xml/web_timeline.xml
+++ b/web_timeline/static/src/xml/web_timeline.xml
@@ -14,4 +14,13 @@
       <div class="oe_timeline_widget" />
     </div>
   </t>
+
+  <svg t-name="TimelineView.Canvas"
+       class="oe_timeline_view_canvas">
+      <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+              <polygon points="10 0, 10 7, 0 3.5" />
+          </marker>
+      </defs>
+  </svg>
 </template>

--- a/web_timeline/views/web_timeline.xml
+++ b/web_timeline/views/web_timeline.xml
@@ -11,6 +11,7 @@
             <script type="text/javascript" src="/web_timeline/static/src/js/timeline_renderer.js"/>
             <script type="text/javascript" src="/web_timeline/static/src/js/timeline_controller.js"/>
             <script type="text/javascript" src="/web_timeline/static/src/js/timeline_model.js"/>
+            <script type="text/javascript" src="/web_timeline/static/src/js/timeline_canvas.js"/>
         </xpath>
     </template>
 


### PR DESCRIPTION
Adds a new optional attribute dependency_arrow.

If the attribute is set it will look like:
![image](https://user-images.githubusercontent.com/10028499/44399992-e05a2580-a549-11e8-9799-bf0ffa7aa501.png)


I created a widget TimelineCanvas which does all the svg stuff. This way the renderer will not be bloated with it.
