### PR TITLE
[10.0] web_sheet_full_width: wider field labels on form view

### DIFF
--- a/web_sheet_full_width/static/src/css/web_sheet_full_width.less
+++ b/web_sheet_full_width/static/src/css/web_sheet_full_width.less
@@ -7,4 +7,13 @@
     .oe_chatter{
         max-width: none;
     }
+    .o_group{
+        &.o_inner_group{
+            > tbody > tr > td{
+                &.o_td_label{
+                    min-width: 200px;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
By default on v10, in particular when you have web_sheet_full_width installed, on a form view, the field labels are pretty narrow, so they often take 2 lines, which make it less readable for the user.

I am NOT a web expert, I don't know if web_sheet_full_width is the right place to fix that... so feel free to comment and improve this PR.

BEFORE:

![col_width-before](https://user-images.githubusercontent.com/1157917/44715941-56660b80-aab9-11e8-8b04-c5582330cbd0.png)

AFTER:

![col_width-after](https://user-images.githubusercontent.com/1157917/44715951-5d8d1980-aab9-11e8-8c43-0e1c2b5bc0e7.png)
