### PR TITLE
[10.0][IMP] Escape field values for timeline color conditions

### DIFF
--- a/web_timeline/static/src/js/web_timeline.js
+++ b/web_timeline/static/src/js/web_timeline.js
@@ -245,7 +245,8 @@ odoo.define('web_timeline.TimelineView', function (require) {
                 group = -1;
             }
             _.each(self.colors, function (color) {
-                if (eval("'" + evt[color.field] + "' " + color.opt + " '" + color.value + "'"))
+                var escaped_field = evt[color.field].toString().replace("'", "\\'");
+                if (eval("'" + escaped_field + "' " + color.opt + " '" + color.value + "'"))
                     self.color = color.color;
             });
             var r = {


### PR DESCRIPTION
I had an issue where we have records that have quotes in their field values. We want to use that field in our timeline conditions to set colors, but that makes the javascript crash.

With that fix, I propose to escape the quotes that could be present in field values.

The toString() method is to convert many2one relation fields which are stored in arrays.

Should I do the same PR for v11.0 ?