### PR TITLE
[IMP] Change display of m2o link

### DIFF
--- a/web_tree_many2one_clickable/README.rst
+++ b/web_tree_many2one_clickable/README.rst
@@ -63,6 +63,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Antonio Espinosa <antonio.espinosa@tecnativa.com>
 * Sodexis <dev@sodexis.com>
+* Alexandre Pollet <alexandre.pollet@akretion.com>
 
 Maintainer
 ----------

--- a/web_tree_many2one_clickable/__manifest__.py
+++ b/web_tree_many2one_clickable/__manifest__.py
@@ -8,7 +8,7 @@
 {
     "name": "Clickable many2one fields for tree views",
     "summary": "Open the linked resource when clicking on their name",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Hidden",
     "website": "https://odoo-community.org/",
     "author": "Therp BV, "

--- a/web_tree_many2one_clickable/static/src/css/m2o_clickable.css
+++ b/web_tree_many2one_clickable/static/src/css/m2o_clickable.css
@@ -1,0 +1,6 @@
+.m2o_clickable a{
+visibility:hidden;
+}
+.m2o_clickable:hover a {
+ visibility:visible;
+}

--- a/web_tree_many2one_clickable/static/src/css/m2o_clickable.css
+++ b/web_tree_many2one_clickable/static/src/css/m2o_clickable.css
@@ -1,6 +1,7 @@
 .m2o_clickable a{
 visibility:hidden;
 }
+
 .m2o_clickable:hover a {
  visibility:visible;
 }

--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -50,7 +50,7 @@ ListView.Column.include({
             var value = row_data[this.id].value;
             var name = value[1] ? value[1].split("\n")[0] : value[1];
             name = _.escape(name || options.value_if_empty);
-            if (this.widget == 'many2one_unclickable') {
+            if (this.widget == 'many2one_unclickable' || !value) {
                 return name;
             } else if (this.use_many2one_clickable) {
                 var values = {
@@ -65,7 +65,7 @@ ListView.Column.include({
                                            options.value_if_empty);
                 }
                 return _.str.sprintf(
-                    '<a class="oe_form_uri" data-many2one-clickable-model="%(model)s" data-many2one-clickable-id="%(id)s">%(name)s</a>',
+                    '<span class="m2o_clickable">%(name)s <a class="oe_form_uri" data-many2one-clickable-model="%(model)s" data-many2one-clickable-id="%(id)s"><i class="fa fa-external-link"></i></a></span>',
                     values
                 );
             }

--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -65,7 +65,7 @@ ListView.Column.include({
                                            options.value_if_empty);
                 }
                 return _.str.sprintf(
-                    '<span class="m2o_clickable">%(name)s <a class="oe_form_uri" data-many2one-clickable-model="%(model)s" data-many2one-clickable-id="%(id)s"><i class="fa fa-external-link"></i></a></span>',
+                    '<span class="m2o_clickable">%(name)s <a class="oe_form_uri" data-many2one-clickable-model="%(model)s" data-many2one-clickable-id="%(id)s"><i class="fa fa-edit"></i></a></span>',
                     values
                 );
             }

--- a/web_tree_many2one_clickable/views/asset.xml
+++ b/web_tree_many2one_clickable/views/asset.xml
@@ -7,6 +7,7 @@
     <xpath expr="." position="inside">
         <script type="text/javascript"
                 src="/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js"/>
+        <link rel="stylesheet" href="/web_tree_many2one_clickable/static/src/css/m2o_clickable.css"/>
     </xpath>
 </template>
 


### PR DESCRIPTION
Change display of m2o link in order to not have a full clickable link but just an icon next to it.
The icon shows up only when cursor is on the value.

It prevents from opening the many2one form by accident.
![m2o_clickable](https://user-images.githubusercontent.com/5516865/45754525-2b845880-bc1c-11e8-8aab-c2b82956bcc3.png)

