### PR TITLE
[11.0][FIX][web_dialog_size] default_maximize check

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.js
@@ -16,8 +16,8 @@ Dialog.include({
         return this._super.apply(this, arguments).then(function () {
             self.$modal.find('.dialog_button_extend').on('click', self.proxy('_extending'));
             self.$modal.find('.dialog_button_restore').on('click', self.proxy('_restore'));
-            return config.done(function(default_maximize) {
-                if (default_maximize) {
+            return config.done(function(r) {
+                if (r.default_maximize) {
                     self._extending();
                 } else {
                     self._restore();


### PR DESCRIPTION
Checking result of rpc call, `dialog_maximize`, will end to be always `true` as the method will return a json: `{'dialog_maximize': false }`. So i changed the test to test the value of json key `dialog_maximize`