### PR TITLE
[FIX] web_decimal_numpad: float_time format

### DIFF
--- a/web_decimal_numpad_dot/__manifest__.py
+++ b/web_decimal_numpad_dot/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Web - Numpad Dot as decimal separator",
-    "version": "11.0.1.0.2",
+    "version": "11.0.1.0.3",
     "license": "AGPL-3",
     "summary": "Allows using numpad dot to enter period decimal separator",
     "depends": [

--- a/web_decimal_numpad_dot/static/src/js/numpad_dot.js
+++ b/web_decimal_numpad_dot/static/src/js/numpad_dot.js
@@ -19,11 +19,12 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
                 ? ":" : translation._t.database.parameters.decimal_point;
         },
 
+        _replaceAt: function (cur_val, index, replacement) {
+            return cur_val.substr(0, index) + replacement +
+                   cur_val.substr(index + replacement.length);
+        },
+
         numpad_dot_replace: function (event) {
-            String.prototype.replaceAt = function (index, replacement) {
-                return this.substr(0, index) + replacement +
-                       this.substr(index + replacement.length);
-            };
             // Only act on numpad dot key
             event.stopPropagation();
             if (event.keyCode !== 110) {
@@ -34,7 +35,7 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
                 to = this.$input.prop("selectionEnd"),
                 cur_val = this.$input.val(),
                 point = this.l10n_decimal_point();
-            var new_val = cur_val.replaceAt(from-1, point);
+            var new_val = this._replaceAt(cur_val, from-1, point);
             this.$input.val(new_val);
             // Put user caret in place
             to = from + point.length;

--- a/web_decimal_numpad_dot/static/src/js/numpad_dot.js
+++ b/web_decimal_numpad_dot/static/src/js/numpad_dot.js
@@ -15,17 +15,18 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
         },
 
         l10n_decimal_point: function () {
-            return this.widget == "float_time"
+            return this.formatType === "float_time"
                 ? ":" : translation._t.database.parameters.decimal_point;
         },
 
         numpad_dot_replace: function (event) {
-            String.prototype.replaceAt=function(index, replacement) {
-                return this.substr(0, index) + replacement + this.substr(index + replacement.length);
-            }
+            String.prototype.replaceAt = function (index, replacement) {
+                return this.substr(0, index) + replacement +
+                       this.substr(index + replacement.length);
+            };
             // Only act on numpad dot key
-            event.stopPropagation()
-            if (event.keyCode != 110) {
+            event.stopPropagation();
+            if (event.keyCode !== 110) {
                 return;
             }
             event.preventDefault();
@@ -33,10 +34,10 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
                 to = this.$input.prop("selectionEnd"),
                 cur_val = this.$input.val(),
                 point = this.l10n_decimal_point();
-            var new_val = cur_val.replaceAt(from-1, point)
+            var new_val = cur_val.replaceAt(from-1, point);
             this.$input.val(new_val);
             // Put user caret in place
-            to = from + point.length
+            to = from + point.length;
             this.$input.prop("selectionStart", to).prop("selectionEnd", to);
         },
     };


### PR DESCRIPTION
- In previous versions, numpad dot was replaced by ":" in float time fields.
- Some lint fixes

cc @Tecnativa