### PR TITLE
[11.0] web_responsive : Support sticky table headers on chrome

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -8,7 +8,7 @@
                "web",
     "version": "11.0.2.0.1",
     "category": "Website",
-    "website": "https://laslabs.com/",
+    "website": "https://github.com/OCA/web",
     "author": "LasLabs, Tecnativa, Alexandre Díaz, "
               "Odoo Community Association (OCA)",
     "license": "LGPL-3",

--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Web Responsive",
     "summary": "It provides a mobile compliant interface for Odoo Community "
                "web",
-    "version": "11.0.2.0.0",
+    "version": "11.0.2.0.1",
     "category": "Website",
     "website": "https://laslabs.com/",
     "author": "LasLabs, Tecnativa, Alexandre Díaz, "

--- a/web_responsive/static/src/less/form_view.less
+++ b/web_responsive/static/src/less/form_view.less
@@ -57,13 +57,16 @@
     >div {
         >.table-responsive {
             >.o_list_view {
-                thead {
+                thead tr:nth-child(1) th {
                     position: sticky;
                     top: 0;
+                    background-color: #EEEEEE;
+                    border: none;
                 }
-                tfoot {
+                tfoot tr:nth-child(1) td {
                     position: sticky;
                     bottom: 0;
+                    background-color: #EEEEEE;
                 }
             }
         }


### PR DESCRIPTION
FF 62.0.3 (64-bit) on ubuntu 16.04 before :
![ff_before](https://user-images.githubusercontent.com/778828/47080186-9c149a00-d207-11e8-8ada-2b25dbd05df3.gif)

FF 62.0.3 (64-bit) on ubuntu 16.04 after :
![ff_after](https://user-images.githubusercontent.com/778828/47080195-a59e0200-d207-11e8-9912-507dfc828267.gif)

Chrome 70.0.3538.67 (64-bit) on ubuntu 16.04 before :
![chrome_before](https://user-images.githubusercontent.com/778828/47080228-bd758600-d207-11e8-8f44-61f1ea00c7ed.gif)

Chrome 70.0.3538.67 (64-bit) on ubuntu 16.04 after :
![chrome_after](https://user-images.githubusercontent.com/778828/47080242-c5cdc100-d207-11e8-8b6e-94688561dc67.gif)

