### PR TITLE
[10.0] [IMP] web_tree_many2one_clickable. Default false.

### DIFF
--- a/web_tree_many2one_clickable/data/ir_config_parameter.xml
+++ b/web_tree_many2one_clickable/data/ir_config_parameter.xml
@@ -6,7 +6,7 @@
 
 <record id="default" model="ir.config_parameter">
     <field name="key">web_tree_many2one_clickable.default</field>
-    <field name="value">true</field>
+    <field name="value">false</field>
 </record>
 
 </odoo>


### PR DESCRIPTION
Having this module not set all Many2one fields clickable by default, greatly increases the
possibility to reuse the functionality in other OCA modules.

For instance I would like to make partner_multi_relation more user friendly, with the possibility to click on the partner fields in a relation list view to go directly to the partner. The widget is ideal for this, but I can not/should not force all users of partner_multi_relation to have all of their Many2one fields clickable.

I think the same would go for other OCA modules that would like to use these widgets.