### PR TITLE
fixup! [IMP] web_widget_x2many_2d_matrix: New option field_att_<name>

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/web_widget_x2many_2d_matrix.js
@@ -45,7 +45,7 @@ openerp.web_widget_x2many_2d_matrix = function(instance)
             this.field_label_y_axis = node.attrs.field_label_y_axis || this.field_y_axis;
             this.field_value = node.attrs.field_value || this.field_value;
             for (var property in node.attrs) {
-                if (property.startsWith("field_att_")) {
+                if (property.indexOf("field_att_") === 0) {
                     this.fields_att[property.substring(10)] = node.attrs[property];
                 }
             }


### PR DESCRIPTION
phantomjs doesn't support `startsWith`, so without this, we can't use the widget in phantomjs tests