### PR TITLE
[FIX] show hidden loading indicator with web responsive theme

### DIFF
--- a/web_responsive/static/src/less/main.less
+++ b/web_responsive/static/src/less/main.less
@@ -106,6 +106,6 @@ main {
     }
 }
 
-.o_chat_window {
+.o_chat_window, .o_loading {
     z-index: 1000;
 }


### PR DESCRIPTION
The " Loading " indicator is hidden by the new navbar. 