### PR TITLE
[8.0][IMP][web_m2x_options] Do not limit the items quantity in the M2O search pop up

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -127,6 +127,11 @@ Known issues
 Double check that you have no inherited view that remove ``options`` you set on a field ! 
 If nothing works, add a debugger in the first line of ``get_search_result method`` and enable debug mode in Odoo. When you write something in a many2one field, javascript debugger should pause. If not verify your installation.
 
+This module fixes an Odoo bug in the pop up of search that limit the items quantity
+to 160 https://github.com/odoo/odoo/commit/8c3cdce539d87775b59b3f2d5ceb433f995821bf
+For that purpose, it makes previously a light ``search`` call, to get all the ids.
+This process could make the display of the pop up slow, in case of huge databases.
+
 Roadmap
 =======
 

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -167,14 +167,20 @@ openerp.web_m2x_options = function (instance) {
                     values.push({
                         label: _t("Search More..."),
                         action: function () {
-                            // limit = 80 for improving performance, similar
-                            // to Odoo implementation here:
+                            // Odoo JS framework is quite bad designed
+                            // _search_create_popup requires to receices the ids
+                            // even if it will do again a search when displayed
+                            // By default, Odoo display hard code a domain of 160 ids
+                            // preventing to make a search if your datalist has more that 160 items
                             // https://github.com/odoo/odoo/commit/8c3cdce539d87775b59b3f2d5ceb433f995821bf
-                            dataset.name_search(
-                                search_val, self.build_domain(),
-                                'ilike', 80).done(function (data) {
-                                    self._search_create_popup("search", data);
+                            new instance.web.Model(dataset.model).call(
+                                    'search', [self.build_domain()]).then(function (ids) {
+                                var ids_list = [];
+                                _.each(ids, function(id) {
+                                    ids_list.push([id]);
                                 });
+                                self._search_create_popup("search", ids_list);
+                            });
                         },
                         classname: 'oe_m2o_dropdown_option'
                     });


### PR DESCRIPTION
Fix #1123. 

- The current module web_m2x_options hardcodes 80 items limit.

- The Odoo web modules hardcodes 160 items limit.
https://github.com/odoo/odoo/commit/8c3cdce539d87775b59b3f2d5ceb433f995821bf

This patch remove this limits and make the search faster. (no call to useless name_search anymore)

Note that maybe it can be slow in very huge database. (tested on DB with 50k products without problems)
