### PR TITLE
[10.0] web_advanced_search_wildcard: adds 'starts with' and 'ends with'

### DIFF
--- a/web_advanced_search_wildcard/README.rst
+++ b/web_advanced_search_wildcard/README.rst
@@ -6,11 +6,16 @@
 Wildcard in advanced search
 ============================
 
-Allows =ilike ('matches') operator to advanced search option.
+This module adds 3 options to advanced search of char, many2one,
+many2many and one2many fields:
+
+* *starts with* (uses the domain *=ilike %<search string>*),
+* *ends with* (uses the domain *=ilike <search string>%*),
+* *matches* (uses the domain *=ilike <search string>*).
 
 Usage
 =====
-Use % as a placeholder.
+When selecting *matches*, use **%** as a placeholder.
 
 Example: "Zip" - 'matches' - "1%" gives all zip starting with 1
 
@@ -19,6 +24,10 @@ Example: "Zip" - 'matches' - "1%" gives all zip starting with 1
 
 Also allows insensitive exact search.
 Example "Name" - 'matches' - "john" will find "John" and "john" but not "Johnson".
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/162/10.0
 
 Bug Tracker
 ===========
@@ -43,6 +52,7 @@ Contributors
 * Thomas Rehn <thomas.rehn@initos.com>
 * L Freeke <lfreeke@therp.nl>
 * Alex Comba <alex.comba@agilebg.com>
+* Alexis de Lattre <alexis.delattre@akretion.com>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/web_advanced_search_wildcard/i18n/fr.po
+++ b/web_advanced_search_wildcard/i18n/fr.po
@@ -1,26 +1,38 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * web_advanced_search_wildcard
+#	* web_advanced_search_wildcard
 #
-# Translators:
-# OCA Transbot <transbot@odoo-community.org>, 2018
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-01-03 03:49+0000\n"
-"PO-Revision-Date: 2018-01-03 03:49+0000\n"
-"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2018\n"
-"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
-"Language: fr\n"
+"POT-Creation-Date: 2018-12-25 23:17+0000\n"
+"PO-Revision-Date: 2018-12-25 23:17+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: \n"
+
+#. module: web_advanced_search_wildcard
+#. openerp-web
+#: code:addons/web_advanced_search_wildcard/static/src/js/search.js:11
+#, python-format
+msgid "ends with"
+msgstr "finit par"
+
+#. module: web_advanced_search_wildcard
+#. openerp-web
+#: code:addons/web_advanced_search_wildcard/static/src/js/search.js:12
+#, python-format
+msgid "matches"
+msgstr "correspond à"
 
 #. module: web_advanced_search_wildcard
 #. openerp-web
 #: code:addons/web_advanced_search_wildcard/static/src/js/search.js:10
 #, python-format
-msgid "matches"
-msgstr "correspondances"
+msgid "starts with"
+msgstr "commence par"
+

--- a/web_advanced_search_wildcard/static/src/js/search.js
+++ b/web_advanced_search_wildcard/static/src/js/search.js
@@ -7,6 +7,20 @@ odoo.define('web_advanced_search_wildcard', function (require) {
     var _lt = core._lt;
 
     search_filters.ExtendedSearchProposition.Char.prototype.operators.push(
-        {value: '=ilike', text: _lt("matches")}
+        {value: "startswith", text: _lt("starts with")},
+        {value: "endswith", text: _lt("ends with")},
+        {value: '=ilike', text: _lt("matches")},
     );
+
+    search_filters.ExtendedSearchProposition.Char.include({
+        get_domain: function (field, operator) {
+            switch (operator.value) {
+            case '∃': return [[field.name, '!=', false]];
+            case '∄': return [[field.name, '=', false]];
+            case 'startswith': return [[field.name, '=ilike', this.get_value() + '%']];
+            case 'endswith': return [[field.name, '=ilike', '%' + this.get_value()]];
+            default: return [[field.name, operator.value, this.get_value()]];
+            }
+        },
+    });
 });

--- a/web_advanced_search_wildcard/static/src/js/search.js
+++ b/web_advanced_search_wildcard/static/src/js/search.js
@@ -9,7 +9,7 @@ odoo.define('web_advanced_search_wildcard', function (require) {
     search_filters.ExtendedSearchProposition.Char.prototype.operators.push(
         {value: "startswith", text: _lt("starts with")},
         {value: "endswith", text: _lt("ends with")},
-        {value: '=ilike', text: _lt("matches")},
+        {value: '=ilike', text: _lt("matches")}
     );
 
     search_filters.ExtendedSearchProposition.Char.include({


### PR DESCRIPTION
We keep the historic feature *matches* provided by web_advanced_search_wildcard, but we add *starts with* and *ends with* with are super-easy and intuitive to use and cover the majority of use cases.