### PR TITLE
[FIX] web_advanced_search: Ignore field domain

### DIFF
--- a/web_advanced_search/static/src/js/web_advanced_search.js
+++ b/web_advanced_search/static/src/js/web_advanced_search.js
@@ -179,7 +179,14 @@ odoo.define("web_advanced_search", function (require) {
                 },
             };
             // See https://stackoverflow.com/a/11508530/1468388
-            params.fields[this.field.name] = _.omit(this.field, "onChange");
+            // to know how to include this in the previous step in ES6
+            params.fields[this.field.name] = _.omit(
+                this.field,
+                // User needs all records, to actually produce a new domain
+                "domain",
+                // Onchanges make no sense in this context, there's no record
+                "onChange"
+            );
             if (this.field.type.endsWith("2many")) {
                 // X2many fields behave like m2o in the search context
                 params.fields[this.field.name].type = "many2one";


### PR DESCRIPTION
If we honor the domain value, the user may not be getting all available
records when selecting from an x2many dropdown, or even worse, if the
domain references another field in the view, the user may be getting
an error when opening the field dropdown, like this:

    Error: NameError: name 'company_id' is not defined

    http://localhost/web/static/lib/py.js/lib/py.js:370
    Rastreo de error:
    PY_ensurepy@http://localhost/web/static/lib/py.js/lib/py.js:370:19
    py.evaluate@http://localhost/web/static/lib/py.js/lib/py.js:1340:20
    py.evaluate@http://localhost/web/static/lib/py.js/lib/py.js:1397:35
    py.evaluate@http://localhost/web/static/lib/py.js/lib/py.js:1409:34
    py.eval@http://localhost/web/static/lib/py.js/lib/py.js:1453:16
    eval_domains/<@http://localhost/web/static/src/js/core/pyeval.js:886:39
    _.forEach@http://localhost/web/static/lib/underscore/underscore.js:145:9
    _.mixin/</_.prototype[name]@http://localhost/web/static/lib/underscore/underscore.js:1484:29
    eval_domains@http://localhost/web/static/src/js/core/pyeval.js:877:16
    pyeval@http://localhost/web/static/src/js/core/pyeval.js:988:16
    stringToArray@http://localhost/web/static/src/js/core/domain.js:243:16
    _getDomain@http://localhost/web/static/src/js/views/basic/basic_model.js:3004:24
    _search@http://localhost/web_m2x_options/static/src/js/form.js:139:26
    source@http://localhost/web/static/src/js/fields/relational_fields.js:198:17
    _search@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:6823:3
    $.widget/</proxiedPrototype[prop]</<@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:415:19
    search@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:6815:10
    $.widget/</proxiedPrototype[prop]</<@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:415:19
    $.widget.bridge/$.fn[name]/<@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:508:19
    each@http://localhost/web/static/lib/jquery/jquery.js:383:49
    each@http://localhost/web/static/lib/jquery/jquery.js:136:24
    $.widget.bridge/$.fn[name]@http://localhost/web/static/lib/jquery.ui/jquery-ui.js:494:4
    _onInputClick@http://localhost/web/static/src/js/fields/relational_fields.js:565:13
    proxy/<@http://localhost/web/static/src/js/core/mixins.js:279:20
    dispatch@http://localhost/web/static/lib/jquery/jquery.js:4640:50
    add/elemData.handle@http://localhost/web/static/lib/jquery/jquery.js:4309:41

@Tecnativa