### PR TITLE
[FIX] web_decimal_numpad_dot: Fix inconsistent behavior

### DIFF
--- a/web_decimal_numpad_dot/static/src/js/numpad_dot.js
+++ b/web_decimal_numpad_dot/static/src/js/numpad_dot.js
@@ -9,7 +9,7 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
     var NumpadDotReplaceMixin = {
         init: function () {
             this.events = $.extend({}, this.events, {
-                "keyup": "numpad_dot_replace",
+                "keydown": "numpad_dot_replace",
             });
             return this._super.apply(this, arguments);
         },
@@ -19,14 +19,13 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
                 ? ":" : translation._t.database.parameters.decimal_point;
         },
 
-        _replaceAt: function (cur_val, index, replacement) {
-            return cur_val.substr(0, index) + replacement +
-                   cur_val.substr(index + replacement.length);
+        _replaceAt: function (cur_val, from, to, replacement) {
+            return cur_val.substring(0, from) + replacement +
+                   cur_val.substring(to);
         },
 
         numpad_dot_replace: function (event) {
             // Only act on numpad dot key
-            event.stopPropagation();
             if (event.keyCode !== 110) {
                 return;
             }
@@ -35,7 +34,7 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
                 to = this.$input.prop("selectionEnd"),
                 cur_val = this.$input.val(),
                 point = this.l10n_decimal_point();
-            var new_val = this._replaceAt(cur_val, from-1, point);
+            var new_val = this._replaceAt(cur_val, from, to, point);
             this.$input.val(new_val);
             // Put user caret in place
             to = from + point.length;


### PR DESCRIPTION
When user was replacing some specific sections or being too fast, the module wasn't behaving fine. Also, it was always displaying the original `.` slightly before doing the replacement.

This is before the fix:
![bad](https://user-images.githubusercontent.com/973709/51176167-25457680-18b4-11e9-971a-9ff714c60f67.gif)

Now, after the fix:
![good](https://user-images.githubusercontent.com/973709/51176174-2aa2c100-18b4-11e9-9e50-c63ff15076db.gif)

@Tecnativa