### PR TITLE
[FIX] web_m2x_options: Fix error in tree views with many2many_tags

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -9,10 +9,12 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
         Dialog = require('web.Dialog'),
         view_dialogs = require('web.view_dialogs'),
         relational_fields = require('web.relational_fields'),
-        FieldMany2One = relational_fields.FieldMany2One,
+        rpc = require('web.rpc');
+
+    var _t = core._t,
         FieldMany2ManyTags = relational_fields.FieldMany2ManyTags,
-        rpc = require('web.rpc'),
-        _t = core._t;
+        FieldMany2One = relational_fields.FieldMany2One,
+        FormFieldMany2ManyTags = relational_fields.FormFieldMany2ManyTags;
 
     var web_m2x_options = rpc.query({
         model: "ir.config_parameter",
@@ -301,7 +303,6 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
         _onOpenBadge: function (event) {
             var self = this;
             var open = (self.nodeOptions && self.is_option_set(self.nodeOptions.open));
-            var no_color_picker = (self.nodeOptions && self.is_option_set(self.nodeOptions.no_color_picker));
             if (open) {
                 var context = self.record.getContext(self.recordParams);
                 var id = parseInt($(event.currentTarget).data('id'), 10);
@@ -350,9 +351,24 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                         }).open();
                     })
                 }
-            } else if (!no_color_picker) {
-                self._onOpenColorPicker(event);
             }
         },
     })
+
+    FormFieldMany2ManyTags.include({
+        events: _.extend({}, FormFieldMany2ManyTags.prototype.events, {
+            'click .badge': '_onOpenBadge',
+        }),
+
+        _onOpenBadge: function (event) {
+            var open = this.is_option_set(this.nodeOptions.open);
+            var no_color_picker = this.is_option_set(
+                this.nodeOptions.no_color_picker
+            );
+            this._super.apply(this, arguments);
+            if (!open && !no_color_picker) {
+                this._onOpenColorPicker(event);
+            }
+        },
+    });
 });


### PR DESCRIPTION
The method `_onOpenColorPicker` is defined on `FormFieldMany2ManyTags`, not in `FieldMany2ManyTags`, so it can only be called on its descendants.

Otherwise, clicking on a `many2many_tags` tag when found in a tree view produces an error such as:

    TypeError: self._onOpenColorPicker is not a function

    http://localhost/web_m2x_options/static/src/js/form.js:354
    Rastreo de error:
    _onOpenBadge@http://localhost/web_m2x_options/static/src/js/form.js:354:17
    proxy/<@http://localhost/web/static/src/js/core/mixins.js:279:20
    dispatch@http://localhost/web/static/lib/jquery/jquery.js:4640:50
    add/elemData.handle@http://localhost/web/static/lib/jquery/jquery.js:4309:41

@Tecnativa