### PR TITLE
[FIX] web_decimal_numpad_dot: Restore keyboard navigation

### DIFF
--- a/web_decimal_numpad_dot/static/src/js/numpad_dot.js
+++ b/web_decimal_numpad_dot/static/src/js/numpad_dot.js
@@ -7,13 +7,6 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
     var translation = require("web.translation");
 
     var NumpadDotReplaceMixin = {
-        init: function () {
-            this.events = $.extend({}, this.events, {
-                "keydown": "numpad_dot_replace",
-            });
-            return this._super.apply(this, arguments);
-        },
-
         l10n_decimal_point: function () {
             return this.formatType === "float_time"
                 ? ":" : translation._t.database.parameters.decimal_point;
@@ -24,10 +17,10 @@ odoo.define("web_decimal_numpad_dot.FieldFloat", function (require) {
                    cur_val.substring(to);
         },
 
-        numpad_dot_replace: function (event) {
+        _onKeydown: function (event) {
             // Only act on numpad dot key
             if (event.keyCode !== 110) {
-                return;
+                return this._super.apply(this, arguments);
             }
             event.preventDefault();
             var from = this.$input.prop("selectionStart"),


### PR DESCRIPTION
When https://github.com/OCA/web/pull/1154 switched to using `keydown` as the event to trigger the numpad dot replacement, it was actually [disabling upstream's `_onKeyDown()`][1], which in turn disabled the keyboard navigation.

To fix this situation, I replaced the method that is being used to directly override `_onKeyDown`.

[1]: https://github.com/odoo/odoo/blob/19558129f0e2d5c9940f6fa95534840f8f025547/addons/web/static/src/js/fields/abstract_field.js#L41

@Tecnativa