### PR TITLE
[FIX] web_responsive: Skip re-search when not writing and make app icons and search results middle-button-clickable

### DIFF
--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -217,7 +217,7 @@ odoo.define('web_responsive', function (require) {
          */
         _searchResultsNavigate: function (event) {
             // Exit soon when not navigating results
-            if (this.$search_results.is(":empty")) {
+            if (this.$search_results.html().trim() === "") {
                 // Just in case it is the 1st search
                 this._searchMenusSchedule();
                 return;
@@ -227,7 +227,7 @@ odoo.define('web_responsive', function (require) {
                 pre_focused = all.filter(".active") || $(all[0]),
                 offset = all.index(pre_focused),
                 key = event.key;
-                // Transform tab presses in arrow presses
+            // Transform tab presses in arrow presses
             if (key === "Tab") {
                 event.preventDefault();
                 key = event.shiftKey ? "ArrowUp" : "ArrowDown";
@@ -246,7 +246,10 @@ odoo.define('web_responsive', function (require) {
                 break;
             // Other keys trigger a search
             default:
-                this._searchMenusSchedule();
+                // All keys that write a character have length 1
+                if (key.length === 1 || key === "Backspace") {
+                    this._searchMenusSchedule();
+                }
                 return;
             }
             // Allow looping on results

--- a/web_responsive/static/src/xml/apps.xml
+++ b/web_responsive/static/src/xml/apps.xml
@@ -4,6 +4,11 @@
 
 <template>
     <t t-extend="AppsMenu">
+        <!-- App icons must be clickable -->
+        <t t-jquery=".o_app" t-operation="attributes">
+            <attribute name="t-attf-href">#menu_id=#{app.menuID}&amp;action_id=#{app.actionID}</attribute>
+        </t>
+
         <!-- App icons should be more than a text -->
         <t t-jquery=".o_app &gt; t" t-operation="replace">
             <t t-call="web_responsive.AppIcon"/>
@@ -47,8 +52,9 @@
     <t t-name="web_responsive.MenuSearchResults">
         <t t-foreach="results" t-as="result">
             <t t-set="menu" t-value="widget._menuInfo(result.original)"/>
-            <div t-attf-class="o-menu-search-result dropdown-item col-12 ml-auto mr-auto #{result_first ? 'active' : ''}"
+            <a t-attf-class="o-menu-search-result dropdown-item col-12 ml-auto mr-auto #{result_first ? 'active' : ''}"
                  t-attf-style="background-image:url('data:image/png;base64,#{menu.web_icon_data}')"
+                 t-attf-href="#menu_id=#{menu.id}&amp;action_id=#{menu.action_id}"
                  t-att-data-menu-id="menu.id"
                  t-att-data-action-id="menu.action_id"
                  t-att-data-parent-id="menu.parent_id[0]"


### PR DESCRIPTION
In the case of app icons, those weren't getting the `href` attribute filled.

In the case of search results, those weren't even an `<a>` element.

Fixed in both cases to fix #1170.

Also, when the user uses TAB or SHIFT+TAB to navigate in search results, he can trigger a SHIFT-only keydown event without noticing, which would reset the selected result position to the first or last.

It is disturbing, so, to avoid that problem, the re-search is only triggered if the currently pressed key has length=1, which will skip most keys that are not actually writing a character into the search input, like i.e. "Shift", "Alt", "F4", etc.

@Tecnativa