### PR TITLE
[ADD] make the module play nice with web_shortcut

### DIFF
--- a/web_searchbar_full_width/static/src/css/web_searchbar_full_width.css
+++ b/web_searchbar_full_width/static/src/css/web_searchbar_full_width.css
@@ -3,6 +3,11 @@
     margin-bottom: 5px;
 }
 
+/* this is effective when web_shortcut is installed */
+.o_control_panel .oe_shortcut_toggle + .breadcrumb {
+    width: calc(100% - 24px);
+}
+
 .o_control_panel .o_cp_searchview {
     width: 100%;
 }


### PR DESCRIPTION
without this, either `web_shortcut` comes first and then we don't have a full width searchbar, or `web_searchbar_full_width` comes first and then we have the start on top of the breadcrumb, not next to it.