### PR TITLE
web_environment_ribbon: allow to set ribbon in configuration file

### DIFF
--- a/web_environment_ribbon/__manifest__.py
+++ b/web_environment_ribbon/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': "Web Environment Ribbon",
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'Web',
     'author': 'Francesco OpenCode Apruzzese, '
               'Tecnativa, '

--- a/web_environment_ribbon/models/web_environment_ribbon_backend.py
+++ b/web_environment_ribbon/models/web_environment_ribbon_backend.py
@@ -1,7 +1,7 @@
 # Copyright 2017 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, models, tools
 
 
 class WebEnvironmentRibbonBackend(models.AbstractModel):
@@ -17,22 +17,32 @@ class WebEnvironmentRibbonBackend(models.AbstractModel):
 
     @api.model
     def _prepare_ribbon_name(self):
-        name_tmpl = self.env['ir.config_parameter'].sudo().get_param(
-            'ribbon.name')
+        name_tmpl = tools.config.get('ribbon.name')
+        if not name_tmpl:
+            name_tmpl = self.env['ir.config_parameter'].sudo().get_param(
+                'ribbon.name')
         vals = self._prepare_ribbon_format_vals()
         return name_tmpl and name_tmpl.format(**vals) or name_tmpl
 
     @api.model
     def get_environment_ribbon(self):
         """
-        This method returns the ribbon data from ir config parameters
+        This method returns the ribbon data
+        from configuration file or from  ir config parameters
         :return: dictionary
         """
         ir_config_model = self.env['ir.config_parameter']
         name = self._prepare_ribbon_name()
+        color = tools.config.get('ribbon.color')
+        if not color:
+            color = ir_config_model.sudo().get_param('ribbon.color')
+        background_color = tools.config.get('ribbon.background.color')
+        if not background_color:
+            background_color = ir_config_model.sudo().get_param(
+                'ribbon.background.color')
+
         return {
             'name': name,
-            'color': ir_config_model.sudo().get_param('ribbon.color'),
-            'background_color': ir_config_model.sudo().get_param(
-                'ribbon.background.color'),
+            'color': color,
+            'background_color': background_color,
         }

--- a/web_environment_ribbon/readme/CONFIGURE.rst
+++ b/web_environment_ribbon/readme/CONFIGURE.rst
@@ -6,3 +6,9 @@
   colors or just set to "False" to use default values.
 * You can add the database name in the ribbon by adding "{db_name}" in the
   system parameter "ribbon.name".
+* It is possible to use the parameters ("ribbon.name", "ribbon.color",
+  "ribbon.background.color") in the configuration file instead of changing
+  the system parameters. This option will be useful in the case of
+  a restoration of a production database on a pre-production environment,
+  where we want to see a different ribbon that corresponds to the environment
+  and not to the value stored in the database.

--- a/web_environment_ribbon/readme/CONTRIBUTORS.rst
+++ b/web_environment_ribbon/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Thomas Binsfeld <thomas.binsfeld@acsone.eu>
 * Xavier Jiménez <xavier.jimenez@qubiq.es>
 * Dennis Sluijk <d.sluijk@onestein.nl>
+* Majda El Mariouli <majda.elmariouli@smile-maroc.com>


### PR DESCRIPTION
Allow to override ribbon settings inside configuration file.

This option will be useful in the case of a restoration of a production database on a staging environment, where we want to see a different ribbon (ie. you want to see "staging" instead of "prod").