### PR TITLE
[12.0][IMP] web_responsive: Sticky chatter topbar

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Web Responsive",
     "summary": "Responsive web client, community-supported",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "category": "Website",
     "website": "https://github.com/OCA/web",
     "author": "LasLabs, Tecnativa, Alexandre Díaz, "

--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -420,6 +420,22 @@ html .o_web_client .o_main .o_main_content {
                     max-width: 50%;
                     min-width: 30%;
                     overflow: auto;
+
+                    .o_chatter_topbar,
+                    .o_thread_composer {
+                        position: sticky;
+                    }
+
+                    .o_chatter_topbar {
+                        top: 0;
+                        z-index: 2;
+                        background-color: $o-view-background-color;
+                    }
+
+                    .o_thread_composer {
+                        top: $o-statusbar-height;
+                        z-index: 1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Improve chatter topbar as suggested in https://github.com/OCA/web/issues/1177

Sets sticky at top 0 because topbar uses margin, if preserve these margin, when sticky, conversation can be seen in these space because is an a transparent zone.