### PR TITLE
[FIX] web_widget_bokeh_chart

### DIFF
--- a/web_widget_bokeh_chart/static/src/css/custom-bokeh.css
+++ b/web_widget_bokeh_chart/static/src/css/custom-bokeh.css
@@ -1,0 +1,4 @@
+.bk-root {
+    /* Overriding this styling option Odoo menu is now displayed on top of bokeh graphs */
+  position: sticky;
+}

--- a/web_widget_bokeh_chart/views/web_widget_bokeh_chart.xml
+++ b/web_widget_bokeh_chart/views/web_widget_bokeh_chart.xml
@@ -6,6 +6,7 @@
         <xpath expr="." position="inside">
             <link rel="stylesheet" href="/web_widget_bokeh_chart/static/src/lib/bokeh/bokeh-0.12.7.css"/>
             <link rel="stylesheet" href="/web_widget_bokeh_chart/static/src/lib/bokeh/bokeh-widgets-0.12.7.css"/>
+            <link rel="stylesheet" href="/web_widget_bokeh_chart/static/src/css/custom-bokeh.css"/>
             <script type="text/javascript" src="/web_widget_bokeh_chart/static/src/lib/bokeh/bokeh-0.12.7.js"/>
             <script type="text/javascript" src="/web_widget_bokeh_chart/static/src/lib/bokeh/bokeh-widgets-0.12.7.js"/>
             <script type="text/javascript" src="/web_widget_bokeh_chart/static/src/js/web_widget_bokeh_chart.js"/>


### PR DESCRIPTION
PR intended to fix visual bug. Odoo menu displayed below bokeh charts.

Behavior before PR:
![image](https://user-images.githubusercontent.com/44768500/52782865-63b78800-3050-11e9-877c-efcb84c0d625.png)

Expected behavior after PR:
![image](https://user-images.githubusercontent.com/44768500/52782924-8b0e5500-3050-11e9-9627-b6dd11457fb6.png)


