### PR TITLE
[IMP] Evaluate web_timeline colors attribute as python

### DIFF
--- a/web_timeline/README.rst
+++ b/web_timeline/README.rst
@@ -38,7 +38,7 @@ the possible attributes for the tag:
   in a popup. If not (default value), the record is edited changing to form
   view.
 * colors (optional): it allows to set certain specific colors if the expressed
-  condition (JS syntax) is met.
+  condition (Python syntax) is met.
 * dependency_arrow (optional): set this attribute to a x2many field to draw
   arrows between the records referenced in the x2many field.
 
@@ -67,7 +67,7 @@ Example:
                           default_group_by="user_id"
                           event_open_popup="true"
                           zoomKey="ctrlKey"
-                          colors="#ec7063:user_id == false;#2ecb71:kanban_state=='done';"
+                          colors="#ec7063:user_id == False;#2ecb71:kanban_state=='done';#f6d5d5:date_end &gt; date_deadline"
                           dependency_arrow="task_dependency_ids">
                     <field name="user_id"/>
                     <templates>

--- a/web_timeline/__manifest__.py
+++ b/web_timeline/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': "Web timeline",
     'summary': "Interactive visualization chart to show events in time",
-    "version": "11.0.1.4.1",
+    "version": "11.1.0.0.0",
     'author': 'ACSONE SA/NV, '
               'Tecnativa, '
               'Monk Software, '

--- a/web_timeline/__manifest__.py
+++ b/web_timeline/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': "Web timeline",
     'summary': "Interactive visualization chart to show events in time",
-    "version": "11.1.0.0.0",
+    "version": "11.0.2.0.0",
     'author': 'ACSONE SA/NV, '
               'Tecnativa, '
               'Monk Software, '

--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -421,7 +421,7 @@ odoo.define('web_timeline.TimelineRenderer', function (require) {
                 group = -1;
             }
             _.each(self.colors, function (color) {
-            if (py.PY_isTrue(py.evaluate(color.ast, evt))) {
+                if (py.PY_isTrue(py.evaluate(color.ast, evt))) {
                     self.color = color.color;
                 }
             });

--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -10,7 +10,6 @@ odoo.define('web_timeline.TimelineRenderer', function (require) {
     var field_utils = require('web.field_utils');
     var TimelineCanvas = require('web_timeline.TimelineCanvas');
 
-
     var _t = core._t;
 
     var TimelineRenderer = AbstractRenderer.extend({
@@ -422,7 +421,7 @@ odoo.define('web_timeline.TimelineRenderer', function (require) {
                 group = -1;
             }
             _.each(self.colors, function (color) {
-                if (eval("'" + evt[color.field] + "' " + color.opt + " '" + color.value + "'")) {
+            if (py.PY_isTrue(py.evaluate(color.ast, evt))) {
                     self.color = color.color;
                 }
             });

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -86,8 +86,8 @@ odoo.define('web_timeline.TimelineView', function (require) {
             this.parse_colors();
             for (var i=0; i<this.colors.length; i++) {
                 for (var j=0; j<this.colors[i].tokens.length; j++) {
-                    if (this.colors[i].tokens[j].id == '(name)') {
-                        fieldNames.push(this.colors[i].tokens[j].value)
+                    if (this.colors[i].tokens[j].id === '(name)') {
+                        fieldNames.push(this.colors[i].tokens[j].value);
                     }
                 }
             }
@@ -175,9 +175,9 @@ odoo.define('web_timeline.TimelineView', function (require) {
         parse_colors: function () {
             if (this.arch.attrs.colors) {
                 this.colors = _(this.arch.attrs.colors.split(';')).chain().compact().map(function (color_pair) {
-                    var temp = color_pair.split(':')
-                    var color = temp[0]
-                    var expr = temp.slice(1).join(':')
+                    var temp = color_pair.split(':');
+                    var color = temp[0];
+                    var expr = temp.slice(1).join(':');
                     var tokens = py.tokenize(expr);
                     var ast = py.parse(tokens);
                     return {

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -84,8 +84,10 @@ odoo.define('web_timeline.TimelineView', function (require) {
             );
 
             this.parse_colors();
-            for (var i=0; i<this.colors.length; i++) {
-                fieldNames.push(this.colors[i].field);
+            for (let color of this.colors) {
+                for (let token of color.tokens) {
+                    if (token.id == '(name)') fieldNames.push(token.value)
+                }
             }
 
             if (attrs.dependency_arrow) {
@@ -171,13 +173,15 @@ odoo.define('web_timeline.TimelineView', function (require) {
         parse_colors: function () {
             if (this.arch.attrs.colors) {
                 this.colors = _(this.arch.attrs.colors.split(';')).chain().compact().map(function (color_pair) {
-                    var pair = color_pair.split(':'), color = pair[0], expr = pair[1];
-                    var temp = py.parse(py.tokenize(expr));
+                    var temp = color_pair.split(':')
+                    var color = temp[0]
+                    var expr = temp.slice(1).join(':')
+                    var tokens = py.tokenize(expr);
+                    var ast = py.parse(tokens);
                     return {
                         'color': color,
-                        'field': temp.expressions[0].value,
-                        'opt': temp.operators[0],
-                        'value': temp.expressions[1].value
+                        'tokens': tokens,
+                        'ast': ast,
                     };
                 }).value();
             } else {

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -84,9 +84,11 @@ odoo.define('web_timeline.TimelineView', function (require) {
             );
 
             this.parse_colors();
-            for (let color of this.colors) {
-                for (let token of color.tokens) {
-                    if (token.id == '(name)') fieldNames.push(token.value)
+            for (var i=0; i<this.colors.length; i++) {
+                for (var j=0; j<this.colors[i].tokens.length; j++) {
+                    if (this.colors[i].tokens[j].id == '(name)') {
+                        fieldNames.push(this.colors[i].tokens[j].value)
+                    }
                 }
             }
 


### PR DESCRIPTION
I'd like to get some feedback on this change.

Con: its a backwards incompatible change, currently colors predicates are evaluated as javascript. I would have to update project_timeline and any other modules with dependencies on web_timeline. 

Pro: this enables the use of record attributes on the rhs of the expression, logical operators, etc.

Use case: project_timeline, project.task red: date_deadline > date_end