### PR TITLE
[FIX] web_drop_target

### DIFF
--- a/web_drop_target/__manifest__.py
+++ b/web_drop_target/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Drop target support",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",
     "license": "AGPL-3",

--- a/web_drop_target/static/src/js/web_drop_target.js
+++ b/web_drop_target/static/src/js/web_drop_target.js
@@ -28,7 +28,7 @@ odoo.define('web_drop_target', function(require) {
 
         _on_drop: function(e) {
             var drop_item = this._get_drop_item(e);
-            if(!drop_item) {
+            if(!drop_item || !(drop_item.getAsFile() instanceof Blob)) {
                 return;
             }
             jQuery(e.delegateTarget).removeClass(this._drag_over_class);
@@ -37,6 +37,7 @@ odoo.define('web_drop_target', function(require) {
                 _.partial(this._handle_file_drop, drop_item.getAsFile())
             );
             reader.readAsArrayBuffer(drop_item.getAsFile());
+            e.stopPropagation();
             e.preventDefault();
         },
 


### PR DESCRIPTION
 Make sure that when a File is dropped into a form the event is propagated and the action only takes place when the element dropped is actually a Blob object.

cc: @hbrunn 