### PR TITLE
[12.0] web_notify: attempt to fix void messages?

### DIFF
--- a/web_notify/static/src/js/web_client.js
+++ b/web_notify/static/src/js/web_client.js
@@ -19,6 +19,13 @@ odoo.define('web_notify.WebClient', function (require) {
             this.channel_warning = 'notify_warning_' + session.uid;
             this.channel_info = 'notify_info_' + session.uid;
             this.channel_default = 'notify_default_' + session.uid;
+            this.all_channels = [
+                this.channel_success,
+                this.channel_danger,
+                this.channel_warning,
+                this.channel_info,
+                this.channel_default,
+            ];
             this.call('bus_service', 'addChannel', this.channel_success);
             this.call('bus_service', 'addChannel', this.channel_danger);
             this.call('bus_service', 'addChannel', this.channel_warning);
@@ -32,9 +39,14 @@ odoo.define('web_notify.WebClient', function (require) {
         bus_notification: function (notifications) {
             var self = this;
             _.each(notifications, function (notification) {
-                // Not used: var channel = notification[0];
+                var channel = notification[0];
                 var message = notification[1];
-                self.on_message(message);
+                if (
+                    self.all_channels != null &&
+                    self.all_channels.indexOf(channel) > -1
+                ) {
+                    self.on_message(message);
+                }
             });
         },
         on_message: function (message) {


### PR DESCRIPTION
Hey,

I've installed `web_notify` module and happened to stumble on an issue. Basically if I try to create any activity I always get an empty void message in the notifications. Please see picture below:

![image](https://user-images.githubusercontent.com/7696589/56043127-4f88c200-5d45-11e9-9dbb-ef07349024fb.png)

It seems besides the custom channels provided in this addon it also catches messages from other channels. E.g. in this case it seems the void popup is triggered by [these activity creation bus messages](https://github.com/odoo/odoo/blob/5e8b667951463125e888f75877cbc76bacf38ea3/addons/mail/models/mail_activity.py#L296-L298)

### Steps to reproduce

Odoo commit: could reproduce on **5e8b667951** and **4da82776ff**
OCA/web commit: **2465278969**

1. Install `crm` and `web_notify` modules
2. Create an activity for yourself (tried for admin user)
3. Empty popup appears

### Attempt to solve

It seems the bus handles all messages non exclusively. I've hacked in a conditional to handle only messages from `web_notify` addon, but its unclear wether this does not break something else.

Before diving deeper into this, maybe you guys know wether its just a configuration issue or experienced this yourselves ?

Thanks!