### PR TITLE
[10][IMP] switch company warning : Add detection of switching database

### DIFF
--- a/web_switch_company_warning/README.rst
+++ b/web_switch_company_warning/README.rst
@@ -16,7 +16,7 @@ Known issues / Roadmap
 
     * If the browser don't implement Sharded Worker (http://www.w3.org/TR/workers/#sharedworker), the warning message will not be displayed (there is no polyfill).
 
-    * Switching company in a separate browser or in private browsing mode will not be detected by this module. It's a limitation of Shared Wworker(limit to browser session, server:port...)
+    * Switching company in a separate browser or in private browsing mode will not be detected by this module. It's a limitation of Shared Worker(limit to browser session, server:port...)
 
 
 Bug Tracker

--- a/web_switch_company_warning/__manifest__.py
+++ b/web_switch_company_warning/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Multicompany - Switch Company Warning",
     "summary": "Show a warning if current company has been switched"
                " in another tab or window.",
-    "version": "10.0.0.1.0",
+    "version": "10.0.0.1.1",
     "category": "web",
     "website": "http://akretion.com",
     "license": "AGPL-3",

--- a/web_switch_company_warning/static/src/js/switch_company_warning.js
+++ b/web_switch_company_warning/static/src/js/switch_company_warning.js
@@ -16,19 +16,21 @@ odoo.define('web_switch_company_warning.widget', function (require) {
             this._super();
             var self = this;
             var w = new SharedWorker('/web_switch_company_warning/static/src/js/switch_company_warning_worker.js');
-
             w.port.addEventListener('message', function (msg) {
                 if (msg.data.type !== 'newCtx') {
                     return;
                 }
-                if(msg.data.newCtx === self.session.company_id) {
+                if(msg.data.newCtx === self.generateSignature()) {
                     self.$el.hide();
                 } else {
                     self.$el.show();
                 }
             });
             w.port.start();
-            w.port.postMessage(this.session.company_id);
+            w.port.postMessage(this.generateSignature());
+        },
+        generateSignature: function() {
+            return [this.session.company_id, this.session.db].join();
         }
     });
 

--- a/web_switch_company_warning/static/src/xml/switch_company_warning.xml
+++ b/web_switch_company_warning/static/src/xml/switch_company_warning.xml
@@ -2,7 +2,7 @@
 <template>
     <t t-name="web_switch_company_warning.warningWidget">
         <div class="container-fluid bg-warning" style="text-align: center; display:none;">
-            <h3>You switched to a different company with another tab or window</h3>
+            <h3>You switched to a different company or database with another tab or window</h3>
             <p><button onclick="location.reload(true);" class="btn">Reload</button> to refresh your session</p>
         </div>
     </t>


### PR DESCRIPTION
You have multiple databases on the same host (like in a dev env) and you have multiple tabs open.
When you switch from a base to another in one tab, thanks to this PR, you get a warning message.