### PR TITLE
[FIX] web_widget_timepicker: fix show current time when choose 0:00

### DIFF
--- a/web_widget_timepicker/static/src/js/web_widget_timepicker.js
+++ b/web_widget_timepicker/static/src/js/web_widget_timepicker.js
@@ -25,7 +25,7 @@ odoo.define('web_widget_timepicker', function (require) {
 
         setValue: function (value) {
             this.set({'value': value});
-            var formatted_value = value ? this._formatClient(value) : null;
+            var formatted_value = this._formatClient(value) || value;
             this.$input.val(formatted_value);
             if (this.picker) {
                 var fdate = new moment(formatted_value, this.options.format);
@@ -36,7 +36,7 @@ odoo.define('web_widget_timepicker', function (require) {
 
         getValue: function () {
             var value = this.get('value');
-            return value ? this._formatClient(value) : null;
+            return this._formatClient(value) || value;
         },
 
         changeDatetime: function () {


### PR DESCRIPTION

Now when we use the `web_widget_timepicker` and choose a `0:00` it will show that expected value.

- Before this MR:
<img width="907" alt="before_test" src="https://user-images.githubusercontent.com/17712814/57182487-3f0bc900-6e65-11e9-9af6-815c73a44c2b.png">

- After this MR:
<img width="442" alt="after_test" src="https://user-images.githubusercontent.com/17712814/57182485-2e5b5300-6e65-11e9-9076-a00b98a8fffc.png">


