### PR TITLE
[10.0] [FIX] web_widget_text_markdown: convert markdown only when widget attr is present in tree view

### DIFF
--- a/web_widget_text_markdown/static/src/js/web_widget_text_markdown.js
+++ b/web_widget_text_markdown/static/src/js/web_widget_text_markdown.js
@@ -121,7 +121,7 @@ odoo.define("web_widget_text_markdown.bootstrap_markdown",
       },
 
       _format: function(row_data, options) {
-        if (this.type === "text") {
+        if (this.type === "text" && this.widget === "bootstrap_markdown") {
           options = options || {};
           var markdown_text = marked(
             formats.format_value(


### PR DESCRIPTION
Before this MR the module web_widget_text_markdown would always
try to parse the contents of all text fields as markdown on the tree views.

After this MR the module will only try to parse the text fields when they
have the widget attribute equal to bootstrap_markdown.

- With widget:

![image](https://user-images.githubusercontent.com/8657959/57184731-4216b180-6e85-11e9-92c8-e0232fdaa08c.png)

- Without widget:

![image](https://user-images.githubusercontent.com/8657959/57184732-48a52900-6e85-11e9-96f3-edf9500f2188.png)


---

Closes: https://github.com/OCA/web/issues/1184

\#OcaDaysManzanillo \#OcaDays2019
