### PR TITLE
[11.0][FIX]web_timeline: fix group orders

### DIFF
--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -159,7 +159,8 @@ odoo.define('web_timeline.TimelineView', function (require) {
             if (grp2.id === -1) {
                 return +1;
             }
-            return grp1.content - grp2.content;
+
+            return  grp1.content.localeCompare(grp2.content);
 
         },
 


### PR DESCRIPTION
Super-seeds the git history mess I created in https://github.com/OCA/web/pull/1239/commits