### PR TITLE
[12.0] web_timeline: small fixups

### DIFF
--- a/web_timeline/static/src/css/web_timeline.css
+++ b/web_timeline/static/src/css/web_timeline.css
@@ -6,7 +6,7 @@
 /* very light gray background in weekends */
 .vis-timeline .vis-grid.vis-saturday,
 .vis-timeline .vis-grid.vis-sunday {
-    background: #DCDCDC;
+    background: #e7e7e7;
 }
 
 .vis-item .vis-item-overflow {
@@ -14,7 +14,7 @@
 }
 
 .oe_chatter_toggle {
-    padding: 15px;
+    padding: 18px;
 }
 
 .oe_timeline_view .vlabel .inner:hover{
@@ -26,6 +26,6 @@
     width: 100%;
     height: 100%;
     position: absolute;
-    left: 0px;
-    top: 0px;
+    left: 5px;
+    top: 5px;
 }


### PR DESCRIPTION
1)  A more better colour that will suit the display of various devices is chosen recent colour blows into white for some devices due to resolution limits.
2) padding of 18px will suit more appropriately
3)  when left ,top were set to 0px  each it may cause sometimes crashing issues.