### PR TITLE
[10.0][FIX][web_widget_image_webcam] Fix swfURL property set

### DIFF
--- a/web_widget_image_webcam/static/src/js/webcam_widget.js
+++ b/web_widget_image_webcam/static/src/js/webcam_widget.js
@@ -31,9 +31,9 @@ odoo.define('web_widget_image_webcam.webcam_widget', function(require) {
                 image_format: 'jpeg',
                 jpeg_quality: 90,
                 force_flash: false,
-                fps: 45,
-                swfURL: '/web_widget_image_webcam/static/src/js/webcam.swf',
+                fps: 45
             });
+            Webcam.setSWFLocation('/web_widget_image_webcam/static/src/js/webcam.swf');
 
             self.$el.find('.o_form_binary_file_web_cam').removeClass('col-md-offset-5');
 


### PR DESCRIPTION
Actually set the swfURL property on Webcam object.

This property needs to be set with the proper setter method 'setSWFLocation'
since the Webcam object does not look at the params property when searching for it.