### PR TITLE
[FIX] web_export_view: float time format broken

### DIFF
--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -69,7 +69,7 @@ odoo.define('web_export_view', function (require) {
                             if (text.search(":")) { 
                                 export_row.push(text);
                             }
-                            if ($cell.hasClass("o_list_number")) {
+			    else if ($cell.hasClass("o_list_number")) {
                                 export_row.push(parseFloat(
                                     text
                                     // Remove thousands separator

--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -65,6 +65,10 @@ odoo.define('web_export_view', function (require) {
                         }
                         else {
                             var text = $cell.text().trim();
+                            // Search : for hour value
+                            if (text.search(":")) { 
+                                export_row.push(text);
+                            }
                             if ($cell.hasClass("o_list_number")) {
                                 export_row.push(parseFloat(
                                     text


### PR DESCRIPTION
In views with float_widget fields when we use the export, truncate the data