### PR TITLE
[FIX] don't depend on hbrunn's branch

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,1 @@
-server-tools https://github.com/hbrunn/server-tools 8.0-base_view_inheritance_extension-user_ids
+server-tools


### PR DESCRIPTION
In https://github.com/OCA/web/pull/787, we prematurely merged the link to my patched version this uses