### PR TITLE
[12.0][FIX] Status Button invisible

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -343,7 +343,7 @@ html .o_web_client .o_main .o_main_content {
         .oe_title {
             width: initial;
 
-            span {
+            span.o_field_widget {
                 max-width: 100%;
                 text-overflow: ellipsis;
                 white-space: nowrap;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4851083/61854082-aada5c80-aebd-11e9-8487-f5178b124eb7.png)
After:
![image](https://user-images.githubusercontent.com/4851083/61854921-6223a300-aebf-11e9-9075-dbcdc670de2c.png)

The problem is that these CSS attributes also affect other elements in the title.

https://github.com/OCA/web/commit/5aa9278b58a01e1119ae566c2340062f46a37c3f#diff-e053f829c6178b791df988b24e4282b4 >> https://github.com/OCA/web/blob/12.0/web_responsive/static/src/css/web_responsive.scss#L346