### PR TITLE
[FIX] handle default filters differently to avoid timing issues

### DIFF
--- a/web_x2m_filter/static/src/js/web_x2m_filter.js
+++ b/web_x2m_filter/static/src/js/web_x2m_filter.js
@@ -19,14 +19,6 @@ openerp.web_x2m_filter = function(instance)
             .web_x2m_filter_apply_domain($button.attr('data-domain'))
             .then(this.proxy('reload_content'));
         },
-        start: function()
-        {
-            var self = this;
-            return this._super.apply(this, arguments).then(function()
-            {
-                self.$('button.web_x2m_filter[data-default]').click();
-            });
-        },
     });
     var apply_domain = function(o2m, domain)
     {
@@ -57,16 +49,44 @@ openerp.web_x2m_filter = function(instance)
             o2m._inhibit_on_change_flag = original;
         });
     };
+    var apply_default_domain = function(o2m)
+    {
+        var default_filter = _.filter(
+            o2m.options.web_x2m_filter,
+            function(filter) { return filter.default }
+        );
+        if(default_filter.length) {
+            return apply_domain(
+                o2m, JSON.stringify(default_filter[0].domain)
+            );
+        }
+    };
     instance.web.form.FieldOne2Many.include({
         web_x2m_filter_apply_domain: function(domain)
         {
             return apply_domain(this, domain);
+        },
+        set_value: function(value) {
+            var self = this;
+            return jQuery.when(
+                this._super.apply(this, arguments)
+            ).then(function() {
+                return apply_default_domain(self);
+            });
         },
     });
     instance.web.form.FieldMany2Many.include({
         web_x2m_filter_apply_domain: function(domain)
         {
             return apply_domain(this, domain);
+        },
+        set_value: function(value) {
+            var self = this;
+            return jQuery.when(
+                this._super.apply(this, arguments)
+            ).then(function() {
+                return apply_default_domain(self);
+            });
         },
     });
 };

--- a/web_x2m_filter/static/src/xml/web_x2m_filter.xml
+++ b/web_x2m_filter/static/src/xml/web_x2m_filter.xml
@@ -4,12 +4,14 @@
         <t t-jquery="thead tr:first-child" t-operation="after">
             <tr t-if="getParent().options &amp;&amp; getParent().options.web_x2m_filter" class="web_x2m_filter">
                 <th t-att-colspan="columns_count">
+                    <t t-set="has_default" t-value="False" />
                     <t t-foreach="getParent().options.web_x2m_filter || {}" t-as="filter">
-                        <button t-attf-class="oe_button oe_list_add web_x2m_filter #{filter.class || ''}" t-att-data-domain="JSON.stringify(filter.domain || [])" t-att-data-default="filter.default">
+                        <button t-attf-class="oe_button oe_list_add web_x2m_filter #{filter.class || ''}" t-att-data-domain="JSON.stringify(filter.domain || [])" t-att-data-default="filter.default" t-att-disabled="has_default and 'disabled' or filter.default and 'disabled' or None">
+                            <t t-set="has_default" t-value="has_default or filter.default" />
                             <t t-esc="_t(filter.name)" />
                         </button>
                     </t>
-                    <button t-att-data-domain="JSON.stringify(getParent().field.domain)" class="oe_button oe_list_add web_x2m_filter" disabled="disabled"><i class="fa fa-refresh" aria-hidden="true"></i></button>
+                    <button t-att-data-domain="JSON.stringify(getParent().field.domain)" class="oe_button oe_list_add web_x2m_filter" t-att-disabled="!has_default and 'disabled' or None"><i class="fa fa-refresh" aria-hidden="true"></i></button>
                 </th>
             </tr>
         </t>
@@ -18,12 +20,14 @@
         <t t-jquery="thead tr:first-child" t-operation="after">
             <tr t-if="getParent().o2m.options.web_x2m_filter" class="web_x2m_filter">
                 <th t-att-colspan="columns_count">
+                    <t t-set="has_default" t-value="False" />
                     <t t-foreach="getParent().o2m.options.web_x2m_filter" t-as="filter">
-                        <button t-attf-class="oe_button oe_list_add web_x2m_filter #{filter.class || ''}" t-att-data-domain="JSON.stringify(filter.domain || [])" t-att-data-default="filter.default">
+                        <button t-attf-class="oe_button oe_list_add web_x2m_filter #{filter.class || ''}" t-att-data-domain="JSON.stringify(filter.domain || [])" t-att-data-default="filter.default" t-att-disabled="has_default and 'disabled' or filter.default and 'disabled' or None">
+                            <t t-set="has_default" t-value="has_default or filter.default" />
                             <t t-esc="_t(filter.name)" />
                         </button>
                     </t>
-                    <button t-att-data-domain="JSON.stringify(getParent().o2m.field.domain || [])" class="oe_button oe_list_add web_x2m_filter" disabled="disabled"><i class="fa fa-refresh" aria-hidden="true"></i></button>
+                    <button t-att-data-domain="JSON.stringify(getParent().o2m.field.domain || [])" class="oe_button oe_list_add web_x2m_filter" t-att-disabled="!has_default and 'disabled' or None"><i class="fa fa-refresh" aria-hidden="true"></i></button>
                 </th>
             </tr>
         </t>


### PR DESCRIPTION
doing this by clicking the button sometimes leaves us with the existing field's contents when creating a new record while having an existing record open.