### PR TITLE
[FIX][12.0] web_responsive: changed 'button box more' initial position

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -329,7 +329,14 @@ html .o_web_client .o_main .o_main_content {
     .o_form_view {
         .o_form_sheet {
             max-width: calc(100% - 32px);
-            overflow-x: scroll;
+            overflow-x: auto;
+
+            .oe_button_box {
+                .o_dropdown_more {
+                    padding: 0.1em;
+                    width: min-content;
+                }
+            }
         }
 
         // Sticky statusbar


### PR DESCRIPTION
This PR fixes #1379 issue. Now the menu opens all times in the same place:
![button_click_b](https://user-images.githubusercontent.com/731270/65626890-82123880-dfce-11e9-88d0-4dbf0757d74d.gif)


Cc @tecnativa

