### PR TITLE
[12.0][IMP] web_widget_color: Apply required modifier

### DIFF
--- a/web_widget_color/README.rst
+++ b/web_widget_color/README.rst
@@ -140,6 +140,8 @@ Contributors
 
   * Ernesto Tejeda
 
+* Dennis Sluijk <d.sluijk@onestein.nl>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/web_widget_color/__manifest__.py
+++ b/web_widget_color/__manifest__.py
@@ -8,7 +8,7 @@
 {
     'name': "Web Widget Color",
     'category': "web",
-    'version': "12.0.1.0.0",
+    'version': "12.0.1.0.1",
     "author": "Savoir-faire Linux, "
               "Anybox, "
               "Taktik SA, "

--- a/web_widget_color/readme/CONTRIBUTORS.rst
+++ b/web_widget_color/readme/CONTRIBUTORS.rst
@@ -5,3 +5,5 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Ernesto Tejeda
+
+* Dennis Sluijk <d.sluijk@onestein.nl>

--- a/web_widget_color/static/description/index.html
+++ b/web_widget_color/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.14: http://docutils.sourceforge.net/" />
 <title>Web Widget Color</title>
 <style type="text/css">
 
@@ -466,6 +466,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Ernesto Tejeda</li>
 </ul>
 </li>
+<li>Dennis Sluijk &lt;<a class="reference external" href="mailto:d.sluijk&#64;onestein.nl">d.sluijk&#64;onestein.nl</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/web_widget_color/static/src/js/widget.js
+++ b/web_widget_color/static/src/js/widget.js
@@ -16,7 +16,23 @@ odoo.define('web.web_widget_color', function(require) {
 
         _renderEdit: function() {
             this.$input = this.$el.find('input');
-            this.jscolor = new jscolor(this.$input[0], {hash:true, zIndex: 2000});
+
+            if (!this.$input[0]._jscLinkedInstance) {
+                this.jscolor = new jscolor(this.$input[0], {
+                    hash: true,
+                    zIndex: 2000,
+                });
+            }
+
+            this.jscolor.fromString(this.value);
+        },
+
+        updateModifiersValue: function () {
+            this._super.apply(this, arguments);
+            if (this.mode !== 'readonly') {
+                this.jscolor.required = this.attrs.modifiersValue.required;
+                this.$el.removeClass('o_required_modifier');
+            }
         },
     });
     field_registry.add('color', FieldColor);


### PR DESCRIPTION
Fixes #1383

The width can be altered by adding a style attribute to the field element.

Also removes warning message "Cannot link jscolor twice to the same element. Skipping."