### PR TITLE
[WIP] [10.0] [ADD] web_advanced_search_list

### DIFF
--- a/web_advanced_search_list/__init__.py
+++ b/web_advanced_search_list/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).

--- a/web_advanced_search_list/__manifest__.py
+++ b/web_advanced_search_list/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 PlanetaTIC - Marc Poch <mpoch@planetatic.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "List in advanced search",
+    "description": "Add 'is in' operator in advanced search field",
+    "version": "10.0.1.0.0",
+    "category": "web",
+    "license": "AGPL-3",
+    "author": "PlanetaTIC, "
+              "Odoo Community Association (OCA)",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "web",
+    ],
+    "data": [
+        "views/template.xml",
+    ],
+}

--- a/web_advanced_search_list/i18n/es.po
+++ b/web_advanced_search_list/i18n/es.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * web_advanced_search_list
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-09-26 13:37+0000\n"
+"PO-Revision-Date: 2019-09-26 13:37+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: web_advanced_search_list
+#. openerp-web
+#: code:addons/web_advanced_search_list/static/src/js/search.js:10
+#, python-format
+msgid "is in"
+msgstr "está en"

--- a/web_advanced_search_list/readme/CONTRIBUTORS.rst
+++ b/web_advanced_search_list/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Marc Poch Mallandrich <mpoch@planetatic.com>

--- a/web_advanced_search_list/readme/DESCRIPTION.rst
+++ b/web_advanced_search_list/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module adds the 'is in' option to advanced search of char fields.
+
+You can filter listing a list of patterns separated by pipe character (|).

--- a/web_advanced_search_list/readme/USAGE.rst
+++ b/web_advanced_search_list/readme/USAGE.rst
@@ -1,0 +1,6 @@
+To use this module, you need to:
+
+In advanced search filter:
+ 1. Select a Char field.
+ 2. Select "is in" operator
+ 3. Input the list of patterns separated by pipe char (|).

--- a/web_advanced_search_list/static/src/js/search.js
+++ b/web_advanced_search_list/static/src/js/search.js
@@ -1,0 +1,24 @@
+odoo.define('web_advanced_search_wildcard', function (require) {
+    "use strict";
+
+    var core = require('web.core');
+    var search_filters = require('web.search_filters');
+
+    var _lt = core._lt;
+
+    search_filters.ExtendedSearchProposition.Char.prototype.operators.push(
+        {value: 'in', text: _lt("is in")}
+    );
+
+    search_filters.ExtendedSearchProposition.Char.include({
+        get_domain: function (field, operator) {
+            switch (operator.value) {
+            case '∃': return [[field.name, '!=', false]];
+            case '∄': return [[field.name, '=', false]];
+            case 'in':
+                return [[field.name, 'in', this.get_value().split("|")]];
+            default: return [[field.name, operator.value, this.get_value()]];
+            }
+        },
+    });
+});

--- a/web_advanced_search_list/static/src/js/search.js
+++ b/web_advanced_search_list/static/src/js/search.js
@@ -1,4 +1,4 @@
-odoo.define('web_advanced_search_wildcard', function (require) {
+odoo.define('web_advanced_search_list', function (require) {
     "use strict";
 
     var core = require('web.core');

--- a/web_advanced_search_list/views/template.xml
+++ b/web_advanced_search_list/views/template.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <template id="assets_backend" name="web_advanced_search_list assets" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script type="text/javascript" src="/web_advanced_search_list/static/src/js/search.js"/>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
New module to add the 'is in' option to advanced search of char fields. With this module, in a tree view you can filter by listing patterns separated by pipe char(|).

Usage:
 1. Select a Char field.
 2. Select "is in" operator
 3. Input the list of patterns separated by pipe char (|).

cc: @PlanetaTIC