### PR TITLE
[IMP] web_responsive: Better support for long titles

### DIFF
--- a/web_responsive/README.rst
+++ b/web_responsive/README.rst
@@ -127,6 +127,7 @@ Known issues / Roadmap
   new size. This is Odoo's own limitation.
 * App navigation with keyboard.
 * Make it more beautiful. Maybe OCA-branded?
+* Handle long titles on forms in a better way
 
 Bug Tracker
 ===========

--- a/web_responsive/readme/ROADMAP.rst
+++ b/web_responsive/readme/ROADMAP.rst
@@ -4,3 +4,4 @@
   new size. This is Odoo's own limitation.
 * App navigation with keyboard.
 * Make it more beautiful. Maybe OCA-branded?
+* Handle long titles on forms in a better way

--- a/web_responsive/static/description/index.html
+++ b/web_responsive/static/description/index.html
@@ -464,6 +464,7 @@ you should reload the web client to get the full experience for that
 new size. This is Odoo’s own limitation.</li>
 <li>App navigation with keyboard.</li>
 <li>Make it more beautiful. Maybe OCA-branded?</li>
+<li>Handle long titles on forms in a better way</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -16,6 +16,15 @@
     transform: none !important;
 }
 
+// Support for long titles
+@include media-breakpoint-up(md) {
+    .o_form_view .oe_button_box + .oe_title,
+    .o_form_view .oe_button_box + .oe_avatar + .oe_title {
+        /* Button-box has a hardcoded width of 132px per button and have three columns */
+        width: calc(100% - 450px);
+    }
+}
+
 // Main navbar (with apps menu, user menu, debug menu...)
 @include media-breakpoint-down(sm) {
     .o_main_navbar {
@@ -348,8 +357,6 @@ html .o_web_client .o_main .o_main_content {
 
         // Support for long title (with ellipsis)
         .oe_title {
-            width: initial;
-
             span.o_field_widget {
                 max-width: 100%;
                 text-overflow: ellipsis;
@@ -370,6 +377,11 @@ html .o_web_client .o_main .o_main_content {
             .oe_title,
             {
                 max-width: 100%;
+            }
+
+            .oe_button_box + .oe_title,
+            .oe_button_box + .oe_avatar + .oe_title {
+                width: 100%;
             }
 
             // Avoid overflow on modals


### PR DESCRIPTION
![long_title](https://user-images.githubusercontent.com/731270/65970830-82478380-e467-11e9-8afe-e40f0c17736f.gif)

Rules used:

* Small screens uses 100%
* Other screen sizes uses 100% - (132px * 3 + Some margin) => Size of button * max colums (+ added some margin) [132px it's a hardcoded size]

Cc @tecnativa