### PR TITLE
web_tree_image_tooltip: add image width and height limit in tooltip

### DIFF
--- a/web_tree_image_tooltip/static/src/js/tooltip.js
+++ b/web_tree_image_tooltip/static/src/js/tooltip.js
@@ -11,7 +11,7 @@ odoo.define('web_tree_image_tooltip.web_tree_image_tooltip',
             var img_src =
                 $(event.currentTarget).children('.img-fluid').attr('src')
             $(event.currentTarget).tooltip({
-                title: "<img src="+img_src+" />",
+                title: "<img src="+img_src+" class='tooltip_image' />",
                 delay: 0,
             }).tooltip('show');
         }

--- a/web_tree_image_tooltip/static/src/scss/common.scss
+++ b/web_tree_image_tooltip/static/src/scss/common.scss
@@ -1,3 +1,8 @@
 .o_image_cell .o_field_image img{
     width:30px;
 }
+
+.tooltip_image {
+    max-width:80vw;
+    max-height:80vh;
+}


### PR DESCRIPTION
Before this PR, size of images in tooltips are not limited. If image is bigger than the screen, it cuts off like in example screenshot below.
The tooltip with large image might also cover up the thumbnail image, where the mouse is hovering, which makes the browser think, that the mouse moved away and tooltip should not be shown anymore. The tooltip gets removed, the mouse starts hovering the thumbnail again, which in turn displays the tooltip again. This results in flickering loop of tooltip appearing and disappearing.

Before:
![image](https://user-images.githubusercontent.com/38809768/67678706-fbb39280-f98f-11e9-98b5-845d9899f322.png)

After:
![image](https://user-images.githubusercontent.com/38809768/67678738-10902600-f990-11e9-97d8-1381b3e7a392.png)
