### PR TITLE
[12.0][ADD] web_widget_url_translatable

### DIFF
--- a/web_widget_url_translatable/__manifest__.py
+++ b/web_widget_url_translatable/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    'name': 'Translatable URL widget',
+    'version': '12.0.1.0.0',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
+    'category': 'Web',
+    'depends': ['web'],
+    'summary': """Enable to set translation on fields using URL widget""",
+    'website': 'https://github.com/OCA/web',
+    'installable': True,
+    'license': 'LGPL-3',
+    'data': ['views/assets.xml'],
+}

--- a/web_widget_url_translatable/readme/CONTRIBUTORS.rst
+++ b/web_widget_url_translatable/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/web_widget_url_translatable/readme/DESCRIPTION.rst
+++ b/web_widget_url_translatable/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module extends the URL widget, so it works the same than other widget with translatable fields.
+In edition mode the button that allows to open the tranlation view is displayed.

--- a/web_widget_url_translatable/static/src/js/fields.js
+++ b/web_widget_url_translatable/static/src/js/fields.js
@@ -1,0 +1,24 @@
+// Copyright 2019 Camptocamp SA
+// License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+//
+odoo.define('web_widget_url_translatable', function (require) {
+    "use strict";
+
+    var basic_fields = require('web.basic_fields');
+
+    basic_fields.UrlWidget.include(basic_fields.TranslatableFieldMixin);
+    basic_fields.UrlWidget.include({
+
+    /* Add translation button */
+
+        _renderEdit: function () {
+            var def = this._super.apply(this, arguments);
+            if (this.field.size && this.field.size > 0) {
+                this.$el.attr('maxlength', this.field.size);
+            }
+            this.$el = this.$el.add(this._renderTranslateButton());
+            return def;
+        },
+    });
+
+});

--- a/web_widget_url_translatable/views/assets.xml
+++ b/web_widget_url_translatable/views/assets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="assets_backend" inherit_id="web.assets_backend" name="Widget URL translatable">
+        <xpath expr="script[last()]" position="after">
+            <script type="text/javascript" src="/web_widget_url_translatable/static/src/js/fields.js"/>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
This module extends the URL widget, so it works the same than other
widget with translatable fields.
In edition mode the button that allows to open the tranlation view
is displayed.