### PR TITLE
[11.0] fix menu search consider parents group also

### DIFF
--- a/web_responsive/models/__init__.py
+++ b/web_responsive/models/__init__.py
@@ -2,3 +2,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import inherited_res_users
+from . import ir_ui_menu

--- a/web_responsive/models/ir_ui_menu.py
+++ b/web_responsive/models/ir_ui_menu.py
@@ -1,0 +1,27 @@
+from odoo import models, api
+
+from odoo.http import request
+
+
+class IrUiMenu(models.Model):
+    _inherit = "ir.ui.menu"
+
+    @api.multi
+    def _visibility_parent_filter(self, debug=False):
+        groups = self.env.user.groups_id
+        if not debug:
+            groups = groups - self.env.ref("base.group_no_one")
+        return self.filtered(
+            lambda menu: (not menu.groups_id or menu.groups_id & groups)
+            and (
+                not menu.parent_id
+                or menu.parent_id._visibility_parent_filter(debug)
+            )
+        ).ids
+
+    @api.multi
+    @api.returns("self")
+    def _filter_visible_menus1(self):
+        menus = super(IrUiMenu, self)._filter_visible_menus()
+        visible_ids = self._visibility_parent_filter(request and request.debug)
+        return menus.filtered(lambda menu: menu.id in visible_ids)


### PR DESCRIPTION
from demo user or any user if you do not have access to parent menu and if you search for the sub-menu and it is displaying the result including sub-menu even though the parent menu has restriction based on group.
 