### PR TITLE
[12.0]  web_widget_x2many_2d_matrix: keyboard navigation

### DIFF
--- a/web_widget_x2many_2d_matrix/readme/CONTRIBUTORS.rst
+++ b/web_widget_x2many_2d_matrix/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 * `CorporateHub <https://corporatehub.eu/>`__
 
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
+* Pablo Fuentes <pablo@studio73.es>

--- a/web_widget_x2many_2d_matrix/readme/ROADMAP.rst
+++ b/web_widget_x2many_2d_matrix/readme/ROADMAP.rst
@@ -5,8 +5,6 @@
 
 * Support limit total records in the matrix. Ref: https://github.com/OCA/web/issues/901
 
-* Support cell traversal through keyboard arrows.
-
 * Entering the widget from behind by pressing ``Shift+TAB`` in your keyboard
   will enter into the 1st cell until https://github.com/odoo/odoo/pull/26490
   is merged.

--- a/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
@@ -10,7 +10,7 @@ odoo.define('web_widget_x2many_2d_matrix.X2Many2dMatrixRenderer', function (requ
     var core = require('web.core');
     var field_utils = require('web.field_utils');
     var _t = core._t;
-    
+
     var FIELD_CLASSES = {
         float: 'o_list_number',
         integer: 'o_list_number',
@@ -434,12 +434,18 @@ odoo.define('web_widget_x2many_2d_matrix.X2Many2dMatrixRenderer', function (requ
                 index = widgets.indexOf(event.target),
                 first = index === 0,
                 last = index === widgets.length - 1,
-                move = 0;
+                move = 0,
+                row = Math.floor(index / this.columns.length),
+                direction = event.data.direction;
             // Guess if we have to move the focus
-            if (event.data.direction === "next" && !last) {
+            if (~["next", "next_line", "right"].indexOf(direction) && !last) {
                 move = 1;
-            } else if (event.data.direction === "previous" && !first) {
+            } else if (~["previous", "left"].indexOf(direction) && !first) {
                 move = -1;
+            } else if (direction === "up" && row) {
+                move = this.columns.length * -1;
+            } else if (direction === "down" && row + 1 < this.rows.length) {
+                move = this.columns.length;
             }
             // Move focus
             if (move) {

--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -223,6 +223,15 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
             } catch (error) {
                 this._backwards = false;
             }
+            var x2many_matrix = this.renderer;
+            // Copied from 2d_matrix_renderer.js _onNavigationMove#L452-L454
+            var target = x2many_matrix.__parentedChildren[0];
+            if (this._backwards) {
+                target = x2many_matrix.__parentedChildren.slice(-1)[0];
+            }
+            var id = target.record.id;
+            var index = x2many_matrix.allFieldWidgets[id].indexOf(target);
+            x2many_matrix._activateFieldWidget(target.record, index, {inc: 0});
             var result = this._super.apply(this, arguments);
             delete this._backwards;
             return result;


### PR DESCRIPTION
_1st Commit_ - **Navigation**
* ➡️, `TAB`, `ENTER` :  Move right
* ⬅️: Move Left
* ⬆️: Previous row
* ⬇️: Next row

_2nd commit_
I'am not 100% sure if is necessary but testing on [runbot](http://3395285-12-0-6c456a.runbot1-2.odoo-community.org/web?db=3395285-12-0-6c456a-all) with the module `sale_order_variant_mgmt`

Without the commit:
* Pressing `TAB` having focus on `Template` **doesn't** change focus to the variants matrix.

With the commit:
* Pressing `TAB` having focus on `Template` **does** change focus to the variants matrix.

![Captura de pantalla 2019-11-08 a las 12 10 59](https://user-images.githubusercontent.com/4355395/68473422-37b5e580-0223-11ea-914a-59c90a194214.png)

