### PR TITLE
[FIX] web_view_calendar_column: Set license of the widget as Open Source

### DIFF
--- a/web_view_calendar_column/static/src/js/calendar_renderer.js
+++ b/web_view_calendar_column/static/src/js/calendar_renderer.js
@@ -70,6 +70,7 @@ odoo.define('web_view_calendar_column.CalendarRenderer', function (require) {
                 //eventResourceEditable: true, // except for between resources
                 height: 'parent',
                 unselectAuto: false,
+                schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
                 locale: locale, // reset locale when fullcalendar has already been instanciated before now
             });
 


### PR DESCRIPTION
The widget was not being correctly licensed, and a warning was shown on the bottom left

![imagen](https://user-images.githubusercontent.com/28590170/68495987-a27e1580-0251-11ea-90e2-fd6f06eccc0c.png)

The change sets the widget as a GPL Open Source Compatible code.