### PR TITLE
[FIX] web_responsive: modify action handling

### DIFF
--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -442,22 +442,24 @@ odoo.define('web_responsive', function (require) {
         * The executed action
         */
         _hideMenusByAction: function (action) {
-            var uniq_sel = '[data-action-id='+action.id+']';
-            // Need close AppDrawer?
-            var menu_apps_dropdown = document.querySelector(
-                '.o_menu_apps .dropdown');
-            $(menu_apps_dropdown).has('.dropdown-menu.show')
-                .has(uniq_sel).find('> a').dropdown('toggle');
-            // Need close Sections Menu?
-            // TODO: Change to 'hide' in modern Bootstrap >4.1
-            var menu_sections = document.querySelector(
-                '.o_menu_sections li.show');
-            $(menu_sections).has(uniq_sel).find('.dropdown-toggle')
-                .dropdown('toggle');
-            // Need close Mobile?
-            var menu_sections_mobile = document.querySelector(
-                '.o_menu_sections.show');
-            $(menu_sections_mobile).has(uniq_sel).collapse('hide');
+            _.defer(function () {
+                var uniq_sel = '[data-action-id='+action.id+']';
+                // Need close AppDrawer?
+                var menu_apps_dropdown = document.querySelector(
+                    '.o_menu_apps .dropdown');
+                $(menu_apps_dropdown).has('.dropdown-menu.show')
+                    .has(uniq_sel).find('> a').dropdown('toggle');
+                // Need close Sections Menu?
+                // TODO: Change to 'hide' in modern Bootstrap >4.1
+                var menu_sections = document.querySelector(
+                    '.o_menu_sections li.show');
+                $(menu_sections).has(uniq_sel).find('.dropdown-toggle')
+                    .dropdown('toggle');
+                // Need close Mobile?
+                var menu_sections_mobile = document.querySelector(
+                    '.o_menu_sections.show');
+                $(menu_sections_mobile).has(uniq_sel).collapse('hide');
+            });
         },
 
         _handleAction: function (action) {


### PR DESCRIPTION
Previous this commit, AppMenu doesn't hide in some situations.

**Steps to reproduce:** (sometimes works, sometimes doesn't)
From Discuss App (refresh) open AppMenu and search some menu, select the second in the list and press enter.
_The action is launched correctly, but the AppMenu doesn't hide._

cc @tecnativa TT20688