### PR TITLE
[FIX] web_widget_x2many_2d_matrix: Wrong widget

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/js/abstract_view_matrix_limit_extend.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/abstract_view_matrix_limit_extend.js
@@ -1,17 +1,16 @@
 odoo.define( "web_widget_x2many_2d_matrix.matrix_limit_extend", function (require) {
-"use strict";
+    "use strict";
 
-        var AbstractView = require("web.AbstractView");
+    var FormView = require("web.FormView");
 
-        AbstractView.include({
-            // We extend this method so that the view is not limited to
-            // just 40 cells when the 'x2many_2d_matrix' widget is used.
-            _setSubViewLimit: function (attrs) {
-                this._super(attrs);
-                if (attrs.widget === "x2many_2d_matrix") {
-                    attrs.limit = Infinity;
-                }
-            },
-        });
-    }
-);
+    FormView.include({
+        // We extend this method so that the view is not limited to
+        // just 40 cells when the 'x2many_2d_matrix' widget is used.
+        _setSubViewLimit: function (attrs) {
+            this._super(attrs);
+            if (attrs.widget === "x2many_2d_matrix") {
+                attrs.limit = Infinity;
+            }
+        },
+    });
+});


### PR DESCRIPTION
In previous versions `_setSubViewLimit` was defined at AbstractView widget but in v12 is defined at FormView widget

**Previous**
![Captura de pantalla 2019-11-22 a las 17 56 39](https://user-images.githubusercontent.com/4355395/69445697-273d5900-0d53-11ea-9db3-eef6407c374e.png)

**Now**
![Captura de pantalla 2019-11-22 a las 18 00 14](https://user-images.githubusercontent.com/4355395/69445710-2dcbd080-0d53-11ea-85ec-ea3e442767d2.png)
