### PR TITLE
[9.0][IMP] web_m2x_options: new option 'search_delay' on Many2one

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -47,7 +47,7 @@ in the field's options dict
 
   Number of displayed record in drop-down panel
 
-``delay`` *int* (Default: openerp default value is ``200``)
+``search_delay`` *int* (Default: openerp default value is ``200``)
 
   Number of milliseconds after a user input to trigger the ``name_search``.
 
@@ -95,9 +95,9 @@ If you disable one option, you can enable it for particular field by setting "cr
 
   Number of displayed record in drop-down panel for all fields in the odoo instance
 
-``web_m2x_options.m2o_delay`` *int* (Default: openerp default value is ``200``)
+``web_m2x_options.m2o_search_delay`` *int* (Default: openerp default value is ``200`` for all data models)
 
-  Number of milliseconds after a user input to trigger the ``name_search`` for all fields in the odoo instance.
+  A JSON object where each key is the name of a a data model, and the value is a number of milliseconds beyond which the user input triggers the ``name_search``.
 
 ``web_m2x_options.search_more`` *boolean* (Default: default value is ``False``)
 
@@ -108,6 +108,7 @@ To add these parameters go to Configuration -> Technical -> Parameters -> System
 - web_m2x_options.create: False
 - web_m2x_options.create_edit: False
 - web_m2x_options.m2o_dialog: False
+- web_m2x_options.m2o_search_delay: {"res.partner": 800}
 - web_m2x_options.limit: 10
 - web_m2x_options.search_more: True
 

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -47,6 +47,10 @@ in the field's options dict
 
   Number of displayed record in drop-down panel
 
+``delay`` *int* (Default: openerp default value is ``200``)
+
+  Number of milliseconds after a user input to trigger the ``name_search``.
+
 ``search_more`` *boolean*
 
   Used to force disable/enable search more button.
@@ -90,6 +94,10 @@ If you disable one option, you can enable it for particular field by setting "cr
 ``web_m2x_options.limit`` *int* (Default: openerp default value is ``7``)
 
   Number of displayed record in drop-down panel for all fields in the odoo instance
+
+``web_m2x_options.m2o_delay`` *int* (Default: openerp default value is ``200``)
+
+  Number of milliseconds after a user input to trigger the ``name_search`` for all fields in the odoo instance.
 
 ``web_m2x_options.search_more`` *boolean* (Default: default value is ``False``)
 

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -266,6 +266,9 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
 
         set_option_autocomplete_delay: function() {
             var self = this;
+            if (_.isUndefined(self.field.relation)) {
+                return;
+            }
             // Handle the 'search_delay' option
             //  - global m2o_search_delay from ir_config_parameter
             if ('web_m2x_options.m2o_search_delay' in self.view.ir_options) {
@@ -282,7 +285,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             }
             // Change the autocomplete 'delay' option
             if (!_.isUndefined(self.search_delay)) {
-                self.$input.autocomplete("option", "delay", self.search_delay);
+                self.$el.find("input").autocomplete("option", "delay", self.search_delay);
             }
         },
     });

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -271,12 +271,14 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             }
             // Handle the 'search_delay' option
             //  - global m2o_search_delay from ir_config_parameter
-            if ('web_m2x_options.m2o_search_delay' in self.view.ir_options) {
-                var m2o_search_delay = JSON.parse(
-                    self.view.ir_options['web_m2x_options.m2o_search_delay']
-                )
-                if (self.field.relation in m2o_search_delay) {
-                  self.search_delay = parseInt(m2o_search_delay[self.field.relation]);
+            if (!_.isUndefined(self.view.ir_options)) {
+                if ('web_m2x_options.m2o_search_delay' in self.view.ir_options) {
+                    var m2o_search_delay = JSON.parse(
+                        self.view.ir_options['web_m2x_options.m2o_search_delay']
+                    )
+                    if (self.field.relation in m2o_search_delay) {
+                        self.search_delay = parseInt(m2o_search_delay[self.field.relation]);
+                    }
                 }
             }
             // - 'search_delay' option on field takes precedence

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -17,7 +17,8 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                    'web_m2x_options.create_edit',
                    'web_m2x_options.limit',
                    'web_m2x_options.search_more',
-                   'web_m2x_options.m2o_dialog',];
+                   'web_m2x_options.m2o_dialog',
+                   'web_m2x_options.m2o_delay',];
 
     // In odoo 9.c FielMany2One is not exposed by form_relational
     // To bypass this limitation we use the widget registry to get the
@@ -256,6 +257,24 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             });
 
             return def;
+        },
+
+        render_editable: function() {
+            this._super();
+            // Get the options
+            // FIXME: could it be avoided here and get benefits
+            // from the call already done in 'start'?
+            this.get_options();
+            // Set the delay beyond which the name_search request is triggered
+            if (!_.isUndefined(this.view.ir_options['web_m2x_options.m2o_delay'])) {
+                this.delay = parseInt(this.view.ir_options['web_m2x_options.m2o_delay']);
+            }
+            if (typeof this.options.delay === 'number') {
+                this.delay = this.options.delay;
+            }
+            if (!_.isUndefined(this.delay)) {
+                this.$input.autocomplete("option", "delay", this.delay);
+            }
         }
     });
 


### PR DESCRIPTION
This option allows to delay the 'name_search' RPC request done when the
user write in Many2one fields.

By default in Odoo the request is performed after 200ms, which can be too fast,
generating a lot of RPC queries stressing uselessly the server.
Increasing this value (for instance to 800ms) allows to get better performance
as the server is less stressed.

As other options, it can be set globally (`ir.config_parameter`) or at
the field level.