### PR TITLE
[IMP] web_responsive: Document Viewer key events

### DIFF
--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -542,9 +542,7 @@ odoo.define('web_responsive', function (require) {
         start: function () {
             core.bus.on('keydown', this, this._onKeydown);
             core.bus.on('keyup', this, this._onKeyUp);
-            const res = this._super.apply(this, arguments);
-            console.log(this.$el);
-            return res;
+            return this._super.apply(this, arguments);
         },
 
         destroy: function () {

--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -527,13 +527,29 @@ odoo.define('web_responsive', function (require) {
     // `KeyboardNavigationMixin` is used upstream
     AbstractWebClient.include(KeyboardNavigationShiftAltMixin);
 
-    // DocumentViewer: Add support to maximize/minimize
+    // DocumentViewer: Add support to maximize/minimize and changes key events
+    // to listen globally
     DocumentViewer.include({
-        events: _.extend(DocumentViewer.prototype.events, {
+        events: _.extend(_.omit(DocumentViewer.prototype.events, [
+            'keydown',
+            'keyup',
+        ]), {
             'click .o_maximize_btn': '_onClickMaximize',
             'click .o_minimize_btn': '_onClickMinimize',
             'shown.bs.modal': '_onShownModal',
         }),
+
+        start: function () {
+            core.bus.on('keydown', this, this._onKeydown);
+            core.bus.on('keyup', this, this._onKeyUp);
+            return this._super.apply(this, arguments);
+        },
+
+        destroy: function () {
+            core.bus.off('keydown', this, this._onKeydown);
+            core.bus.off('keyup', this, this._onKeyUp);
+            this._super.apply(this, arguments);
+        },
 
         _onShownModal: function () {
             // Disable auto-focus to allow to use controls in edit mode.

--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -542,7 +542,9 @@ odoo.define('web_responsive', function (require) {
         start: function () {
             core.bus.on('keydown', this, this._onKeydown);
             core.bus.on('keyup', this, this._onKeyUp);
-            return this._super.apply(this, arguments);
+            const res = this._super.apply(this, arguments);
+            console.log(this.$el);
+            return res;
         },
 
         destroy: function () {


### PR DESCRIPTION
This fixes #1476 changing key events listeners to main events instead of widget events.

PDF Viewer uses iframe and Odoo bus doesn't listen events from there. Can't use 'Document Viewer' keybinds when the active element is the PDF Viewer.

cc @tecnativa