### PR TITLE
[FIX] web_responsive: make followers dropdown usable

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -345,6 +345,11 @@ html .o_web_client .o_action_manager .o_action {
             padding-top: 0;
         }
 
+        .o_chatter_topbar {
+            height: auto;
+            flex-wrap: wrap-reverse;
+        }
+
         // Sticky statusbar
         .o_form_statusbar {
             position: sticky;
@@ -464,9 +469,6 @@ html .o_web_client .o_action_manager .o_action {
                 }
 
                 .o_chatter_topbar {
-                    height: auto;
-                    flex-wrap: wrap-reverse;
-
                     > .o_topbar_right_area {
                         flex: 1 0 auto;
                         flex-wrap: wrap;
@@ -516,7 +518,6 @@ html .o_web_client .o_action_manager .o_action {
                         position: sticky;
                         background-color: $o-view-background-color;
                         z-index: 1;
-                        overflow-x: auto;
 
                         // Scrollable input text to avoid hide conversation & buttons
                         .o_composer_text_field {


### PR DESCRIPTION
Fix a visual glitch that impeded using the followers dropdown with a sided chatter.

Before:

![Peek 19-01-2020 10-09](https://user-images.githubusercontent.com/973709/72679320-f1dc8f80-3aa5-11ea-937d-d078a38ccb85.gif)

After:

![Peek 19-01-2020 10-22](https://user-images.githubusercontent.com/973709/72679326-f6a14380-3aa5-11ea-9641-9f96c2fbfb3b.gif)
