### PR TITLE
[FIX] web_responsive: Remove auto-focus for the document viewer modal

### DIFF
--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -532,14 +532,15 @@ odoo.define('web_responsive', function (require) {
         events: _.extend(DocumentViewer.prototype.events, {
             'click .o_maximize_btn': '_onClickMaximize',
             'click .o_minimize_btn': '_onClickMinimize',
+            'shown.bs.modal': '_onShownModal',
         }),
 
-        start: function () {
-            this.$btnMaximize = this.$('.o_maximize_btn');
-            this.$btnMinimize = this.$('.o_minimize_btn');
-            return this._super.apply(this, arguments);
+        _onShownModal: function () {
+            // Disable auto-focus to allow to use controls in edit mode.
+            // This only affects the active modal.
+            // More info: https://stackoverflow.com/a/14795256
+            $(document).off('focusin.modal');
         },
-
         _onClickMaximize: function () {
             this.$el.removeClass('o_responsive_document_viewer');
         },


### PR DESCRIPTION
This commit disables auto-focus for document viewer modal to don't block edition mode.

cc @tecnativa TT21363