### PR TITLE
[IMP] web_responsive: Document Viewer key events

### DIFF
--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -529,11 +529,30 @@ odoo.define('web_responsive', function (require) {
 
     // DocumentViewer: Add support to maximize/minimize
     DocumentViewer.include({
-        events: _.extend(DocumentViewer.prototype.events, {
+        // Widget 'keydown' and 'keyup' events are only dispatched when
+        // this.$el is active, but now the modal have buttons that can obtain
+        // the focus. For this reason we now listen core events, that are
+        // dispatched every time.
+        events: _.extend(_.omit(DocumentViewer.prototype.events, [
+            'keydown',
+            'keyup',
+        ]), {
             'click .o_maximize_btn': '_onClickMaximize',
             'click .o_minimize_btn': '_onClickMinimize',
             'shown.bs.modal': '_onShownModal',
         }),
+
+        start: function () {
+            core.bus.on('keydown', this, this._onKeydown);
+            core.bus.on('keyup', this, this._onKeyUp);
+            return this._super.apply(this, arguments);
+        },
+
+        destroy: function () {
+            core.bus.off('keydown', this, this._onKeydown);
+            core.bus.off('keyup', this, this._onKeyUp);
+            this._super.apply(this, arguments);
+        },
 
         _onShownModal: function () {
             // Disable auto-focus to allow to use controls in edit mode.


### PR DESCRIPTION
This fixes #1476 changing key events listeners to main events instead of widget events.

PDF Viewer uses iframe and Odoo bus doesn't listen events from there. Can't use 'Document Viewer' keybinds when the active element is the PDF Viewer.

cc @Tecnativa