### PR TITLE
[12.0] [FIX] Tree m2o clickable: call to get_formview_action()

### DIFF
--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -11,6 +11,7 @@ odoo.define('web_tree_many2one_clickable.many2one_clickable', function (require)
 
     var ListRenderer = require('web.ListRenderer');
     var ListFieldMany2One = require('web.relational_fields').ListFieldMany2One;
+    var rpc = require('web.rpc');
 
     ListRenderer.include({
         _renderBodyCell: function (record, node, colIndex, options) {
@@ -48,12 +49,12 @@ odoo.define('web_tree_many2one_clickable.many2one_clickable', function (require)
                     ev.preventDefault();
                     ev.stopPropagation();
 
-                    self.do_action({
-                        type: 'ir.actions.act_window',
-                        res_model: self.field.relation,
-                        res_id: self.value.res_id,
-                        views: [[false, 'form']],
-                        target: 'target',
+                    rpc.query({
+                        model: self.field.relation,
+                        method: 'get_formview_action',
+                        args: [[self.value.res_id]],
+                    }).then(function (action) {
+                        return self.do_action(action);
                     });
                 });
                 this.$el.append($a);


### PR DESCRIPTION
When clicking on a m2o field on a form view, the method 'get_formview_action()' is called in order to get the action.
This method can be overridden in order to return specific action for a certain model.

IMO, we should expect the same behaviour when clicking on the m2o field on a tree view.