### PR TITLE
[12.0] [ADD] m2x_options: Option open for One2Many fields

### DIFF
--- a/web_m2x_options/readme/USAGE.rst
+++ b/web_m2x_options/readme/USAGE.rst
@@ -37,7 +37,7 @@ in the field's options dict
 
 ``open`` *boolean* (Default: ``False``)
 
-  Makes many2many_tags buttons that open the linked resource
+  Makes many2many_tags and one2many rows buttons that open the linked resource
 
 ``no_color_picker`` *boolean* (Default: ``False``)
 

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -14,6 +14,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
     var _t = core._t,
         FieldMany2ManyTags = relational_fields.FieldMany2ManyTags,
         FieldMany2One = relational_fields.FieldMany2One,
+        FieldOne2Many = relational_fields.FieldOne2Many,
         FormFieldMany2ManyTags = relational_fields.FormFieldMany2ManyTags;
 
     var web_m2x_options = rpc.query({
@@ -352,6 +353,27 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                     })
                 }
             }
+        },
+    });
+
+    FieldOne2Many.include({
+        _onOpenRecord: function (ev) {
+            var self = this;
+            var open = this.nodeOptions.open;
+            if (open && self.mode === 'readonly') {
+                ev.stopPropagation();
+                var id = ev.data.id;
+                var res_id = self.record.data[self.name].data.filter(line => line.id === id)[0].res_id;
+                self._rpc({
+                    model: self.field.relation,
+                    method: 'get_formview_action',
+                    args: [[res_id]],
+                }).then(function (action) {
+                    return self.do_action(action);
+                });
+            } else {
+                return this._super.apply(this, arguments);
+            };
         },
     });
 


### PR DESCRIPTION
With 'open' option, clicking on a row of a o2m field will open the view for the record in fullscreen rather than in a popup.