### PR TITLE
[FIX] web_responsive: usable search buttons in md screens

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -232,6 +232,29 @@ html .o_web_client .o_main .o_main_content {
 }
 
 // Control panel (breadcrumbs, search box, buttons...)
+.o_search_options {
+    flex-grow: 1;
+
+    > div {
+        width: 100%;
+
+
+        > .btn-group {
+            max-width: 33%;
+
+            .o_dropdown_toggler_btn {
+                max-width: 100%;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+    }
+}
+
+.o_pager_counter {
+    white-space: nowrap;
+}
+
 @include media-breakpoint-down(sm) {
     .o_control_panel {
         // Arrange buttons to use space better


### PR DESCRIPTION
When the screen wasn't small enough to trigger mobile mode but wasn't big enough to display properly search buttons, those got awkward.

Before:
![2020-01-27_11-58](https://user-images.githubusercontent.com/973709/73173376-1f0bec00-40fd-11ea-9a75-ba4c386329fe.png)

After:
![Peek 27-01-2020 11-59](https://user-images.githubusercontent.com/973709/73173391-23380980-40fd-11ea-8e1c-c4455af8a2fc.gif)


@Tecnativa TT21728