### PR TITLE
[FIX] web_widget_x2many_2d_matrix: Ensure lines order

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -34,8 +34,9 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
          */
         init_params: function () {
             var node = this.attrs;
-            this.by_x_axis = {};
             this.by_y_axis = {};
+            this.x_axis = [];
+            this.y_axis = [];
             this.field_x_axis = node.field_x_axis || this.field_x_axis;
             this.field_y_axis = node.field_y_axis || this.field_y_axis;
             this.field_label_x_axis =
@@ -84,8 +85,9 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
         init_matrix: function () {
             var records = this.recordData[this.name].data;
             // Wipe the content if something still exists
-            this.by_x_axis = {};
             this.by_y_axis = {};
+            this.x_axis = [];
+            this.y_axis = [];
             _.each(records, function (record) {
                 var x = record.data[this.field_x_axis],
                     y = record.data[this.field_y_axis];
@@ -97,18 +99,22 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                     // We have a related record
                     y = y.data.display_name;
                 }
-                this.by_x_axis[x] = this.by_x_axis[x] || {};
                 this.by_y_axis[y] = this.by_y_axis[y] || {};
-                this.by_x_axis[x][y] = record;
                 this.by_y_axis[y][x] = record;
+                if (this.y_axis.indexOf(y) === -1) {
+                    this.y_axis.push(y);
+                }
+                if (this.x_axis.indexOf(x) === -1) {
+                    this.x_axis.push(x);
+                }
             }.bind(this));
             // Init columns
             this.columns = [];
-            $.each(this.by_x_axis, function (x) {
+            _.each(this.x_axis, function (x) {
                 this.columns.push(this._make_column(x));
             }.bind(this));
             this.rows = [];
-            $.each(this.by_y_axis, function (y) {
+            _.each(this.y_axis, function (y) {
                 this.rows.push(this._make_row(y));
             }.bind(this));
             this.matrix_data = {
@@ -156,7 +162,7 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 },
                 'data': [],
             };
-            $.each(self.by_x_axis, function (x) {
+            _.each(self.x_axis, function (x) {
                 row.data.push(self.by_y_axis[y][x]);
             });
             return row;


### PR DESCRIPTION
As objects are unordered collections of properties, we ensure incoming lines order by using lists

Same fix as in #792 but using ES5 compatible syntax