### PR TITLE
[12.0][IMP] web_responsive: Payment info popover position

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -496,6 +496,14 @@ html .o_web_client .o_main .o_main_content {
 
                     > .o_form_sheet {
                         min-width: unset;
+
+                        .oe_subtotal_footer .popover {
+                            /* This is an inaccurate workaround for a problem with how Odoo places the popover
+                             * See: https://github.com/odoo/odoo/blob/12.0/addons/account/static/src/js/account_payment_field.js#L83
+                             */
+                            position: fixed !important;
+                            top: 11.4em !important;
+                        }
                     }
                 }
 


### PR DESCRIPTION
This PR try to mitigate the problem with payment info popover placement when users have the sided chatter enabled...

Before:
![popover_bad](https://user-images.githubusercontent.com/731270/73565421-cc666300-4461-11ea-8125-6396ebf689f7.gif)

After:
![popover_good](https://user-images.githubusercontent.com/731270/73565436-d25c4400-4461-11ea-93f1-e98f98740871.gif)

cc @tecnativa TT21756