### PR TITLE
[FIX] if nocreate=1 then also see that as true

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -87,7 +87,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             var is_string = typeof option === 'string'
             var is_bool = typeof option === 'boolean'
             if (is_string) {
-                return option === 'true' || option === 'True'
+                return option === 'true' || option === 'True' || option === '1'
             } else if (is_bool) {
                 return option
             }


### PR DESCRIPTION
Some people in their custom modules have used 'no_create=1' instead of True to disable create or edit, which [works](https://github.com/OCA/OCB/blob/10.0/addons/web/static/src/js/views/form_common.js#L235) in standard Odoo. But when `web_m2x_options` is installed, it will stop working, which is IMO undesired/unintended behavior.