### PR TITLE
[12.0][FIX] - advanced search, combination of several OR operators

### DIFF
--- a/web_advanced_search/static/src/js/web_advanced_search.js
+++ b/web_advanced_search/static/src/js/web_advanced_search.js
@@ -47,6 +47,7 @@ odoo.define("web_advanced_search", function (require) {
             this._super(parent);
             this.model = model;
             this.domain = new Domain(domain);
+            this.domain_array = domain;
         },
 
         /**
@@ -55,16 +56,15 @@ odoo.define("web_advanced_search", function (require) {
          * @returns {Object} In the format expected by `web.FiltersMenu`.
          */
         get_filter: function () {
-            var domain_array = this.domain.toArray();
             return {
                 attrs: {
-                    domain: domain_array,
+                    domain: this.domain_array,
                     // TODO Remove when merged
                     // https://github.com/odoo/odoo/pull/25922
                     string: human_domain.getHumanDomain(
                         this,
                         this.model,
-                        domain_array
+                        this.domain_array
                     ),
                 },
                 children: [],


### PR DESCRIPTION
Fixes: #1518 

There is a problem when converting a domain object to an array.

in the case of a combination of several OR operators, the retroconversion into an array
from the domain object is not equal to the original array used for initialization.

The problem can be related to the initialization of the domain object or to the
conversion to an array, but in any case, it is out of this PR scope.

The humanDomain needs an array domain, which mean that the conversion and the
retro-conversion are useless in this case.