### PR TITLE
[12.0][IMP] web_notify: add channels only if not done already

### DIFF
--- a/web_notify/static/src/js/web_client.js
+++ b/web_notify/static/src/js/web_client.js
@@ -26,15 +26,26 @@ odoo.define('web_notify.WebClient', function (require) {
                 this.channel_info,
                 this.channel_default,
             ];
-            this.call('bus_service', 'addChannel', this.channel_success);
-            this.call('bus_service', 'addChannel', this.channel_danger);
-            this.call('bus_service', 'addChannel', this.channel_warning);
-            this.call('bus_service', 'addChannel', this.channel_info);
-            this.call('bus_service', 'addChannel', this.channel_default);
+
+            // startPolling to get this new tab registered,
+            // in order to be able to call isMasterTab
+            this.call('bus_service', 'startPolling');
+
+            // - no need to add channels again if it was done already
+            // - this is also a workaround for the infinite loop issue
+            //   that occures when user logs in as a different user
+            //   while still being logged in 2+ other tabs
+            if(this.call('bus_service', 'isMasterTab')) {
+                this.call('bus_service', 'addChannel', this.channel_success);
+                this.call('bus_service', 'addChannel', this.channel_danger);
+                this.call('bus_service', 'addChannel', this.channel_warning);
+                this.call('bus_service', 'addChannel', this.channel_info);
+                this.call('bus_service', 'addChannel', this.channel_default);
+            }
+
             this.call(
                 'bus_service', 'on', 'notification',
                 this, this.bus_notification);
-            this.call('bus_service', 'startPolling');
         },
         bus_notification: function (notifications) {
             var self = this;


### PR DESCRIPTION
Hi there,

We faced a use case that can lead to a resources exhaustion both on client and server sides when `web_notify` is installed on the instance.

Here's how to reproduce the issue (in your local):
- open a first tab
- open `DevTools > Network`
- log in the instance as `admin`
- duplicate this tab twice (required)
- in the third tab, replace the url in the location bar by `/web/login`
- log in as `demo`

As a consequence:
- Odoo will get stuck in an infinite loop, continuously adding/removing `notify_*` channels (due to the native [crosstab mechanism](https://github.com/odoo/odoo/blob/12.0/addons/bus/static/src/js/crosstab_bus.js#L328))
- these changes will trigger thousands of xhr requests to `/longpolling/poll`, that will:
  - on the client side: accumulate and start using a lot of memory, making the tab very slow ("net:ERR_INSUFFICIENT_RESOURCES") and finally crash
  - on the server side: high load the `gevent` process (reaching limits: "Too many open files" (`ulimit -n`); "The Connection Pool Is Full" (`db_maxconn`))

Here's how it looks:

![out](https://user-images.githubusercontent.com/511258/75146641-19221e80-572e-11ea-8746-d7d101b2a8f3.gif)

Some might argue:
- that the use case is not legit: why would a user log in as a different user in the same browser session?
  - testers do (they should not but they do)
  - some real life  use cases, like the creation and the testing of new users by the admin can lead to that case
- that this should be fixed in odoo instead: true, if you have an idea how to fix it let me know

Meanwhile, here's a commit that fixes the issue.