### PR TITLE
[12.0][FIX] web_translate_dialog: load translation for text field

### DIFF
--- a/web_translate_dialog/models/base.py
+++ b/web_translate_dialog/models/base.py
@@ -25,7 +25,7 @@ class BaseModel(models.BaseModel):
             for name in field_names:
 
                 tr_read_res = self.env['ir.translation'].search_read([
-                    ('name', 'like', '%s,%s' % (self._name, field_names)),
+                    ('name', 'like', '%s,%s' % (self._name, name)),
                     ('res_id', '=', rec_id),
                     ('lang', '!=', 'en_US')
                 ])

--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -215,7 +215,7 @@ var TranslateDialog = Dialog.extend({
                 });
                 if (code === self.view_language) {
                     _.each(text, function(value, key) {
-                        var view_elem = self.view.$('input[name="'+ key + '"]');
+                        var view_elem = self.view.$( ":input[name='" + key +"']")
                         view_elem.val(value).trigger('change');
                     });
                 }


### PR DESCRIPTION
translated field can be saved in input or textarea as there no other possibility to find which type of field has an initial field check for both of them