### PR TITLE
[12.0][FIX][web_m2x_options] when all is undefined, fall back to core's default

### DIFF
--- a/web_m2x_options/static/src/xml/base.xml
+++ b/web_m2x_options/static/src/xml/base.xml
@@ -6,7 +6,7 @@
     <t t-extend="FieldMany2One">
         <t t-jquery=".o_external_button" t-operation="attributes">
             <attribute name="t-if">
-                !(widget.nodeOptions.no_open || widget.nodeOptions.no_open_edit)
+                !(widget.nodeOptions.no_open || widget.nodeOptions.no_open_edit || widget.noOpen)
             </attribute>
         </t>
     </t>


### PR DESCRIPTION
the module as it is fails web's tests, namely https://github.com/OCA/OCB/blob/12.0/addons/web/static/tests/fields/relational_fields_tests.js#L1002

What I propose here is to fall back on https://github.com/OCA/OCB/blob/12.0/addons/web/static/src/js/fields/relational_fields.js#L129 if none of the options are set.