### PR TITLE
[IMP] web_tree_many2one_clickable: Don't break keyboard navigation

### DIFF
--- a/web_tree_many2one_clickable/static/src/css/web_tree_many2one_clickable.scss
+++ b/web_tree_many2one_clickable/static/src/css/web_tree_many2one_clickable.scss
@@ -1,10 +1,17 @@
 td.o_many2one_cell {
-  a {
-    margin-left: 0.5em;
-    visibility: hidden;
-  }
+    a {
+        color: $o-main-text-color !important;
+        &:hover {
+            color: $o-main-text-color !important;
+        }
 
-  &:hover a {
-    visibility: visible;
-  }
+        .many2one_clickable {
+            margin-left: 0.5em;
+            visibility: hidden;
+        }
+    }
+
+    &:hover a.many2one_clickable {
+        visibility: visible;
+    }
 }

--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -32,19 +32,18 @@ odoo.define('web_tree_many2one_clickable.many2one_clickable', function (require)
             var self = this;
 
             if (!this.noOpen && this.value) {
-                // Replace '<a>' element
-                this.$el.removeClass('o_form_uri');
-                this.$el = $('<span/>', {
-                    html: this.$el.html(),
-                    class: this.$el.attr('class') + ' o_field_text',
-                    name: this.$el.attr('name'),
-                });
+                // Disable 'click' events
+                this.$el.off('click');
+                this.$el.on('click', function (ev) {
+                    ev.preventDefault();
+                })
 
                 // Append button
                 var $a = $('<a/>', {
                     href: '#',
                     class: 'o_form_uri btn btn-sm btn-secondary' +
-                           ' fa fa-angle-double-right',
+                           ' fa fa-angle-double-right many2one_clickable',
+                    tabindex: '-1',
                 }).on('click', function (ev) {
                     ev.preventDefault();
                     ev.stopPropagation();


### PR DESCRIPTION
Before, you can't use "TAB" to navigate through all fields:
![before_c](https://user-images.githubusercontent.com/731270/79241609-896a3800-7e73-11ea-8e73-75a88ae1b319.gif)

After, you can!
![after_c](https://user-images.githubusercontent.com/731270/79241614-8c652880-7e73-11ea-88b7-4a29932500db.gif)

cc @tecnativa TT22262