### PR TITLE
[13.0] [FIX] web_m2x_options: quick search filter only if search value

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -258,15 +258,19 @@ odoo.define("web_m2x_options.web_m2x_options", function(require) {
                                             var ids = _.map(results, function(x) {
                                                 return x[0];
                                             });
-                                            dynamicFilters = [
-                                                {
-                                                    description: _.str.sprintf(
-                                                        _t("Quick search: %s"),
-                                                        search_val
-                                                    ),
-                                                    domain: [["id", "in", ids]],
-                                                },
-                                            ];
+                                            if (search_val) {
+                                                dynamicFilters = [
+                                                    {
+                                                        description: _.str.sprintf(
+                                                            _t("Quick search: %s"),
+                                                            search_val
+                                                        ),
+                                                        domain: [["id", "in", ids]],
+                                                    },
+                                                ];
+                                            } else {
+                                                dynamicFilters = [];
+                                            }
                                         }
                                         self._searchCreatePopup(
                                             "search",


### PR DESCRIPTION
Before this commit, an empty filter was applied when opening the search more if nothing in the quick search.

**Behavior before this PR:**

![demo](https://user-images.githubusercontent.com/16916103/79307723-a5afb880-7ef7-11ea-9c0b-cb59a991acbd.gif)
