### PR TITLE
[13.0] [FIX] web_m2x_options: search_more behavior

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -258,15 +258,19 @@ odoo.define("web_m2x_options.web_m2x_options", function(require) {
                                             var ids = _.map(results, function(x) {
                                                 return x[0];
                                             });
-                                            dynamicFilters = [
-                                                {
-                                                    description: _.str.sprintf(
-                                                        _t("Quick search: %s"),
-                                                        search_val
-                                                    ),
-                                                    domain: [["id", "in", ids]],
-                                                },
-                                            ];
+                                            if (search_val) {
+                                                dynamicFilters = [
+                                                    {
+                                                        description: _.str.sprintf(
+                                                            _t("Quick search: %s"),
+                                                            search_val
+                                                        ),
+                                                        domain: [["id", "in", ids]],
+                                                    },
+                                                ];
+                                            } else {
+                                                dynamicFilters = [];
+                                            }
                                         }
                                         self._searchCreatePopup(
                                             "search",

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -232,57 +232,59 @@ odoo.define("web_m2x_options.web_m2x_options", function(require) {
                             self.ir_options["web_m2x_options.search_more"]
                         );
 
-                    if (values.length > self.limit) {
+                    if (
+                        (values.length > self.limit && search_more_undef) ||
+                        can_search_more ||
+                        search_more
+                    ) {
                         values = values.slice(0, self.limit);
-                        if (can_search_more || search_more_undef || search_more) {
-                            values.push({
-                                label: _t("Search More..."),
-                                action: function() {
-                                    var prom = [];
-                                    if (search_val !== "") {
-                                        prom = self._rpc({
-                                            model: self.field.relation,
-                                            method: "name_search",
-                                            kwargs: {
-                                                name: search_val,
-                                                args: domain,
-                                                operator: "ilike",
-                                                limit: self.SEARCH_MORE_LIMIT,
-                                                context: context,
-                                            },
-                                        });
-                                    }
-                                    Promise.resolve(prom).then(function(results) {
-                                        var dynamicFilters = [];
-                                        if (results) {
-                                            var ids = _.map(results, function(x) {
-                                                return x[0];
-                                            });
-                                            if (search_val) {
-                                                dynamicFilters = [
-                                                    {
-                                                        description: _.str.sprintf(
-                                                            _t("Quick search: %s"),
-                                                            search_val
-                                                        ),
-                                                        domain: [["id", "in", ids]],
-                                                    },
-                                                ];
-                                            } else {
-                                                dynamicFilters = [];
-                                            }
-                                        }
-                                        self._searchCreatePopup(
-                                            "search",
-                                            false,
-                                            {},
-                                            dynamicFilters
-                                        );
+                        values.push({
+                            label: _t("Search More..."),
+                            action: function() {
+                                var prom = [];
+                                if (search_val !== "") {
+                                    prom = self._rpc({
+                                        model: self.field.relation,
+                                        method: "name_search",
+                                        kwargs: {
+                                            name: search_val,
+                                            args: domain,
+                                            operator: "ilike",
+                                            limit: self.SEARCH_MORE_LIMIT,
+                                            context: context,
+                                        },
                                     });
-                                },
-                                classname: "o_m2o_dropdown_option",
-                            });
-                        }
+                                }
+                                Promise.resolve(prom).then(function(results) {
+                                    var dynamicFilters = [];
+                                    if (results) {
+                                        var ids = _.map(results, function(x) {
+                                            return x[0];
+                                        });
+                                        if (search_val) {
+                                            dynamicFilters = [
+                                                {
+                                                    description: _.str.sprintf(
+                                                        _t("Quick search: %s"),
+                                                        search_val
+                                                    ),
+                                                    domain: [["id", "in", ids]],
+                                                },
+                                            ];
+                                        } else {
+                                            dynamicFilters = [];
+                                        }
+                                    }
+                                    self._searchCreatePopup(
+                                        "search",
+                                        false,
+                                        {},
+                                        dynamicFilters
+                                    );
+                                });
+                            },
+                            classname: "o_m2o_dropdown_option",
+                        });
                     }
 
                     var create_enabled = self.can_create && !self.nodeOptions.no_create;


### PR DESCRIPTION
When setting search_more: True on a field, the search more button should __always__ be visible. Same when setting the global config.
When nothing specified, the standard behavior based on the limit is preserved.

-----------
This PR includes https://github.com/OCA/web/pull/1577 (approved) to avoid conflicts.