### PR TITLE
[12.0][FIX] web_translate_dialog: Search using '=' to target right field

### DIFF
--- a/web_translate_dialog/models/base.py
+++ b/web_translate_dialog/models/base.py
@@ -25,7 +25,7 @@ class BaseModel(models.BaseModel):
             for name in field_names:
 
                 tr_read_res = self.env['ir.translation'].search_read([
-                    ('name', 'like', '%s,%s' % (self._name, name)),
+                    ('name', '=', '%s,%s' % (self._name, name)),
                     ('res_id', '=', rec_id),
                     ('lang', '!=', 'en_US')
                 ])


### PR DESCRIPTION
Without this commit, ir.translation are searched using a LIKE,
meaning that for a field called 'title', we'd get the translations
of all the fields beginning with title on this model.
Therefore, the returned value for field 'title' that is displayed
in the widget will be the value of the last result returned by
search_read, what could be anything beginning with title, and not
necessarily the field title itself.