### PR TITLE
Fix bootstrap-markdown url

### DIFF
--- a/web_widget_text_markdown/README.rst
+++ b/web_widget_text_markdown/README.rst
@@ -6,7 +6,7 @@ This module adds a new widget for text field in form view on Odoo:
 - In readonly mode, it uses text contents to parse and render them to html markdown syntax.
 - In write mode, use [bootstrap-markdown][1]
 
-[1]: http://www.codingdrama.com/bootstrap-markdown/    "bootstrap-markdown"
+[1]: `bootstrap-markdown <https://github.com/toopay/bootstrap-markdown>`_
 
 Usage
 =====


### PR DESCRIPTION
Fix dead URL from http://www.codingdrama.com/bootstrap-markdown/ to Github repo http://github.com/toopay/bootstrap-markdown