### PR TITLE
[IMP] web_widget_x2many_2d_matrix : Add 'avg' operator support

### DIFF
--- a/web_widget_x2many_2d_matrix/readme/CONTRIBUTORS.rst
+++ b/web_widget_x2many_2d_matrix/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * Jairo Llopis <jairo.llopis@tecnativa.com>
 * Dennis Sluijk <d.sluijk@onestein.nl>
 * Alexey Pelykh <alexey.pelykh@brainbeanapps.com>
+* Maxence Groine <mgroine@fiefmanage.ch>

--- a/web_widget_x2many_2d_matrix/readme/USAGE.rst
+++ b/web_widget_x2many_2d_matrix/readme/USAGE.rst
@@ -29,12 +29,21 @@ field_label_y_axis
     Use another field to display in the table header
 field_value
     Show this field as value
-show_row_totals
+show_row_agg
     If field_value is a numeric field, it indicates if you want to calculate
-    row totals. True by default
-show_column_totals
+    row aggregates. True by default
+show_col_agg
     If field_value is a numeric field, it indicates if you want to calculate
-    column totals. True by default
+    column aggregates. True by default
+agg_function
+    'sum' or 'avg' (arithmetic mean)
+    Indicates the computation to be done in the aggregates columns/rows.
+    'sum' by default
+agg_format
+    If passed, can force formatting of the aggregates computation results.
+    e.g.: You might want 'float' formatting for 'avg' computations on integer
+    values rather than leaving the default 'integer' formatting which would
+    round the computed means.
 
 Example
 ~~~~~~~

--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -69,16 +69,18 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                     this.field_value
                 ));
             }
-            this.show_row_totals = utils.toBoolElse(
-                node.show_row_totals ||
+            this.show_row_agg = utils.toBoolElse(
+                node.show_row_agg ||
                 this.is_aggregatable(field_defs[this.field_value]),
                 false
             );
-            this.show_column_totals = utils.toBoolElse(
-                node.show_column_totals ||
+            this.show_col_agg = utils.toBoolElse(
+                node.show_col_agg ||
                 this.is_aggregatable(field_defs[this.field_value]),
                 false
             );
+            this.agg_function = node.agg_function || 'sum';
+            this.agg_format = node.agg_format || undefined;
         },
 
         /**
@@ -128,8 +130,10 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 'field_y_axis': this.field_y_axis,
                 'columns': this.columns,
                 'rows': this.rows,
-                'show_row_totals': this.show_row_totals,
-                'show_column_totals': this.show_column_totals,
+                'show_row_agg': this.show_row_agg,
+                'show_col_agg': this.show_row_agg,
+                'agg_function': this.agg_function,
+                'agg_format': this.agg_format
             };
         },
 

--- a/web_widget_x2many_2d_matrix_example/models/x2m_demo.py
+++ b/web_widget_x2many_2d_matrix_example/models/x2m_demo.py
@@ -32,6 +32,10 @@ class X2MDemo(models.Model):
         return self._open_x2m_matrix('x2many_2d_matrix_demo')
 
     @api.multi
+    def open_x2m_matrix_avg_and_format(self):
+        return self._open_x2m_matrix('x2many_2d_matrix_demo_integer_avg_and_format')
+
+    @api.multi
     def open_x2m_matrix_selection(self):
         return self._open_x2m_matrix('x2many_2d_matrix_demo_selection')
 

--- a/web_widget_x2many_2d_matrix_example/views/x2m_demo.xml
+++ b/web_widget_x2many_2d_matrix_example/views/x2m_demo.xml
@@ -23,6 +23,9 @@
                         <button name="open_x2m_matrix" type="object"
                                 string="Try x2m 2d matrix"
                                 class="oe_link" icon="fa-edit"/>
+                        <button name="open_x2m_matrix_avg_and_format" type="object"
+                                string="Try x2m 2d matrix with avg aggregate"
+                                class="oe_link" icon="fa-edit"/>
                         <button name="open_x2m_matrix_selection" type="object"
                                 string="Try x2m 2d matrix (selection)"
                                 class="oe_link" icon="fa-edit"/>

--- a/web_widget_x2many_2d_matrix_example/wizard/x2m_matrix.xml
+++ b/web_widget_x2many_2d_matrix_example/wizard/x2m_matrix.xml
@@ -19,6 +19,25 @@
         </field>
     </record>
 
+    <record id="x2many_2d_matrix_demo_integer_avg_and_format" model="ir.ui.view">
+        <field name="name">x2m.matrix.demo.wiz</field>
+        <field name="model">x2m.matrix.demo.wiz</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="line_ids" widget="x2many_2d_matrix"
+                       field_x_axis="demo_id" field_y_axis="user_id" field_value="value"
+                       agg_function="avg" agg_format="float">
+                    <tree>
+                        <field name="demo_id"/>
+                        <field name="user_id"/>
+                        <field name="value"/>
+                    </tree>
+                </field>
+            </form>
+        </field>
+    </record>
+
     <record id="x2many_2d_matrix_demo_selection" model="ir.ui.view">
         <field name="name">x2m.matrix.demo.wiz</field>
         <field name="model">x2m.matrix.demo.wiz</field>


### PR DESCRIPTION
I don't know if this PR might be of interest but I've had to add support for an arithmetic mean ('avg') operator over the 2d matrix widget instead of the default 'sum' operator and maybe this could be useful in the main module. Let me know.

The result looks something like this (i've updated the `web_widget_x2many_2d_matrix_example` module to add this example) :

![Screenshot from 2020-07-21 11-55-50](https://user-images.githubusercontent.com/5863446/88040459-39bd9b80-cb49-11ea-99e6-006a0cde9c5c.png)

The choice of operator to apply for the aggregates column is handled by an attribute `agg_function` on the field, and an optional `agg_format` attribute can force formatting - else an arithmetic mean over integers would get automatically formatted as an integer and rounded, which is not always helpful.