### PR TITLE
[12.0][IMP] web_advanced_search: Prevent the menu from closing when using a relational field

### DIFF
--- a/web_advanced_search/static/src/js/web_advanced_search.js
+++ b/web_advanced_search/static/src/js/web_advanced_search.js
@@ -88,6 +88,19 @@ odoo.define("web_advanced_search", function (require) {
         }),
 
         /**
+         * Handle dropdown hidden event to prevent the menu from closing when using a 
+         * relational field 
+         *
+         * @override
+         */
+        start: function () {
+            this._super.apply(this, arguments);
+            this.$el.on('hide.bs.dropdown', function() {
+                return !($('.o_technical_modal.show').length || $('body.oe_wait').length);
+            });
+        },
+
+        /**
          * @override
          */
         init: function () {


### PR DESCRIPTION
Fix: https://github.com/OCA/web/issues/1553

Is a workaround because I don't see a better way to handle this issue.

cc @tecnativa 