### PR TITLE
[IMP] web_advanced_search: Don't block modal filter menu

### DIFF
--- a/web_advanced_search/static/src/js/web_advanced_search.js
+++ b/web_advanced_search/static/src/js/web_advanced_search.js
@@ -88,15 +88,16 @@ odoo.define("web_advanced_search", function (require) {
         }),
 
         /**
-         * Handle dropdown hidden event to prevent the menu from closing when using a 
-         * relational field 
+         * Handle dropdown hidden event to prevent the menu from closing when using a
+         * relational field
          *
          * @override
          */
         start: function () {
             this._super.apply(this, arguments);
             this.$el.on('hide.bs.dropdown', function() {
-                return !($('.o_technical_modal.show').length || $('body.oe_wait').length);
+                var $modal = $('.o_technical_modal.show');
+                return !(($modal.length && !$modal.has($(this)).length) || $('body.oe_wait').length);
             });
         },
 


### PR DESCRIPTION
Previous commit to prevent close the filter menu when click an option that shows a modal menu introduces a new bug that blocks hide the filter menu of modals. This PR fix the new problem.

cc @tecnativa