### PR TITLE
[FIX] web_translate_dialog: check outbound array when set_maxlength

### DIFF
--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -111,9 +111,14 @@ var TranslateDialog = Dialog.extend({
     set_maxlength: function(){
         // set maxlength if initial field has size attr
         _.each(this.translatable_fields, function(field_name){
-            var size = $('[name='+field_name+']')[0].maxLength;
-            if (size > 0){
-                this.$('input.oe_translation_field[name$="'+field_name+'"], textarea.oe_translation_field[name$="'+field_name+'"]').attr('maxlength', size);
+            var field = $('[name='+field_name+']');
+            if (field.length > 0) {
+                var size = field[0].maxLength;
+                if (size > 0) {
+                    this.$('input.oe_translation_field[name$="'+field_name+'"], textarea.oe_translation_field[name$="'+field_name+'"]').attr('maxlength', size);
+                } else {
+                    console.error("Missing field_name from set_maxlength web_translate_dialog.js: " + field_name);
+                }
             }
         }, this);
     },


### PR DESCRIPTION
Fix outbound error on array when set_maxlength
```
TypeError: undefined is not an object (evaluating '$('[name='+field_name+']')[0].maxLength')
http://127.0.0.1:8069/web/content/1885-4a86985/web.assets_backend.js:4042
Retraçage :
http://127.0.0.1:8069/web/content/1885-4a86985/web.assets_backend.js:4042:160
http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:10:335
http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:12:566
set_maxlength@http://127.0.0.1:8069/web/content/1885-4a86985/web.assets_backend.js:4042:75
http://127.0.0.1:8069/web/content/1885-4a86985/web.assets_backend.js:4042:1802
fire@http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:796:304
fireWith@http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:801:202
http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:803:56
http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:3558:17
http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:802:686
fire@http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:796:304
fireWith@http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:801:202
http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:802:874
fire@http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:796:304
fireWith@http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:801:202
done@http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:1192:106
callback@http://127.0.0.1:8069/web/content/1844-d28431a/web.assets_common.js:1212:23
```