### PR TITLE
[FIX] web_widget_digitized_signature: Render signature on edit mode

### DIFF
--- a/web_widget_digitized_signature/static/src/js/digital_sign.js
+++ b/web_widget_digitized_signature/static/src/js/digital_sign.js
@@ -87,8 +87,8 @@ odoo.define('web_widget_digitized_signature.web_digital_sign', function(require)
                         ? this.options.preview_image
                                 : this.name;
                     new Model(this.view.dataset.model).call("read", [this.view.datarecord.id, [field_name]]).done(function(data) {
-                        if (data) {
-                            var field_desc = _.values(_.pick(data, field_name));
+                        if (data.length) {
+                            var field_desc = _.values(_.pick(data[0], field_name));
                             self.$el.find(".signature").jSignature("reset");
                             self.$el.find(".signature").jSignature("setData",'data:image/png;base64,'+field_desc[0]);
                         }


### PR DESCRIPTION
This fixes the rendering of the signature in edit mode.
However, it brings up another issue: the stroke thickens each time you save and re-enter edit mode.

I would wait to solve this problem before merging the PR.
Meanwhile, if anyone has any idea what the problem might be, any opinion is welcome.

Thanks.