### PR TITLE
Fix enterprise mobile bug

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -137,6 +137,9 @@ odoo.define("web_m2x_options.web_m2x_options", function(require) {
 
         _search: function(search_val) {
             var self = this;
+            if (search_val === undefined) {
+                return this._super.apply(this, arguments);
+            }
             var def = new Promise(resolve => {
                 // Add options limit used to change number of selections record
                 // returned.


### PR DESCRIPTION
On enterprise mobile version, on m2o fields show error on variable search_val.length line 313 because this value come as undefined value

Related with pr #1650 