### PR TITLE
[12.0][FIX] web_responsive update scss

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -537,7 +537,7 @@ html .o_web_client .o_main .o_main_content {
                     flex: 0 0 $chatter_zone_width;
                     max-width: initial;
                     min-width: initial;
-                    overflow: auto;
+                    overflow: initial;
 
                     .o_chatter_header_container {
                         padding-top: $grid-gutter-width * 0.5;


### PR DESCRIPTION
On the edit page of a channel, if the user is configured with the chat on the side, when clicking to add a subscriber, the list is truncated. Changing the overflow of the div o_chatter displays the list correctly.