### PR TITLE
[FIX] web_pivot_computed_measure : do not raise Javascript error in case of no data

### DIFF
--- a/web_pivot_computed_measure/static/src/js/pivot_model.js
+++ b/web_pivot_computed_measure/static/src/js/pivot_model.js
@@ -127,7 +127,11 @@ odoo.define('web_pivot_computed_measure.PivotModel', function (require) {
                             resData, resComparison),
                     };
                 } else {
-                    dataPoint[cm.id] = py.eval(cm.operation, dataPoint);
+                    if (dataPoint.__count === 0) {
+                        dataPoint[cm.id] = false;
+                    } else {
+                        dataPoint[cm.id] = py.eval(cm.operation, dataPoint);
+                    }
                 }
             });
         },


### PR DESCRIPTION
Hi. Using the module ``web_pivot_computed_measure`` I have the following error, when there is no data at all to display to the user. (it can occurs if you add a computed measure on any dashboard, then create a new company and switch to the new company, because no data are available in that context).

This patch fixes this bug.


### error Detail

```
Error: TypeError: unsupported operand type(s) for /: 'NoneType' and 'NoneType'

http://my-odoo-12:8012/web/static/lib/py.js/lib/py.js:1287
Retraçage :
PY_op@http://my-odoo-12:8012/web/static/lib/py.js/lib/py.js:1287:15
py.evaluate@http://my-odoo-12:8012/web/static/lib/py.js/lib/py.js:1448:20
py.eval@http://my-odoo-12:8012/web/static/lib/py.js/lib/py.js:1458:19
_fillComputedMeasuresData/<@http://my-odoo-12:8012/web_pivot_computed_measure/static/src/js/pivot_model.js:131:47
_.forEach@http://my-odoo-12:8012/web/static/lib/underscore/underscore.js:145:17
_fillComputedMeasuresData@http://my-odoo-12:8012/web_pivot_computed_measure/static/src/js/pivot_model.js:114:15
```

CC : @quentinDupont #GRAPOCA