### PR TITLE
[12.0][FIX] web_translate_dialog reload parent view

### DIFF
--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -222,6 +222,7 @@ var TranslateDialog = Dialog.extend({
                 return done;
             });
         });
+        this.view.reload();
         this.close();
     },
     on_button_close: function() {

--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -222,7 +222,9 @@ var TranslateDialog = Dialog.extend({
                 return done;
             });
         });
-        this.view.reload();
+        save_mutex.exec(function() {
+            self.view.reload();
+        });
         this.close();
     },
     on_button_close: function() {


### PR DESCRIPTION
This fixes the following isssue:
1. Open a record.
2. Use the translator wizard: action -> Translate and save your changes
3. When you land back into the form view, the changes of translations are not visible directly. They are visible only if you reload the page. 

Goal:
The webpage should be reloaded with the newest translations