### PR TITLE
[14.0][ADD] web_calendar_color_field

### DIFF
--- a/setup/web_calendar_color_field/odoo/addons/web_calendar_color_field
+++ b/setup/web_calendar_color_field/odoo/addons/web_calendar_color_field
@@ -1,0 +1,1 @@
+../../../../web_calendar_color_field

--- a/setup/web_calendar_color_field/setup.py
+++ b/setup/web_calendar_color_field/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/web_calendar_color_field/__manifest__.py
+++ b/web_calendar_color_field/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2019 Iván Todorovich
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Calendar Color Field",
+    "version": "14.0.1.0.0",
+    "category": "Web",
+    "website": "https://github.com/OCA/web",
+    "author": "Iván Todorovich, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [
+        "web",
+    ],
+    "data": [
+        "views/assets.xml",
+    ],
+}

--- a/web_calendar_color_field/readme/CONTRIBUTORS.rst
+++ b/web_calendar_color_field/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Iván Todorovich <ivan.todorovich@gmail.com>

--- a/web_calendar_color_field/readme/DESCRIPTION.rst
+++ b/web_calendar_color_field/readme/DESCRIPTION.rst
@@ -1,0 +1,9 @@
+This is a technical module. It doesn't do anything on its own.
+
+Odoo introduced a mechanism to set the desired color for a calendar filter,
+through the field's `color` attribute.
+
+Unfortunately, this only works for filters, but not if we want to use the
+calendar's `color` attribute.
+
+This module makes the appropiate changes so that the filter's color is used, if available.

--- a/web_calendar_color_field/readme/USAGE.rst
+++ b/web_calendar_color_field/readme/USAGE.rst
@@ -1,0 +1,13 @@
+Set a color attribute value on any many2one calendar field set as filter and
+set the calendar's color attribute to use the same many2one field.
+
+Example:
+
+.. code-block:: xml
+
+    <calendar color="category_id">
+        <field name="category_id" filter="1" color="kanban_color"/>
+    </calendar>
+
+- `category_id` is a `Many2one` field in your record.
+- `kanban_color` is an integer field in your category record.

--- a/web_calendar_color_field/static/src/js/calendar.js
+++ b/web_calendar_color_field/static/src/js/calendar.js
@@ -1,0 +1,67 @@
+odoo.define("web_calendar_color_field.CalendarModel", function (require) {
+    "use strict";
+
+    const CalendarModel = require("web.CalendarModel");
+
+    CalendarModel.include({
+        /**
+         * Overload to handle custom colorIndex
+         *
+         * Default beaviour when using a many2one field as color attribute
+         * is to generate random colors based on the record id.
+         *
+         * We are changing that behaviour to play nicely with the newly added
+         * <field filter="1" color="color"/> color attribute.
+         *
+         * If the field is also added to filters, and a color field is defined,
+         * we use that color field as colorIndex.
+         */
+        _loadColors: function (element, events) {
+            var self = this;
+            if (this.fieldColor) {
+                var fieldName = this.fieldColor;
+                var filter = this.data.filters[fieldName];
+                if (filter && filter.color_model && filter.field_color) {
+                    // If we haven't loaded the color fields, we do it, and we
+                    // store it in self._field_color_map.  We only do it once,
+                    // because subsequent calls will simply read it from the map.
+                    // Note: _loadRecordsToFilters will also read these values
+                    // from db, but on first render it's called after this method
+                    var defs = [];
+                    if (!this._field_color_map) {
+                        var ids = _.map(events, function (event) {
+                            return event.record[fieldName][0];
+                        });
+                        defs.push(
+                            this._rpc({
+                                model: filter.color_model,
+                                method: "read",
+                                args: [_.uniq(ids), [filter.field_color]],
+                            }).then(function (res) {
+                                self._field_color_map = self._field_color_map || {};
+                                _.each(res, function (item) {
+                                    self._field_color_map[item.id] =
+                                        item[filter.field_color];
+                                });
+                            })
+                        );
+                    }
+                    Promise.all(defs).then(function () {
+                        _.each(events, function (event) {
+                            var value = event.record[fieldName][0];
+                            event.color_index = self._field_color_map[value];
+                        });
+                    });
+                    // Don't set model color, so that filters generate their own
+                    // https://github.com/odoo/odoo/blob/14.0/addons/web/static/src/js/views/calendar/calendar_model.js#L629
+                    // this.model_color = this.fields[fieldName].relation || element.model;
+                } else {
+                    return this._super.apply(this, arguments);
+                }
+            }
+            return Promise.resolve();
+        },
+    });
+
+    return CalendarModel;
+});

--- a/web_calendar_color_field/views/assets.xml
+++ b/web_calendar_color_field/views/assets.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template id="assets_backend" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/web_calendar_color_field/static/src/js/calendar.js"
+            />
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Odoo introduced a mechanism to set the desired color for a calendar filter, through the field's `color` attribute.
Unfortunately, this only works for filters, but not if we want to use the calendar's `color` attribute.

This module makes the appropiate changes so that the filter's color is used, if available.

Usage example:

```xml
    <calendar color="category_id">
        <field name="category_id" filter="1" color="kanban_color"/>
    </calendar>
```

Where:
- `category_id` is a `Many2one` field in your record.
- `kanban_color` is an integer field in your category record.