### PR TITLE
[12.0][FIX] web_translate_dialog: on_button_translate load current record

### DIFF
--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -247,7 +247,7 @@ FormController.include({
     on_button_translate: function() {
         var self = this;
         $.when(this.has_been_loaded).then(function() {
-            self.open_translate_dialog(null, self.initialState.res_id);
+            self.open_translate_dialog(null, self.getSelectedIds()[0]);
         });
     },
 


### PR DESCRIPTION
**Context**
1. Open the translations via Actions>Translate in a record1
2. Close it 
3. Switch to another record2 
4. open the translations via Actions>Translate

There's still the texts from record1.

**Goal** 
When you change record, it must load the translations of the one you are viewing.