### PR TITLE
[12.0][IMP] web_m2x_options: Added limit for o2m field entries + efficiency

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -115,6 +115,10 @@ If you disable one option, you can enable it for particular field by setting "cr
 
   Whether the field should always show "Search more..." entry or not.
 
+``web_m2x_options.field_limit_entries`` *int*
+
+  Number of displayed lines on all One2many fields
+
 To add these parameters go to Configuration -> Technical -> Parameters -> System Parameters and add new parameters like:
 
 - web_m2x_options.create: False
@@ -122,6 +126,7 @@ To add these parameters go to Configuration -> Technical -> Parameters -> System
 - web_m2x_options.m2o_dialog: False
 - web_m2x_options.limit: 10
 - web_m2x_options.search_more: True
+- web_m2x_options.field_limit_entries: 5
 
 
 Example

--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -177,6 +177,7 @@ Contributors
   * Jairo Llopis <jairo.llopis@tecnativa.com>
   * David Vidal <david.vidal@tecnativa.com>
   * Ernesto Tejeda <ernesto.tejeda87@gmail.com>
+  * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_m2x_options/models/ir_config_parameter.py
+++ b/web_m2x_options/models/ir_config_parameter.py
@@ -9,4 +9,7 @@ class IrConfigParameter(models.Model):
         opts = ['web_m2x_options.create', 'web_m2x_options.create_edit',
                 'web_m2x_options.limit', 'web_m2x_options.search_more',
                 'web_m2x_options.m2o_dialog']
-        return self.sudo().search_read([['key', 'in', opts]], ["key", "value"])
+        return {
+            res["key"]: res["value"] for res in self.sudo().search_read(
+                [['key', 'in', opts]], ["key", "value"])
+        }

--- a/web_m2x_options/models/ir_config_parameter.py
+++ b/web_m2x_options/models/ir_config_parameter.py
@@ -8,7 +8,7 @@ class IrConfigParameter(models.Model):
     def get_web_m2x_options(self):
         opts = ['web_m2x_options.create', 'web_m2x_options.create_edit',
                 'web_m2x_options.limit', 'web_m2x_options.search_more',
-                'web_m2x_options.m2o_dialog']
+                'web_m2x_options.m2o_dialog', 'web_m2x_options.field_limit_entries']
         return {
             res["key"]: res["value"] for res in self.sudo().search_read(
                 [['key', 'in', opts]], ["key", "value"])

--- a/web_m2x_options/readme/CONTRIBUTORS.rst
+++ b/web_m2x_options/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
   * Jairo Llopis <jairo.llopis@tecnativa.com>
   * David Vidal <david.vidal@tecnativa.com>
   * Ernesto Tejeda <ernesto.tejeda87@gmail.com>
+  * Carlos Roca

--- a/web_m2x_options/readme/USAGE.rst
+++ b/web_m2x_options/readme/USAGE.rst
@@ -69,6 +69,10 @@ If you disable one option, you can enable it for particular field by setting "cr
 
   Whether the field should always show "Search more..." entry or not.
 
+``web_m2x_options.field_limit_entries`` *int*
+
+  Number of displayed lines on all One2many fields
+
 To add these parameters go to Configuration -> Technical -> Parameters -> System Parameters and add new parameters like:
 
 - web_m2x_options.create: False
@@ -76,6 +80,7 @@ To add these parameters go to Configuration -> Technical -> Parameters -> System
 - web_m2x_options.m2o_dialog: False
 - web_m2x_options.limit: 10
 - web_m2x_options.search_more: True
+- web_m2x_options.field_limit_entries: 5
 
 
 Example

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -361,4 +361,16 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             }
         },
     });
+
+    // Extending class to allow change the limit of o2m registry entries using the
+    // system parameter "web_m2x_options.field_limit_entries".
+    FormView.include({
+        _setSubViewLimit: function (attrs) {
+            this._super(attrs);
+            var limit = ir_options["web_m2x_options.field_limit_entries"];
+            if (!_.isUndefined(limit)) {
+                attrs.limit = parseInt(limit);
+            }
+        },
+    });
 });

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -7,9 +7,10 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
     var core = require('web.core'),
         data = require('web.data'),
         Dialog = require('web.Dialog'),
+        FormView = require("web.FormView"),
         view_dialogs = require('web.view_dialogs'),
         relational_fields = require('web.relational_fields'),
-        rpc = require('web.rpc');
+        ir_options = require('web_m2x_options.ir_options');
 
     var _t = core._t,
         FieldMany2ManyTags = relational_fields.FieldMany2ManyTags,
@@ -17,10 +18,15 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
         FieldOne2Many = relational_fields.FieldOne2Many,
         FormFieldMany2ManyTags = relational_fields.FormFieldMany2ManyTags;
 
-    var web_m2x_options = rpc.query({
-        model: "ir.config_parameter",
-        method: 'get_web_m2x_options',
-    });
+    function is_option_set (option) {
+        if (_.isUndefined(option))
+            return false;
+        if (typeof option === 'string')
+            return option === 'true' || option === 'True';
+        if (typeof option === 'boolean')
+            return option;
+        return false
+    };
 
     var M2ODialog = Dialog.extend({
         template: "M2ODialog",
@@ -81,39 +87,8 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
     });
 
     FieldMany2One.include({
-
-        start: function () {
-            this._super.apply(this, arguments);
-            return this.get_options();
-        },
-
-        get_options: function () {
-            var self = this;
-            if (_.isUndefined(this.ir_options_loaded)) {
-                this.ir_options_loaded = $.Deferred();
-                this.ir_options = {};
-                web_m2x_options.done(function (records) {
-                    _(records).each(function(record) {
-                        self.ir_options[record.key] = record.value;
-                    });
-                    self.ir_options_loaded.resolve();
-                });
-            }
-            return $.when();
-        },
-
-        is_option_set: function (option) {
-            if (_.isUndefined(option))
-                return false;
-            if (typeof option === 'string')
-                return option === 'true' || option === 'True';
-            if (typeof option === 'boolean')
-                return option;
-            return false
-        },
-
         _onInputFocusout: function () {
-            var m2o_dialog_opt = this.is_option_set(this.nodeOptions.m2o_dialog) || _.isUndefined(this.nodeOptions.m2o_dialog) && this.is_option_set(this.ir_options['web_m2x_options.m2o_dialog']) || _.isUndefined(this.nodeOptions.m2o_dialog) && _.isUndefined(this.ir_options['web_m2x_options.m2o_dialog']);
+            var m2o_dialog_opt = is_option_set(this.nodeOptions.m2o_dialog) || _.isUndefined(this.nodeOptions.m2o_dialog) && is_option_set(ir_options['web_m2x_options.m2o_dialog']) || _.isUndefined(this.nodeOptions.m2o_dialog) && _.isUndefined(ir_options['web_m2x_options.m2o_dialog']);
             if (this.can_create && this.floating && m2o_dialog_opt) {
                 new M2ODialog(this, this.string, this.$input.val()).open();
             }
@@ -126,8 +101,8 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
 
             // add options limit used to change number of selections record
             // returned.
-            if (!_.isUndefined(this.ir_options['web_m2x_options.limit'])) {
-                this.limit = parseInt(this.ir_options['web_m2x_options.limit'], 10);
+            if (!_.isUndefined(ir_options['web_m2x_options.limit'])) {
+                this.limit = parseInt(ir_options['web_m2x_options.limit'], 10);
             }
 
             if (typeof this.nodeOptions.limit === 'number') {
@@ -198,9 +173,9 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                 }
 
                 // search more... if more results that max
-                var can_search_more = (self.nodeOptions && self.is_option_set(self.nodeOptions.search_more)),
-                    search_more_undef = _.isUndefined(self.nodeOptions.search_more) && _.isUndefined(self.ir_options['web_m2x_options.search_more']),
-                    search_more = self.is_option_set(self.ir_options['web_m2x_options.search_more']);
+                var can_search_more = (self.nodeOptions && is_option_set(self.nodeOptions.search_more)),
+                    search_more_undef = _.isUndefined(self.nodeOptions.search_more) && _.isUndefined(ir_options['web_m2x_options.search_more']),
+                    search_more = is_option_set(ir_options['web_m2x_options.search_more']);
 
                 if (values.length > self.limit) {
                     values = values.slice(0, self.limit);
@@ -232,10 +207,10 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                 var create_enabled = self.can_create && !self.nodeOptions.no_create;
                 // quick create
                 var raw_result = _.map(result, function (x) { return x[1]; });
-                var quick_create = self.is_option_set(self.nodeOptions.create),
+                var quick_create = is_option_set(self.nodeOptions.create),
                     quick_create_undef = _.isUndefined(self.nodeOptions.create),
-                    m2x_create_undef = _.isUndefined(self.ir_options['web_m2x_options.create']),
-                    m2x_create = self.is_option_set(self.ir_options['web_m2x_options.create']);
+                    m2x_create_undef = _.isUndefined(ir_options['web_m2x_options.create']),
+                    m2x_create = is_option_set(ir_options['web_m2x_options.create']);
                 var show_create = (!self.nodeOptions && (m2x_create_undef || m2x_create)) || (self.nodeOptions && (quick_create || (quick_create_undef && (m2x_create_undef || m2x_create))));
                 if (create_enabled && !self.nodeOptions.no_quick_create &&
                     search_val.length > 0 && !_.contains(raw_result, search_val) &&
@@ -249,10 +224,10 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                 }
                 // create and edit ...
 
-                var create_edit = self.is_option_set(self.nodeOptions.create) || self.is_option_set(self.nodeOptions.create_edit),
+                var create_edit = is_option_set(self.nodeOptions.create) || is_option_set(self.nodeOptions.create_edit),
                     create_edit_undef = _.isUndefined(self.nodeOptions.create) && _.isUndefined(self.nodeOptions.create_edit),
-                    m2x_create_edit_undef = _.isUndefined(self.ir_options['web_m2x_options.create_edit']),
-                    m2x_create_edit = self.is_option_set(self.ir_options['web_m2x_options.create_edit']);
+                    m2x_create_edit_undef = _.isUndefined(ir_options['web_m2x_options.create_edit']),
+                    m2x_create_edit = is_option_set(ir_options['web_m2x_options.create_edit']);
                 var show_create_edit = (!self.nodeOptions && (m2x_create_edit_undef || m2x_create_edit)) || (self.nodeOptions && (create_edit || (create_edit_undef && (m2x_create_edit_undef || m2x_create_edit))));
                 if (create_enabled && !self.nodeOptions.no_create_edit && show_create_edit) {
                     var createAndEditAction = function () {
@@ -291,19 +266,9 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
             return result;
         },
 
-        is_option_set: function (option) {
-            if (_.isUndefined(option))
-                return false;
-            if (typeof option === 'string')
-                return option === 'true' || option === 'True';
-            if (typeof option === 'boolean')
-                return option;
-            return false
-        },
-
         _onOpenBadge: function (event) {
             var self = this;
-            var open = (self.nodeOptions && self.is_option_set(self.nodeOptions.open));
+            var open = (self.nodeOptions && is_option_set(self.nodeOptions.open));
             if (open) {
                 var context = self.record.getContext(self.recordParams);
                 var id = parseInt($(event.currentTarget).data('id'), 10);
@@ -383,8 +348,8 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
         }),
 
         _onOpenBadge: function (event) {
-            var open = this.is_option_set(this.nodeOptions.open);
-            var no_color_picker = this.is_option_set(
+            var open = is_option_set(this.nodeOptions.open);
+            var no_color_picker = is_option_set(
                 this.nodeOptions.no_color_picker
             );
             this._super.apply(this, arguments);

--- a/web_m2x_options/static/src/js/ir_options.js
+++ b/web_m2x_options/static/src/js/ir_options.js
@@ -1,0 +1,12 @@
+/* Copyright 2020 Tecnativa - Carlos Roca
+ *  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+odoo.define('web_m2x_options.ir_options', function (require) {
+    "use strict";
+
+    var rpc = require('web.rpc');
+
+    return rpc.query({
+        model: "ir.config_parameter",
+        method: 'get_web_m2x_options',
+    });
+});

--- a/web_m2x_options/views/view.xml
+++ b/web_m2x_options/views/view.xml
@@ -6,6 +6,8 @@
         <xpath expr="." position="inside">
             <script type="text/javascript"
                     src="/web_m2x_options/static/src/js/form.js"></script>
+            <script type="text/javascript"
+                    src="/web_m2x_options/static/src/js/ir_options.js"></script>
         </xpath>
     </template>
 


### PR DESCRIPTION
cc @Tecnativa TT26667

Added the system parameter "web_m2x_options.field_limit_entries" to set the limit of entries that can be displayed on One2many fields.

Improved the eficiency of code: With this improvement we achieve to just do an rpc call when the js file is called instead of do the call for each field.

Here you have an example:
![1](https://user-images.githubusercontent.com/35952655/98531348-80faa400-2280-11eb-94b9-95b7de2d4f7e.gif)

Please @chienandalu @ernestotejeda can you review this