### PR TITLE
[12.0][IMP] web_m2x_options: Add search_more_always option

### DIFF
--- a/web_m2x_options/models/ir_config_parameter.py
+++ b/web_m2x_options/models/ir_config_parameter.py
@@ -8,5 +8,5 @@ class IrConfigParameter(models.Model):
     def get_web_m2x_options(self):
         opts = ['web_m2x_options.create', 'web_m2x_options.create_edit',
                 'web_m2x_options.limit', 'web_m2x_options.search_more',
-                'web_m2x_options.m2o_dialog']
+                'web_m2x_options.search_more_always', 'web_m2x_options.m2o_dialog']
         return self.sudo().search_read([['key', 'in', opts]], ["key", "value"])

--- a/web_m2x_options/readme/USAGE.rst
+++ b/web_m2x_options/readme/USAGE.rst
@@ -69,6 +69,10 @@ If you disable one option, you can enable it for particular field by setting "cr
 
   Whether the field should always show "Search more..." entry or not.
 
+``web_m2x_options.search_more_always`` *boolean* (Default: default value is ``False``)
+
+  Whether the field should always show "Search more..." entry even if records displayed are < limit.
+
 To add these parameters go to Configuration -> Technical -> Parameters -> System Parameters and add new parameters like:
 
 - web_m2x_options.create: False
@@ -76,6 +80,7 @@ To add these parameters go to Configuration -> Technical -> Parameters -> System
 - web_m2x_options.m2o_dialog: False
 - web_m2x_options.limit: 10
 - web_m2x_options.search_more: True
+- web_m2x_options.search_more_always: True
 
 
 Example

--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -200,33 +200,36 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                 // search more... if more results that max
                 var can_search_more = (self.nodeOptions && self.is_option_set(self.nodeOptions.search_more)),
                     search_more_undef = _.isUndefined(self.nodeOptions.search_more) && _.isUndefined(self.ir_options['web_m2x_options.search_more']),
-                    search_more = self.is_option_set(self.ir_options['web_m2x_options.search_more']);
+                    search_more = self.is_option_set(self.ir_options['web_m2x_options.search_more']),
+                    search_more_always = self.is_option_set(self.ir_options['web_m2x_options.search_more_always']);
 
                 if (values.length > self.limit) {
                     values = values.slice(0, self.limit);
-                    if (can_search_more || search_more_undef || search_more) {
-                        values.push({
-                            label: _t("Search More..."),
-                            action: function () {
-                                // limit = 80 for improving performance, similar
-                                // to Odoo implementation here:
-                                // https://github.com/odoo/odoo/commit/8c3cdce539d87775b59b3f2d5ceb433f995821bf
-                                self._rpc({
-                                        model: self.field.relation,
-                                        method: 'name_search',
-                                        kwargs: {
-                                            name: search_val,
-                                            args: domain,
-                                            operator: "ilike",
-                                            limit: 80,
-                                            context: context,
-                                        },
-                                    })
-                                    .then(self._searchCreatePopup.bind(self, "search"));
-                            },
-                            classname: 'o_m2o_dropdown_option',
-                        });
-                    }
+                    var show_search_more = can_search_more || search_more_undef || search_more;
+                }
+
+                if (show_search_more || search_more_always) {
+                    values.push({
+                        label: _t("Search More..."),
+                        action: function () {
+                            // limit = 80 for improving performance, similar
+                            // to Odoo implementation here:
+                            // https://github.com/odoo/odoo/commit/8c3cdce539d87775b59b3f2d5ceb433f995821bf
+                            self._rpc({
+                                    model: self.field.relation,
+                                    method: 'name_search',
+                                    kwargs: {
+                                        name: search_val,
+                                        args: domain,
+                                        operator: "ilike",
+                                        limit: 80,
+                                        context: context,
+                                    },
+                                })
+                                .then(self._searchCreatePopup.bind(self, "search"));
+                        },
+                        classname: 'o_m2o_dropdown_option',
+                    });
                 }
 
                 var create_enabled = self.can_create && !self.nodeOptions.no_create;


### PR DESCRIPTION
Adds a new option search_more_always that when set to True
in system parameters, it ALWAYS shows "search more..." option even if
there are no records or records number < limit.

This is useful especially when the referenced table in many2one has
active field and you want to select a record that is archived.