### PR TITLE
[12.0] [IMP]  web_ir_actions_close_wizard_refresh_view: Add to determine the current view type

### DIFF
--- a/web_ir_actions_close_wizard_refresh_view/static/src/js/web_ir_actions_close_wizard_refresh_view.js
+++ b/web_ir_actions_close_wizard_refresh_view/static/src/js/web_ir_actions_close_wizard_refresh_view.js
@@ -17,7 +17,9 @@ odoo.define('web_ir_actions_close_wizard_refresh_view', function (require) {
             var state = this._getControllerState(
                 this.getCurrentController().jsID);
 
-            return $.when(this.loadState(state));
+            if(state['view_type'] === 'list'){
+                return $.when(this.loadState(state));
+            }
         },
     });
 });


### PR DESCRIPTION
When opening the wizard in the form view, loadState will jump to the new view and should only be used in list view.