### PR TITLE
[13.0][FIX] web_responsive: Hide search panel on small screens

### DIFF
--- a/web_responsive/README.rst
+++ b/web_responsive/README.rst
@@ -62,6 +62,10 @@ Features for mobile:
 
   .. image:: https://user-images.githubusercontent.com/973709/50965168-1d0ec500-14c9-11e9-82a0-dfee82ed0861.gif
 
+* Search panel is hidden on small screens.
+
+  .. image:: https://raw.githubusercontent.com/OCA/web/13.0/web_responsive/static/img/search_panel.gif
+
 Features for computers:
 
 * Keyboard shortcuts for easier navigation, **using ``Alt + Shift + [key]``**

--- a/web_responsive/readme/DESCRIPTION.rst
+++ b/web_responsive/readme/DESCRIPTION.rst
@@ -35,6 +35,10 @@ Features for mobile:
 
   .. image:: https://user-images.githubusercontent.com/973709/50965168-1d0ec500-14c9-11e9-82a0-dfee82ed0861.gif
 
+* Search panel is hidden on small screens.
+
+  .. image:: ../static/img/search_panel.gif
+
 Features for computers:
 
 * Keyboard shortcuts for easier navigation, **using ``Alt + Shift + [key]``**

--- a/web_responsive/static/description/index.html
+++ b/web_responsive/static/description/index.html
@@ -398,6 +398,9 @@ Other control panel buttons use icons to save space.</p>
 <li><p class="first">Breadcrumbs navigation is collapsed with a “back arrow” button.</p>
 <img alt="https://user-images.githubusercontent.com/973709/50965168-1d0ec500-14c9-11e9-82a0-dfee82ed0861.gif" src="https://user-images.githubusercontent.com/973709/50965168-1d0ec500-14c9-11e9-82a0-dfee82ed0861.gif" />
 </li>
+<li><p class="first">Search panel is hidden on small screens.</p>
+<img alt="https://raw.githubusercontent.com/OCA/web/13.0/web_responsive/static/img/search_panel.gif" src="https://raw.githubusercontent.com/OCA/web/13.0/web_responsive/static/img/search_panel.gif" />
+</li>
 </ul>
 <p>Features for computers:</p>
 <ul>

--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -747,3 +747,13 @@ html .o_web_client .o_action_manager .o_action {
         }
     }
 }
+
+// Search Panel
+@include media-breakpoint-down(sm) {
+    // Hide search panel
+    .o_controller_with_searchpanel {
+        .o_search_panel {
+            display: none;
+        }
+    }
+}


### PR DESCRIPTION
Hide search panel on small screens:

![search_panel](https://user-images.githubusercontent.com/731270/100449735-b989e280-30b4-11eb-8a26-baebef66f82e.gif)

cc @tecnativa TT26806