### PR TITLE
[12.0][IMP] web_responsive: Cut long filters names in the filters menu

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -251,6 +251,17 @@ html .o_web_client .o_main .o_main_content {
             }
         }
     }
+
+    .o_filters_menu {
+        .o_menu_item {
+            @include o-search-options-dropdown-custom-item;
+
+            a {
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+    }
 }
 
 .o_pager_counter {


### PR DESCRIPTION
cc @tecnativa TT27055

![filter_menu](https://user-images.githubusercontent.com/731270/100783585-42cf4b00-340e-11eb-9075-d42e7f4bf561.png)
