### PR TITLE
[13.0][IMP] web_pivot_computed_measure: Saving vertical space

### DIFF
--- a/web_pivot_computed_measure/static/src/js/pivot_controller.js
+++ b/web_pivot_computed_measure/static/src/js/pivot_controller.js
@@ -176,7 +176,8 @@ odoo.define("web_pivot_computed_measure.PivotController", function(require) {
             if ($(ev.target).val() === "custom") {
                 this.$buttons_measures_ex
                     .find("#container_computed_measure_operation_custom")
-                    .removeClass("d-none");
+                    .removeClass("d-none")
+                    .addClass("d-table-row");
             } else {
                 const format = $option.data("format");
                 if (format) {
@@ -186,6 +187,7 @@ odoo.define("web_pivot_computed_measure.PivotController", function(require) {
                 }
                 this.$buttons_measures_ex
                     .find("#container_computed_measure_operation_custom")
+                    .removeClass("d-table-row")
                     .addClass("d-none");
             }
         },

--- a/web_pivot_computed_measure/static/src/scss/web_pivot_computed_measure.scss
+++ b/web_pivot_computed_measure/static/src/scss/web_pivot_computed_measure.scss
@@ -1,0 +1,9 @@
+#add_computed_measure_wrapper {
+    padding: 0 20px;
+    min-width: 300px;
+    white-space: nowrap;
+    .d-table-cell {
+        vertical-align: middle;
+        padding: 3px 0;
+    }
+}

--- a/web_pivot_computed_measure/static/src/xml/web_pivot_computed_measure.xml
+++ b/web_pivot_computed_measure/static/src/xml/web_pivot_computed_measure.xml
@@ -59,73 +59,98 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 </span>
             </a>
             <t t-if="isOpen">
-                <div class="dropdown-item-text">
-                    <label for="computed_measure_field_1">Measure 1</label>
-                    <select
-                        class="o_input o_date_field_selector"
-                        id="computed_measure_field_1"
+                <div id="add_computed_measure_wrapper" class="d-table">
+                    <div class="d-table-row">
+                        <div class="d-table-cell">
+                            <label for="computed_measure_field_1">Measure 1</label>
+                        </div>
+                        <div class="d-table-cell">
+                            <select class="o_input" id="computed_measure_field_1">
+                                <t t-foreach="measures" t-as="measure">
+                                    <option t-att-value="measure[0]">
+                                        <t t-esc="measure[1].string" />
+                                    </option>
+                                </t>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="d-table-row">
+                        <div class="d-table-cell">
+                            <label for="computed_measure_field_2">Measure 2</label>
+                        </div>
+                        <div class="d-table-cell">
+                            <select class="o_input" id="computed_measure_field_2">
+                                <t t-foreach="measures" t-as="measure">
+                                    <option t-att-value="measure[0]">
+                                        <t t-esc="measure[1].string" />
+                                    </option>
+                                </t>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="d-table-row">
+                        <div class="d-table-cell">
+                            <label for="computed_measure_operation">Operation</label>
+                        </div>
+                        <div class="d-table-cell">
+                            <select class="o_input" id="computed_measure_operation">
+                                <t
+                                    t-call="web_pivot_computed_measure.ComputedMeasureOperations"
+                                />
+                            </select>
+                        </div>
+                    </div>
+                    <div
+                        t-if="debug"
+                        class="d-none"
+                        id="container_computed_measure_operation_custom"
                     >
-                        <t t-foreach="measures" t-as="measure">
-                            <option t-att-value="measure[0]">
-                                <t t-esc="measure[1].string" />
-                            </option>
-                        </t>
-                    </select>
-                </div>
-                <div class="dropdown-item-text">
-                    <label for="computed_measure_field_2">Measure 2</label>
-                    <select
-                        class="o_input o_time_range_selector"
-                        id="computed_measure_field_2"
-                    >
-                        <t t-foreach="measures" t-as="measure">
-                            <option t-att-value="measure[0]">
-                                <t t-esc="measure[1].string" />
-                            </option>
-                        </t>
-                    </select>
-                </div>
-                <div class="dropdown-item-text">
-                    <label for="computed_measure_operation">Operation</label>
-                    <select
-                        class="o_input o_time_range_selector"
-                        id="computed_measure_operation"
-                    >
-                        <t
-                            t-call="web_pivot_computed_measure.ComputedMeasureOperations"
-                        />
-                    </select>
-                </div>
-                <div
-                    t-if="debug"
-                    class="dropdown-item-text d-none"
-                    id="container_computed_measure_operation_custom"
-                >
-                    <label for="computed_measure_operation_custom">Formula</label>
-                    <input type="text" id="computed_measure_operation_custom" />
-                </div>
-                <div class="dropdown-item-text">
-                    <label for="computed_measure_name">Name</label>
-                    <input
-                        placeholder="Can be empty"
-                        type="text"
-                        id="computed_measure_name"
-                    />
-                </div>
-                <div class="dropdown-item-text">
-                    <label for="computed_measure_format">Format</label>
-                    <select
-                        class="o_input o_time_range_selector"
-                        id="computed_measure_format"
-                    >
-                        <t t-call="web_pivot_computed_measure.ComputedMeasureFormats" />
-                    </select>
-                </div>
-                <div class="dropdown-item-text">
-                    <button
-                        class="btn btn-primary o_add_computed_measure"
-                        type="button"
-                    >Add</button>
+                        <div class="d-table-cell">
+                            <label
+                                for="computed_measure_operation_custom"
+                            >Formula</label>
+                        </div>
+                        <div class="d-table-cell">
+                            <input
+                                type="text"
+                                class="o_input"
+                                id="computed_measure_operation_custom"
+                            />
+                        </div>
+                    </div>
+                    <div class="d-table-row">
+                        <div class="d-table-cell">
+                            <label for="computed_measure_name">Name</label>
+                        </div>
+                        <div class="d-table-cell">
+                            <input
+                                placeholder="Can be empty"
+                                type="text"
+                                class="o_input"
+                                id="computed_measure_name"
+                            />
+                        </div>
+                    </div>
+                    <div class="d-table-row">
+                        <div class="d-table-cell">
+                            <label for="computed_measure_format">Format</label>
+                        </div>
+                        <div class="d-table-cell">
+                            <select class="o_input" id="computed_measure_format">
+                                <t
+                                    t-call="web_pivot_computed_measure.ComputedMeasureFormats"
+                                />
+                            </select>
+                        </div>
+                    </div>
+                    <div class="d-table-row">
+                        <div class="d-table-cell">
+                            <button
+                                class="btn btn-primary o_add_computed_measure"
+                                type="button"
+                            >Add</button>
+                        </div>
+                    </div>
                 </div>
             </t>
         </div>

--- a/web_pivot_computed_measure/view/assets.xml
+++ b/web_pivot_computed_measure/view/assets.xml
@@ -10,6 +10,10 @@
                 type="text/javascript"
                 src="/web_pivot_computed_measure/static/src/js/pivot_controller.js"
             />
+            <link
+                rel="stylesheet"
+                href="/web_pivot_computed_measure/static/src/scss/web_pivot_computed_measure.scss"
+            />
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
cc @Tecnativa TT25958

Put in the same line the label and the dropdowns for saving vertical space as @pedrobaeza commented in the PR of the migration of this module to v13 https://github.com/OCA/web/pull/1746#pullrequestreview-539258233
Current
![image](https://user-images.githubusercontent.com/38267832/100829407-47f0c200-342f-11eb-8c03-cad61d182ff8.png)

Desired
![image](https://user-images.githubusercontent.com/38267832/100828635-8c7b5e00-342d-11eb-9aff-0af2d4f539ed.png)
