### PR TITLE
[13.0][IMP] web_responsive: Cut long filters names in the filters menu

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -757,3 +757,17 @@ html .o_web_client .o_action_manager .o_action {
         }
     }
 }
+
+// Filter Menu
+.o_control_panel {
+    .o_filters_menu {
+        .o_menu_item {
+            @include o-search-options-dropdown-custom-item;
+
+            a {
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Same as https://github.com/OCA/web/pull/1750 but for 13.0

cc @tecnativa TT27055