### PR TITLE
[12.0][IMP] web_widget_numeric_step: better visualization in list view cells

### DIFF
--- a/web_widget_numeric_step/static/src/css/numeric_step.scss
+++ b/web_widget_numeric_step/static/src/css/numeric_step.scss
@@ -1,3 +1,6 @@
 .widget_numeric_step {
     display: inline-flex;
 }
+.numeric_step_editing_cell {
+    min-width: 120px;
+}

--- a/web_widget_numeric_step/static/src/js/numeric_step.js
+++ b/web_widget_numeric_step/static/src/js/numeric_step.js
@@ -124,7 +124,18 @@ odoo.define('web_widget_numeric_step.field', function (require) {
          * @override
          */
         _renderEdit: function () {
+            $("td.o_numeric_step_cell").addClass("numeric_step_editing_cell");
             this._prepareInput(this.$el.find('input.input_numeric_step'));
+        },
+
+        /**
+         * Resets the content to the formated value in readonly mode.
+         *
+         * @override
+         */
+        _renderReadonly: function () {
+            $("td.o_numeric_step_cell").removeClass("numeric_step_editing_cell");
+            this._super.apply(this, arguments);
         },
 
         /**


### PR DESCRIPTION
cc @Tecnativa TT25581

better visualization in list view cells. If a list view has many columns and the widget field (numeric step) has a very small width, editing it is very difficult.
Before:
![image](https://user-images.githubusercontent.com/38267832/102020298-5485ec00-3d46-11eb-8e57-52d85a7703e5.png)
After:
![2020-12-13_13-26](https://user-images.githubusercontent.com/38267832/102020402-fc9bb500-3d46-11eb-8f24-b274732ab296.png)
