### PR TITLE
[CHANGE] Wrap and center app name

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -235,6 +235,8 @@ $chatter_zone_width: 35%;
             margin-top: 4px;
             font-size: 1.25rem;
             text-shadow: 1px 1px 1px rgba(gray("black"), 0.4);
+            white-space: normal;
+            text-align: center;
         }
         // Search input for menus
         .form-row {


### PR DESCRIPTION
Before : Long app names are not wrapped and therefore are covering one each other

![Capture d’écran 2020-12-28 à 11 06 36](https://user-images.githubusercontent.com/12003829/103206753-d9533700-48fc-11eb-88ae-435e18752561.png)

After : Long app names are wrapped and do not cover each other anymore

![Capture d’écran 2020-12-28 à 11 06 48](https://user-images.githubusercontent.com/12003829/103206768-e07a4500-48fc-11eb-959a-5ce3b2370dda.png)
