### PR TITLE
[12.0][FIX] web_widget_numeric_step: Better visualization in list view cells

### DIFF
--- a/web_widget_numeric_step/static/src/css/numeric_step.scss
+++ b/web_widget_numeric_step/static/src/css/numeric_step.scss
@@ -1,6 +1,11 @@
 .widget_numeric_step {
     display: inline-flex;
 }
+
 .numeric_step_editing_cell {
     min-width: 120px;
+
+    .input_numeric_step {
+        height: auto;
+    }
 }

--- a/web_widget_numeric_step/static/src/js/numeric_step.js
+++ b/web_widget_numeric_step/static/src/js/numeric_step.js
@@ -21,6 +21,7 @@ odoo.define('web_widget_numeric_step.field', function (require) {
             'keydown .input_numeric_step': '_onKeyDown',
             'change .input_numeric_step': '_onChange',
             'input .input_numeric_step': '_onInput',
+            'onfocusout .widget_numeric_step': '_onFocusOut',
         }),
         supportedFieldTypes: ['float', 'integer'],
 
@@ -32,6 +33,9 @@ odoo.define('web_widget_numeric_step.field', function (require) {
         DELAY_THROTTLE_CHANGE: 200,
 
 
+        /**
+         * @override
+         */
         init: function () {
             this._super.apply(this, arguments);
 
@@ -124,7 +128,9 @@ odoo.define('web_widget_numeric_step.field', function (require) {
          * @override
          */
         _renderEdit: function () {
-            $("td.o_numeric_step_cell").addClass("numeric_step_editing_cell");
+            _.defer(function () {
+                this.$el.parents("td.o_numeric_step_cell").addClass("numeric_step_editing_cell");
+            }.bind(this));
             this._prepareInput(this.$el.find('input.input_numeric_step'));
         },
 
@@ -134,7 +140,7 @@ odoo.define('web_widget_numeric_step.field', function (require) {
          * @override
          */
         _renderReadonly: function () {
-            $("td.o_numeric_step_cell").removeClass("numeric_step_editing_cell");
+            this.$el.parents("td.numeric_step_editing_cell").removeClass("numeric_step_editing_cell");
             this._super.apply(this, arguments);
         },
 
@@ -166,7 +172,21 @@ odoo.define('web_widget_numeric_step.field', function (require) {
             }
         },
 
+        /**
+         * @private
+         */
+        _clearStepInterval: function () {
+            clearTimeout(this._auto_step_interval);
+            this._auto_step_interval = false;
+            this._click_delay = this.DEF_CLICK_DELAY;
+        },
+
         // Handle Events
+
+        /**
+         * @private
+         * @param {MouseClickEvent} ev
+         */
         _onStepClick: function (ev) {
             if (!this._autoStep) {
                 var mode = ev.target.dataset.mode;
@@ -175,19 +195,38 @@ odoo.define('web_widget_numeric_step.field', function (require) {
             this._autoStep = false;
         },
 
+        /**
+         * @private
+         * @param {MouseClickEvent} ev
+         */
         _onStepMouseDown: function (ev) {
-            if (!this._auto_step_interval) {
+            if (ev.button === 0 && !this._auto_step_interval) {
                 this._auto_step_interval = setTimeout(
                     $.proxy(this, "_whileMouseDown", ev), this._click_delay);
             }
         },
 
-        _onMouseUp: function () {
-            clearTimeout(this._auto_step_interval);
-            this._auto_step_interval = false;
-            this._click_delay = this.DEF_CLICK_DELAY;
+        /**
+         * @private
+         * @param {FocusoutEvent} ev
+         */
+        _onFocusOut: function (evt) {
+            if (this._auto_step_interval) {
+                this._clearStepInterval();
+            }
         },
 
+        /**
+         * @private
+         */
+        _onMouseUp: function () {
+            this._clearStepInterval();
+        },
+
+        /**
+         * @private
+         * @param {MouseClickEvent} ev
+         */
         _whileMouseDown: function (ev) {
             this._autoStep = true;
             var mode = ev.target.dataset.mode;


### PR DESCRIPTION
Fix #1760 changes

Previous PR applies the css class to all elements, so one in "readonly" mode affects to other in "normal" mode.
For a strange cause i need use "defer" .. appears that "start" resolves the promise before insert DOM operation ends.
Now click event only affects if "left click" was pressed.
Now the "auto step" events are cleaned if the widget lost the focus.

cc @tecnativa TT27407

![numeric_step](https://user-images.githubusercontent.com/731270/103304649-7ac7af00-4a09-11eb-81b3-a8b02b26605f.gif)
