### PR TITLE
[13.0][web_widget_domain_editor_dialog][FIX] Error when used in wizards.

### DIFF
--- a/web_widget_domain_editor_dialog/static/src/js/basic_fields.js
+++ b/web_widget_domain_editor_dialog/static/src/js/basic_fields.js
@@ -16,6 +16,9 @@ odoo.define("web_widget_domain_editor_dialog.basic_fields", function(require) {
             if (this.mode === "readonly") {
                 return this._super.apply(this, arguments);
             }
+            if (!this.value) {
+                this.value = [];
+            }
             const dialog = new DomainEditorDialog(this, {
                 title: _t("Select records..."),
                 res_model: this._domainModel,


### PR DESCRIPTION
When clicking edit the list of record an error happened due to lack
of proper initialization of the default domain.


https://user-images.githubusercontent.com/7683926/105528833-c35f4900-5ce5-11eb-8ecb-f6dc6f185a6c.mp4

@chienandalu @CarlosRoca13
