### PR TITLE
[Fix] issue #1683 : show_row_totals and show_column_totals doesn't work

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -59,14 +59,16 @@ odoo.define("web_widget_x2many_2d_matrix.widget", function(require) {
                     )
                 );
             }
+            this.show_row_totals = this.parse_boolean(node.show_row_totals || "1");
             this.show_row_totals = this.parse_boolean(
-                node.show_row_totals ||
+                this.show_row_totals &&
                     this.is_aggregatable(field_defs[this.field_value])
                     ? "1"
                     : ""
             );
+            this.show_column_totals = this.parse_boolean(node.show_column_totals || "1");
             this.show_column_totals = this.parse_boolean(
-                node.show_column_totals ||
+                this.show_column_totals &&
                     this.is_aggregatable(field_defs[this.field_value])
                     ? "1"
                     : ""


### PR DESCRIPTION
Correction of .js for the correct operation of the show_row_totals and show_colum_totals fields.

This error must be present in other branches, but I have been able to test it on V 13 

The logical operation was incorrect, because as long as the fields were aggregated, it would show sums in rows and columns, also I think there could be errors when retrieving node.show_row_totals and node.show_column_totals values, because parse was not performed.

Modification does not change behavior. If these values are not specified, the summation will be displayed as indicated in the documentation. 
