### PR TITLE
[10.0] [FIX] web_m2x_options:  Open m2m_tag form into the same view mode as the parent form

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -434,7 +434,12 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                         res_model: self.field.relation,
                         views: [[false, 'form']],
                         res_id: id,
-                        target: "new"
+                        target: "new",
+                        flags: {
+                            form: {
+                                "initial_mode": self.view.get('actual_mode'),
+                            }
+                        }
                     });
                 }.bind(this));
             }else if(no_color_picker){


### PR DESCRIPTION
On many2many_tags widget open dialog with the same view mode as the parent view

Before this change the Form was always opened in edit mode when clicking on a many2many_tags. With this change, the Form is always open into the same mode as the parent form.