### PR TITLE
[FIX][12.0] search_panel view: Do not apply model domain to comodel

### DIFF
--- a/web_view_searchpanel/models/base.py
+++ b/web_view_searchpanel/models/base.py
@@ -48,16 +48,10 @@ class Base(models.AbstractModel):
         if parent_name:
             fields.append(parent_name)
 
-        model_domain = expression.AND([
-            kwargs.get('search_domain', []),
-            kwargs.get('category_domain', []),
-            kwargs.get('filter_domain', []),
-        ])
-
         return {
             'parent_field': parent_name,
             'values': Comodel.with_context(
-                hierarchical_naming=False).search_read(model_domain, fields),
+                hierarchical_naming=False).search_read([], fields),
         }
 
     @api.model


### PR DESCRIPTION
Description
-----------

This commit fixes incorrect bechavior (error thrown) in case when
additional `domain` provided to action (`ir.actions.act_window`)
that displays view with search panel enabled.

Before this commit
------------------

For example we have following models:
- My Category
- My Model

And in category view, we have stat-button that display number of records
of records in this category. On click, it have to open view for My
Model, with domain like `[('category_id', '=', 42)]`.
In this case, following error will be raised:

```tracaback
Error:
Odoo Server Error

Traceback (most recent call last):
  ...
  File "/opt/odoo/custom_addons/web_view_searchpanel/models/base.py", line 60, in search_panel_select_range
    hierarchical_naming=False).search_read(model_domain, fields),
  File "/opt/odoo/odoo/odoo/models.py", line 4615, in search_read
    records = self.search(domain or [], offset=offset, limit=limit, order=order)
  File "/opt/odoo/odoo/odoo/models.py", line 1581, in search
    res = self._search(args, offset=offset, limit=limit, order=order, count=count)
  File "/opt/odoo/odoo/odoo/models.py", line 4147, in _search
    query = self._where_calc(args)
  File "/opt/odoo/odoo/odoo/models.py", line 3939, in _where_calc
    e = expression.expression(domain, self)
  File "/opt/odoo/odoo/odoo/osv/expression.py", line 673, in __init__
    self.parse()
  File "/opt/odoo/odoo/odoo/osv/expression.py", line 854, in parse
    raise ValueError("Invalid field %r in leaf %r" % (left, str(leaf)))
ValueError: Invalid field 'category_id' in leaf "<osv.ExtendedLeaf: ('category_id', '=', 26) on bureaucrat_knowledge_category (ctx: )>"
```

Diagnostics
-----------

It seems that model domain was passed to comodel, thus system cannot
find field related to model in comodel. See code
(web_view_searchpanel/models/base.py", line 60, in
search_panel_select_range)

As tested, the `search_domain` causes this bug.

But if we look at implementation of same method
(`search_panel_select_range`) in Odoo 13.0 (see
[code](https://github.com/odoo/odoo/blob/13.0/addons/web/models/models.py#L214))
then we can see, that there is only empty domain applied for search.

Solution
--------

It seems, that variable `model_domain` could be simply removed, and
we could do the search in comodel without any extra domain in this case.

So, this commit, only makes imlementation of this method look same as in
Odoo 13.0

After this commit
-----------------

Everything is working fine.