### PR TITLE
[12.0][IMP] web_widget_one2many_product_picker: BS grid columns

### DIFF
--- a/web_widget_one2many_product_picker/README.rst
+++ b/web_widget_one2many_product_picker/README.rst
@@ -177,6 +177,13 @@ Other example for 'purchase.order.line' fields:
         </form>
     </field>
 
+
+Boostrap Modifications:
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The product picker view container have a custom media queries space adding a new screen size called 'xxl' (>= 1440px) and modifies the columns to have 24 instead of 12.
+This means that you can use "col-xxl-" inside the product picker view container.
+
 Usage
 =====
 

--- a/web_widget_one2many_product_picker/readme/CONFIGURE.rst
+++ b/web_widget_one2many_product_picker/readme/CONFIGURE.rst
@@ -134,3 +134,10 @@ Other example for 'purchase.order.line' fields:
             <field name="product_uom" class="mb-2" options="{'no_open': True, 'no_create': True, 'no_edit': True}" />
         </form>
     </field>
+
+
+Boostrap Modifications:
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The product picker view container have a custom media queries space adding a new screen size called 'xxl' (>= 1440px) and modifies the columns to have 24 instead of 12.
+This means that you can use "col-xxl-" inside the product picker view container.

--- a/web_widget_one2many_product_picker/static/description/index.html
+++ b/web_widget_one2many_product_picker/static/description/index.html
@@ -377,10 +377,10 @@ ul.auto-toc {
 <li><a class="reference internal" href="#widget-options" id="id3">Widget options:</a></li>
 <li><a class="reference internal" href="#default-context" id="id4">Default context:</a></li>
 <li><a class="reference internal" href="#examples" id="id5">Examples:</a></li>
+<li><a class="reference internal" href="#boostrap-modifications" id="id6">Boostrap Modifications:</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#usage" id="id6">Usage</a><ul>
-<li><a class="reference internal" href="#parts-of-the-widget" id="id7">Parts of the widget:</a></li>
+<li><a class="reference internal" href="#usage" id="id7">Usage</a><ul>
 <li><a class="reference internal" href="#preview" id="id8">Preview:</a></li>
 </ul>
 </li>
@@ -562,18 +562,14 @@ options=&quot;{'search': [{'name': _('Starts With'), 'domain': [('name', '=like'
 <span class="nt">&lt;/field&gt;</span>
 </pre>
 </div>
+<div class="section" id="boostrap-modifications">
+<h2><a class="toc-backref" href="#id6">Boostrap Modifications:</a></h2>
+<p>The product picker view container have a custom media queries space adding a new screen size called ‘xxl’ (&gt;= 1440px) and modifies the columns to have 24 instead of 12.
+This means that you can use “col-xxl-” inside the product picker view container.</p>
+</div>
 </div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#id6">Usage</a></h1>
-<p>When you change the value of a field and switch to edit another record, the
-changes will be applied to the previous record without having to click on
-accept changes.</p>
-<div class="section" id="parts-of-the-widget">
-<h2><a class="toc-backref" href="#id7">Parts of the widget:</a></h2>
-<blockquote>
-<img alt="https://raw.githubusercontent.com/OCA/web/12.0/web_widget_one2many_product_picker/static/img/product_picker_anat.png" src="https://raw.githubusercontent.com/OCA/web/12.0/web_widget_one2many_product_picker/static/img/product_picker_anat.png" />
-</blockquote>
-</div>
+<h1><a class="toc-backref" href="#id7">Usage</a></h1>
 <div class="section" id="preview">
 <h2><a class="toc-backref" href="#id8">Preview:</a></h2>
 <blockquote>

--- a/web_widget_one2many_product_picker/static/src/scss/main_variables.scss
+++ b/web_widget_one2many_product_picker/static/src/scss/main_variables.scss
@@ -1,0 +1,6 @@
+$one2many-product-picker-grid-breakpoints: map-merge(
+    $grid-breakpoints,
+  (
+    xxl: 1440px,
+  )
+);

--- a/web_widget_one2many_product_picker/static/src/scss/one2many_product_picker.scss
+++ b/web_widget_one2many_product_picker/static/src/scss/one2many_product_picker.scss
@@ -45,6 +45,8 @@
     }
 
     .oe_one2many_product_picker_view {
+        @include make-grid-columns($columns: 24, $breakpoints: $one2many-product-picker-grid-breakpoints);
+
         overflow: auto;
 
         > .row {

--- a/web_widget_one2many_product_picker/static/src/xml/one2many_product_picker.xml
+++ b/web_widget_one2many_product_picker/static/src/xml/one2many_product_picker.xml
@@ -69,7 +69,7 @@
     </t>
 
     <t t-name="One2ManyProductPicker.FlipCard">
-        <div class="oe_flip_container p-1 col-4 col-sm-4 col-md-2 col-lg-2 col-xl-1">
+        <div class="oe_flip_container p-1 col-12 col-sm-8 col-md-6 col-lg-4 col-xl-3 col-xxl-2">
             <div t-attf-class="oe_flip_card {{!state &amp;&amp; 'disabled' || ''}}">
                 <div class="oe_flip_card_inner text-center">
                     <div t-attf-class="oe_flip_card_front p-0 {{(modified &amp;&amp; 'border-warning') || (state &amp;&amp; !is_virtual &amp;&amp; 'border-success') || ''}}">

--- a/web_widget_one2many_product_picker/templates/assets.xml
+++ b/web_widget_one2many_product_picker/templates/assets.xml
@@ -7,6 +7,12 @@
         </xpath>
     </template>
 
+    <template id="_assets_bootstrap" inherit_id="web._assets_bootstrap">
+        <xpath expr="link[2]">
+          <link type="text/css" rel="stylesheet" href="/web_widget_one2many_product_picker/static/src/scss/main_variables.scss"/>
+        </xpath>
+    </template>
+
     <template id="assets_backend" name="account assets" inherit_id="web.assets_backend">
         <xpath expr="." position="inside">
             <link type="text/css" rel="stylesheet"


### PR DESCRIPTION
Adds more cols (24 instead of 12) to the product picker container
Adds a new media query to bigger screens >= 1440px (col-xxl-)

Current grid columns: 3 - 6 - 12
With this PR (more screen sizes): 2 - 3 - 4 - 6 - 8 - 12
** Values per screen size

Old vs New Previews:

- col-xs
  - old
![old_prod_pick_xs](https://user-images.githubusercontent.com/731270/106902066-b0427500-66f8-11eb-8630-12d3dca66ce0.png)
  - new
![new_prod_pick_xs](https://user-images.githubusercontent.com/731270/106902187-d23bf780-66f8-11eb-9c6f-95ed4c7ed9ec.png)

- col-sm
  - old
![old_prod_pick_sm](https://user-images.githubusercontent.com/731270/106902353-057e8680-66f9-11eb-903d-11f66263b208.png)
  - new
![new_prod_pick_sm](https://user-images.githubusercontent.com/731270/106902373-0e6f5800-66f9-11eb-8fa4-4bd2a8334056.png)

- col-md
  - old
![old_prod_pick_md](https://user-images.githubusercontent.com/731270/106902391-13cca280-66f9-11eb-8a70-5fc5cfbe5bf9.png)
  - new
![new_prod_pick_md](https://user-images.githubusercontent.com/731270/106902414-1a5b1a00-66f9-11eb-85d6-8f6fe55ff7f7.png)

- col-lg
  - old
![old_prod_pick_lg](https://user-images.githubusercontent.com/731270/106902437-1fb86480-66f9-11eb-8990-7f889b536df4.png)
  - new
![new_prod_pick_lg](https://user-images.githubusercontent.com/731270/106902452-2515af00-66f9-11eb-826a-960a32b127f2.png)

- col-xl
  - old
![old_prod_pick_xl](https://user-images.githubusercontent.com/731270/106902470-2b0b9000-66f9-11eb-9379-a70f9cc698d7.png)
  - new
![new_prod_pick_xl](https://user-images.githubusercontent.com/731270/106902477-2fd04400-66f9-11eb-8645-507885f4d3a2.png)

- col-xxl
  - new
![new_prod_pick_xxl](https://user-images.githubusercontent.com/731270/106902502-3494f800-66f9-11eb-851d-b6ffdaf41153.png)


cc @tecnativa TT28038