### PR TITLE
[12.0][FIX] web_responsive: Do not set overflow property on inline fields

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -397,14 +397,17 @@ html .o_web_client .o_main .o_main_content {
         // Support for long title (with ellipsis)
         .oe_title {
             span.o_field_widget {
-                max-width: 100%;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-                overflow: hidden;
-                width: initial;
-            }
-            span:active {
-                white-space: normal;
+                &:not(.oe_inline) {
+                    max-width: 100%;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    width: initial;
+                    
+                    &:active {
+                        white-space: normal;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
The responsive css does not exclude inline fields when it wants enabled ellipsis on titles and it leads to wrong align.

Before:
![image](https://user-images.githubusercontent.com/22446243/107046842-62e10900-67c7-11eb-85b6-2fd17888c427.png)

After:
![image](https://user-images.githubusercontent.com/22446243/107046809-56f54700-67c7-11eb-9eb6-db6837e1f084.png)
