### PR TITLE
[12.0] web_m2x_options: fix always show search more

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -177,7 +177,7 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                     search_more_undef = _.isUndefined(self.nodeOptions.search_more) && _.isUndefined(ir_options['web_m2x_options.search_more']),
                     search_more = is_option_set(ir_options['web_m2x_options.search_more']);
 
-                if (values.length > self.limit) {
+                if (values.length > self.limit || search_more) {
                     values = values.slice(0, self.limit);
                     if (can_search_more || search_more_undef || search_more) {
                         values.push({


### PR DESCRIPTION
Add fix to show 'search more' on many2one field always when such option is set on field.
Before that, even if field had attribute option={'search_more':True} it wasn't working due to conditions in the function.