### PR TITLE
[FIX] web_ir_actions_act_multi: preprocess chained actions

### DIFF
--- a/web_ir_actions_act_multi/static/src/js/web_ir_actions_act_multi.js
+++ b/web_ir_actions_act_multi/static/src/js/web_ir_actions_act_multi.js
@@ -23,8 +23,8 @@ odoo.define('web_ir_actions_act_multi.ir_actions_act_multi', function (require) 
 
         /**
          * Handle 'ir.actions.act_multi' action
-         * @param {Object} action see _handleAction() parameters
-         * @param {Object} options see _handleAction() parameters
+         * @param {Object} action see doAction() parameters
+         * @param {Object} options see doAction() parameters
          * @param {integer|undefined} index Index of action being handled
          * @returns {$.Promise}
          */
@@ -36,13 +36,13 @@ odoo.define('web_ir_actions_act_multi.ir_actions_act_multi', function (require) 
             }
 
             if (index === action.actions.length - 1) {
-                return this._handleAction(action.actions[index], options);
+                return this.doAction(action.actions[index], options);
             } else if (index >= action.actions.length) {
                 return $.when();
             }
 
             return this
-                ._handleAction(action.actions[index], options)
+                .doAction(action.actions[index], options)
                 .then(function () {
                     return self._executeMultiAction(action, options, index + 1);
                 });


### PR DESCRIPTION
The proper way to execute an action is to pass it trhough `doAction` instead of `_handleAction`, because `doAction` performs some preparations to make the action usable.

One example is if some of your chained actions returns `context` as a string. That is valid for Odoo, but since we are skipping the action preparation step, it does not get evaluated and thus fails.

@Tecnativa TT28202