### PR TITLE
[14.0][FIX] web_responsive error on grouped mobile kanban with zero groups

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -710,6 +710,19 @@ html .o_web_client .o_action_manager .o_action {
         }
     }
 
+    //No content message improvements on mobile
+    @include media-breakpoint-down(md) {
+        .o_view_nocontent {
+            top: 80px;
+        }
+        .o_nocontent_help {
+            box-shadow: none;
+        }
+        .o_sample_data_disabled {
+            display: none;
+        }
+    }
+
     // Sided chatter, if user wants
     .o_chatter_position_sided & {
         @include media-breakpoint-up(lg) {

--- a/web_responsive/static/src/js/kanban_renderer_mobile.js
+++ b/web_responsive/static/src/js/kanban_renderer_mobile.js
@@ -26,6 +26,24 @@
             this._super.apply(this, arguments);
             this.isMobile = true;
         },
+        /**
+         * KanbanRenderer will decide can we close quick create or not
+         * @private
+         * @override
+         */
+        _cancel: function () {
+            this.trigger_up("close_quick_create");
+        },
+        /**
+         * Clear input when showed
+         * @override
+         */
+        toggleFold: function () {
+            this._super.apply(this, arguments);
+            if (!this.folded) {
+                this.$input.val("");
+            }
+        },
     });
 
     KanbanView.include({
@@ -345,6 +363,9 @@
          *   and displayed
          */
         _moveToGroup: function (moveToIndex, animate) {
+            if (this.widgets.length === 0) {
+                return Promise.resolve();
+            }
             var self = this;
             if (moveToIndex >= 0 && moveToIndex < this.widgets.length) {
                 this.activeColumnIndex = moveToIndex;
@@ -477,8 +498,8 @@
             if (event) {
                 event.stopPropagation();
             }
-            this.$(".o_kanban_group").toggle();
             this.quickCreate.toggleFold();
+            this.$(".o_kanban_group").toggle(this.quickCreate.folded);
         },
         /**
          * @private
@@ -489,6 +510,16 @@
                 this.quickCreate.toggleFold();
             }
             this._moveToGroup($(event.currentTarget).index(), true);
+        },
+        /**
+         * @private
+         * @override
+         */
+        _onCloseQuickCreate: function () {
+            if (this.widgets.length && !this.quickCreate.folded) {
+                this.$(".o_kanban_group").toggle(true);
+                this.quickCreate.toggleFold();
+            }
         },
     });
 });


### PR DESCRIPTION
When trying to reproduce #1870 I've found another problem.
When mobile kanban view rendered in grouped mode (f.x. CRM Pipeline) and there is no groups, JavaScript error appears.
This PR fixes it.