### PR TITLE
[12.0][FIX] Freeze and bump matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ bokeh==1.1.0
 # web_widget_plotly_chart
 plotly==4.1.0
 # web_widget_mpld3_chart
-matplotlib>=2.0.0
+matplotlib==3.0.3; python_version < '3.7'
+matplotlib==3.4.1; python_version >= '3.7'
 mpld3==0.3


### PR DESCRIPTION
More recent versions of matplotlib depend on Pillow >= 6.2 which is [incompatible with Odoo dependencies](https://github.com/odoo/odoo/blob/b2afcb56cc42b89bad2a90e3d46b9787a0804264/requirements.txt#L23-L24).

Depending on your python version it can cause some silent bugs like barcodes not rendering in reports.

This is the latest version that depends on Pillow >= 3.4

Please also check out the 13.0 FW PR : https://github.com/OCA/web/pull/1894