### PR TITLE
[8.0][FIX] web_export_view: Boolean fields aren't export

### DIFF
--- a/web_export_view/README.rst
+++ b/web_export_view/README.rst
@@ -45,6 +45,7 @@ Contributors
  * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
  * Stefan Rijnhart <stefan@therp.nl>
  * Leonardo Pistone <leonardo.pistone@camptocamp.com>
+ * Isaac Gallart <igallart@puntsistemes.es>
 
 Maintainer
 ----------

--- a/web_export_view/static/src/js/web_export_view.js
+++ b/web_export_view/static/src/js/web_export_view.js
@@ -145,7 +145,8 @@ openerp.web_export_view = function (instance) {
                     $.each(view.visible_columns, function() {
                         if(this.tag == 'field'){
                             export_row.push(
-                                this.type != 'integer' && this.type != 'float' ?
+                                this.type != 'integer' && this.type != 'float'
+                                && this.type != 'boolean' ?
                                 jQuery('<div/>').html(this.format(
                                     record.data, {process_modifiers: false}
                                 )).text() : record.data[this.id].value


### PR DESCRIPTION
In excel file, the boolean fields appear without value.

Runbot
http://3478259-8-0-6ea583.runbot3.odoo-community.org/web?debug=#page=0&limit=80&view_type=list&model=product.product&action=143