### PR TITLE
[FIX] The document preview can't be used properly because .o_modal_fullscreen.o_document_viewer has z-index: 10 small than z-index: 1051 of .o_thread_window

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -697,7 +697,7 @@ html .o_web_client .o_action_manager .o_action {
 .o_web_client.o_chatter_position_sided {
     .o_modal_fullscreen.o_document_viewer {
         // On-top of navbar
-        z-index: 10;
+        z-index: $o-mail-thread-window-zindex + 1;
 
         &.o_responsive_document_viewer {
             /* Show sided viewer on large screens */


### PR DESCRIPTION
Fix issuse #1910