### PR TITLE
[14.0][FIX] web_responsive word wrap for appdrawer menu items

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -195,6 +195,8 @@ $chatter_zone_width: 35%;
             background: none;
             transition: 300ms ease;
             transition-property: background-color;
+            white-space: normal;
+            text-align: center;
 
             img {
                 box-shadow: none;


### PR DESCRIPTION
This PR adds word wrapping for applications menu items.
It's hard to reproduce problem with english locale, but these steps are quite close to problem.
Steps to reproduce:
1. On 14.0 runbot install modules Email Marketing and Manufacturing.
2. Open Applications menu with web_responsive installed.
On some resolutions app names of just installed modules may overlap.
![image](https://user-images.githubusercontent.com/6389955/116752725-ac2fa600-aa0e-11eb-8200-e6788d82dfaa.png)
With english locale it is not actually happen. But screenshot with russian locale can illustrate problem:
![image](https://user-images.githubusercontent.com/6389955/116753126-47288000-aa0f-11eb-9a2b-93cac0452c66.png)
I think this problem may affect some other locales.