### PR TITLE
Update README.md for the activation of the HTTP2 protocol for Odoo OCA

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,13 @@ This project aims to deal with modules related to the webclient of Odoo. You'll 
 - Ease the import/export features
 - Generally add clientside functionality
 
+The activation of the HTTP2 protocol for Odoo OCA
+=================================================
 
+This section is related to the activation of the HTTP2 protocol and get the Responsive Web UI loading correctly, when deploying Odoo behind a Proxy Server (Nginx, Traefik, Apache, ...) :
+
+     1. - Nginx Proxy :
+     
+         - Install Odoo OCA Web Responsive module.
+         - Activate the HTTP2 protocol in the server block of your Odoo Nginx configuration file's.
+         - Add the Nginx parameter "large_client_header_buffers" with a minimum size of "4 32k" in your Nginx proxy configuration file's to the HTTP block.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ This section is related to the activation of the HTTP2 protocol and get the Resp
      
          - Install Odoo OCA Web Responsive module.
          - Activate the HTTP2 protocol in the server block of your Odoo Nginx configuration file's.
-         - Add the Nginx parameter "large_client_header_buffers" with a minimum size of "4 32k" in your Nginx proxy configuration file's to the HTTP block.
+         - Add the Nginx parameter "[large_client_header_buffers](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers)" with a minimum size of "4 32k" in your Nginx proxy configuration file's to the HTTP block.


### PR DESCRIPTION
This PR is related to the activation of the HTTP2 protocol and get the Responsive Web UI loading correctly, when deploying Odoo behind a Proxy Server (Nginx, Traefik, Apache, ...)