### PR TITLE
[14.0][FIX] web_widget_x2many_2d_matrix - show_column_totals and show_row_totals

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -59,17 +59,13 @@ odoo.define("web_widget_x2many_2d_matrix.widget", function (require) {
                     )
                 );
             }
-            this.show_row_totals = this.parse_boolean(
-                node.show_row_totals ||
+            this.show_row_totals = Boolean(
+                this.parse_boolean(node.show_row_totals || "1") &&
                     this.is_aggregatable(field_defs[this.field_value])
-                    ? "1"
-                    : ""
             );
-            this.show_column_totals = this.parse_boolean(
-                node.show_column_totals ||
+            this.show_column_totals = Boolean(
+                this.parse_boolean(node.show_column_totals || "1") &&
                     this.is_aggregatable(field_defs[this.field_value])
-                    ? "1"
-                    : ""
             );
         },
 


### PR DESCRIPTION
Needs to `parse_boolean()` the `show_column_totals` and `show_row_totals` attributes. 
Also it was aggregating every float, monetary or integer field even if the attribute was false, so OR operator has been changed for AND.
