### PR TITLE
[FIX] 14.0 take care field_label_x_axis and field_label_y_axis

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
@@ -223,7 +223,7 @@ odoo.define("web_widget_x2many_2d_matrix.X2Many2dMatrixRenderer", function (requ
          */
         _renderLabelCell: function (record) {
             var $td = $("<td>");
-            var value = record.data[this.matrix_data.field_y_axis];
+            var value = record.data[this.matrix_data.field_label_y_axis];
             if (value.type === "record") {
                 // We have a related record
                 value = value.data.display_name;

--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -88,8 +88,8 @@ odoo.define("web_widget_x2many_2d_matrix.widget", function (require) {
             _.each(
                 records,
                 function (record) {
-                    var x = record.data[this.field_x_axis],
-                        y = record.data[this.field_y_axis];
+                    var x = record.data[this.field_label_x_axis],
+                        y = record.data[this.field_label_y_axis];
                     if (x.type === "record") {
                         // We have a related record
                         x = x.data.display_name;
@@ -127,6 +127,8 @@ odoo.define("web_widget_x2many_2d_matrix.widget", function (require) {
                 field_value: this.field_value,
                 field_x_axis: this.field_x_axis,
                 field_y_axis: this.field_y_axis,
+                field_label_x_axis: this.field_label_x_axis,
+                field_label_y_axis: this.field_label_y_axis,
                 columns: this.columns,
                 rows: this.rows,
                 show_row_totals: this.show_row_totals,


### PR DESCRIPTION
This fix the usage of field_label_x_axis and field_label_y_axis

it assume this field return different values that's consistent with
respectives field_x_axis and field_y_axis.

ie: to display the unit of a number in the header you could use
a compute field that concatenate the value to the unit name