### PR TITLE
 [IMP] web_tree_dynamic_colored_field : Add bg_color_field option

### DIFF
--- a/web_tree_dynamic_colored_field/__manifest__.py
+++ b/web_tree_dynamic_colored_field/__manifest__.py
@@ -6,7 +6,7 @@
     'category': 'Hidden/Dependency',
     'version': '12.0.1.0.0',
     'depends': ['web'],
-    'author': "Camptocamp, Therp BV, Odoo Community Association (OCA)",
+    'author': "Camptocamp, Therp BV, GRAP, Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'website': 'https://github.com/OCA/web',
     'demo': [

--- a/web_tree_dynamic_colored_field/readme/CONTRIBUTORS.rst
+++ b/web_tree_dynamic_colored_field/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Holger Brunn <hbrunn@therp.nl>
 * Artem Kostyuk <a.kostyuk@mobilunity.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Sylvain LE GAL <https://twitter.com/legalsylvain>

--- a/web_tree_dynamic_colored_field/readme/USAGE.rst
+++ b/web_tree_dynamic_colored_field/readme/USAGE.rst
@@ -38,6 +38,9 @@
     </field>
     ...
 
+* You can also use ``colors="bg_color_field: my_color"`` to defined the field name that will be used
+  for the background color of the line.
+
 * If you want to use more than one color, you can split the attributes using ';':
 
 .. code::

--- a/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
+++ b/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
@@ -6,7 +6,7 @@ odoo.define('web_tree_dynamic_colored_field', function (require) {
 
     ListRenderer.include({
         /**
-         * Look up for a `color_field` parameter in tree `colors` attribute
+         * Look up for a `color_field` or ``bg_color_field`` parameter in tree `colors` attribute
          *
          * @override
          */
@@ -14,10 +14,15 @@ odoo.define('web_tree_dynamic_colored_field', function (require) {
             if (this.arch.attrs.colors) {
                 var colorAttr = this.arch.attrs.colors.split(';');
                 if (colorAttr.length > 0) {
+                    var colorType = colorAttr[0].split(':')[0].trim()
                     var colorField = colorAttr[0].split(':')[1].trim();
                     // validate the presence of that field in tree view
                     if (this.state.data.length && colorField in this.state.data[0].data) {
-                        this.colorField = colorField;
+                        if (colorType === "color_field") {
+                            this.colorField = colorField;
+                        } else if (colorType === "bg_color_field") {
+                            this.bgColorField = colorField;
+                        }
                     } else {
                         console.warn(
                             "No field named '" + colorField + "' present in view."
@@ -50,6 +55,10 @@ odoo.define('web_tree_dynamic_colored_field', function (require) {
             var treeColor = record.data[this.colorField];
             if (treeColor) {
                 $td.css('color', treeColor);
+            }
+            var treeBgColor = record.data[this.bgColorField];
+            if (treeBgColor) {
+                $td.css('background-color', treeBgColor);
             }
             // apply <field>'s own `options`
             if (!node.attrs.options) { return; }


### PR DESCRIPTION
simple improvement to add the possibility to define a field in ``bg_color_field`` that will be used to dynamically set a color to a line.

CC : original developpers : @guewen, @damdam-s, @hbrunn

Sample of implementation below and review welcome here : https://github.com/OCA/margin-analysis/pull/96

![with_module_web_tree_dynamic_colored_field](https://user-images.githubusercontent.com/3407482/121376234-a4362080-c941-11eb-948e-82a533e415a1.png)
