### PR TITLE
 [IMP+FIX] web_responsive : fix shortcut display and add new shortcuts (u) for the User menu

### DIFF
--- a/web_responsive/readme/USAGE.rst
+++ b/web_responsive/readme/USAGE.rst
@@ -1,6 +1,9 @@
 The following keyboard shortcuts are implemented:
 
-* Toggle app drawer - ``Alt + Shift + H``
+* Toggle app drawer - ``Alt + Shift + A``
 * Navigate app search results - Arrow keys
 * Choose app result - ``Enter``
 * ``Esc`` to close app drawer
+
+
+Also you can access to the user menu, with ``Alt + Shift + U``

--- a/web_responsive/static/src/xml/menu.xml
+++ b/web_responsive/static/src/xml/menu.xml
@@ -1,9 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
+<t t-extend="UserMenu">
+    <t t-jquery=".dropdown-toggle" t-operation="attributes">
+        <attribute name="accesskey">u</attribute>
+    </t>
+</t>
+
 <div t-extend="UserMenu.shortcuts">
+    <!-- Replace "a" shortcut by "e" (for 'Edit a Record') -->
+    <t t-jquery="table.o_shortcut_table > tbody > tr > td:nth-child(2) > span:nth-child(2).o_key:contains('a')" t-operation="replace">
+        <span class="o_key">e</span>
+    </t>
+    <t t-jquery="table.o_shortcut_table > tbody > tr > td:nth-child(3) > span:nth-child(3).o_key:contains('a')" t-operation="replace">
+        <span class="o_key">e</span>
+    </t>
+
+    <!-- Replace "j" shortcut by "d" (for 'Discard a record modification') -->
+    <t t-jquery="table.o_shortcut_table > tbody > tr > td:nth-child(2) > span:nth-child(2).o_key:contains('j')" t-operation="replace">
+        <span class="o_key">d</span>
+    </t>
+    <t t-jquery="table.o_shortcut_table > tbody > tr > td:nth-child(3) > span:nth-child(3).o_key:contains('j')" t-operation="replace">
+        <span class="o_key">d</span>
+    </t>
+
+    <!-- Add Shift for all windows / linux shortcuts -->
     <t t-jquery="table.o_shortcut_table > tbody > tr > td:nth-child(2) > span:first-child" t-operation="after">
         + <span class="o_key">Shift</span>
+    </t>
+
+    <!-- Add new accesskeys -->
+    <t t-jquery=".o_shortcut_table tbody" t-operation="append">
+        <tr>
+            <td align="left">Select menu</td>
+            <td>
+                <span class="o_key">Alt</span> + <span class="o_key">Shift</span> + <span class="o_key">a</span>
+            </td>
+            <td>
+                <span class="o_key">Control</span> + <span class="o_key">Alt</span> + <span class="o_key">a</span>
+            </td>
+        </tr>
+    </t>
+
+    <t t-jquery=".o_shortcut_table tbody" t-operation="append">
+        <tr>
+            <td align="left">User menu</td>
+            <td>
+                <span class="o_key">Alt</span> + <span class="o_key">Shift</span> + <span class="o_key">u</span>
+            </td>
+            <td>
+                <span class="o_key">Control</span> + <span class="o_key">Alt</span> + <span class="o_key">u</span>
+            </td>
+        </tr>
     </t>
 </div>
 


### PR DESCRIPTION
* Update shortcut form to display correct shortcut for "Edit a Record" (A >> E)
* Update shortcut form to display correct shortcut for "Discard a record modification" (J >> D)
* Add new entry in the form to display correct shortcut for "Select menu" (A)

![image](https://user-images.githubusercontent.com/3407482/122541324-cd357000-d029-11eb-95ff-4d99ff1bbe43.png)

* add a new shortcut ~"z"~ "u" for the user Menu. (that is used a lot for login out)

CC : @quentinDupont (ref : apps/deck/#/board/144/card/1678)

CC : ``web_responsive`` contributors : @sergio-teruel, @Tardo, @lasley