### PR TITLE
[14.0] [MOD] Pass context defined on tree view field

### DIFF
--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -58,6 +58,7 @@ odoo.define("web_tree_many2one_clickable.many2one_clickable", function (require)
                         res_id: self.value.res_id,
                         views: [[false, "form"]],
                         target: "target",
+                        context: self.attrs.context || {},
                     });
                 });
                 this.$el.append($a);


### PR DESCRIPTION
When for instance a form_view_ref context is defined on a field in a specific tree view, the context should also be passed when opening the form.