### PR TITLE
[13.0][FIX] web_advanced_search: fix error when clicking Search More in sales dashboard

### DIFF
--- a/web_advanced_search/static/src/js/web_advanced_search.js
+++ b/web_advanced_search/static/src/js/web_advanced_search.js
@@ -162,6 +162,10 @@ odoo.define("web_advanced_search", function(require) {
         tagName: "div",
         className: "x2x_container",
         attributes: {},
+        custom_events: _.extend({}, FieldManagerMixin.custom_events, {
+            load_optional_fields: "_onLoadOptionalFields",
+            save_optional_fields: "_onSaveOptionalFields",
+        }),
 
         /**
          * @override
@@ -312,6 +316,14 @@ odoo.define("web_advanced_search", function(require) {
         _confirmChange: function(id, fields, event) {
             this.datapoint_id = id;
             return this._field_widget.reset(this._get_record(), event);
+        },
+
+        _onLoadOptionalFields: function(ev) {
+            ev.stopPropagation();
+        },
+
+        _onSaveOptionalFields: function(ev) {
+            ev.stopPropagation();
         },
 
         /**


### PR DESCRIPTION
Before this PR whenever you wanted to use the Search More functionality in the Sales Dashboard, you would get the following error:
![image](https://user-images.githubusercontent.com/44768500/126125103-ddcab815-f6ba-4296-92b8-468faa4ab02f.png)

This PR intends to solve this issue.

cc ~ @ForgeFlow