### PR TITLE
Issue with create button on lots in Manufacturing Orders

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -34,9 +34,9 @@ odoo.define("web_m2x_options.web_m2x_options", function (require) {
                         text: _t("Create"),
                         classes: "btn-primary",
                         click: function () {
-                            if (this.$("input").val()) {
+                            if (this.$("input").val() || this.value) {
                                 this.trigger_up("quick_create", {
-                                    value: this.$("input").val(),
+                                    value: this.$("input").val() || this.value,
                                 });
                                 this.close(true);
                             } else {
@@ -51,7 +51,7 @@ odoo.define("web_m2x_options.web_m2x_options", function (require) {
                         click: function () {
                             this.trigger_up("search_create_popup", {
                                 view_type: "form",
-                                value: this.$("input").val(),
+                                value: this.$("input").val() || this.value,
                             });
                         },
                     },


### PR DESCRIPTION
Issue with create button on lots in Manufacturing Orders

When you enter a new lot number, if you click the green plus button or anywhere else on the screen other that where it says “Create” or “Create and Edit”, it creates a pop-up. On that pop-up, the “Create” button doesn’t function; clicking on it does not create the lot or close the pop-up.