### PR TITLE
[12][FIX] web_view_calendar_list Add missing viewType attribute in view definition

### DIFF
--- a/web_view_calendar_list/static/src/js/calendar_list_view.js
+++ b/web_view_calendar_list/static/src/js/calendar_list_view.js
@@ -15,6 +15,7 @@ odoo.define('web_view_calendar_list.CalendarListView', function (require) {
     var CalendarListView = CalendarView.extend({
         display_name: _lt('Calendar List'),
         icon: 'fa-calendar-check-o',
+        viewType: 'calendar_list',
         config: {
             Model: CalendarListModel,
             Controller: CalendarListController,


### PR DESCRIPTION
So that it selects the right Calendar View List button instead of Calendar button in action views selection control panel.