### PR TITLE
[12.0][FIX] web_timeline UTC timezone and + 1 hour when adding events

### DIFF
--- a/web_timeline/static/src/js/timeline_controller.js
+++ b/web_timeline/static/src/js/timeline_controller.js
@@ -288,12 +288,12 @@ odoo.define('web_timeline.TimelineController', function (require) {
                 default_context['default_'.concat(this.date_delay)] = 1;
             }
             if (this.date_start) {
-                default_context['default_'.concat(this.date_start)] = moment(item.start).add(1, 'hours').format(
+                default_context['default_'.concat(this.date_start)] = moment.utc(item.start).format(
                     'YYYY-MM-DD HH:mm:ss'
                 );
             }
             if (this.date_stop && item.end) {
-                default_context['default_'.concat(this.date_stop)] = moment(item.end).add(1, 'hours').format(
+                default_context['default_'.concat(this.date_stop)] = moment.utc(item.end).format(
                     'YYYY-MM-DD HH:mm:ss'
                 );
             }


### PR DESCRIPTION
Date times must be sent as UTC to Odoo. and why adding 1 hour? just leave the javascript timeline make the job.