### PR TITLE
[12.0][IMP] web_m2x_options: Disable hardcoded "Search More..." limit when no search value is set.

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -183,10 +183,11 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                         values.push({
                             label: _t("Search More..."),
                             action: function () {
-                                // limit = 80 for improving performance, similar
-                                // to Odoo implementation here:
-                                // https://github.com/odoo/odoo/commit/8c3cdce539d87775b59b3f2d5ceb433f995821bf
-                                self._rpc({
+                                if (search_val) {
+                                    // limit = 80 for improving performance, similar
+                                    // to Odoo implementation here:
+                                    // https://github.com/odoo/odoo/commit/8c3cdce539d87775b59b3f2d5ceb433f995821bf
+                                    self._rpc({
                                         model: self.field.relation,
                                         method: 'name_search',
                                         kwargs: {
@@ -198,6 +199,9 @@ odoo.define('web_m2x_options.web_m2x_options', function (require) {
                                         },
                                     })
                                     .then(self._searchCreatePopup.bind(self, "search"));
+                                } else {
+                                    self._searchCreatePopup("search");
+                                }
                             },
                             classname: 'o_m2o_dropdown_option',
                         });


### PR DESCRIPTION
To improve `name_get` performance, there is an existing hard-coded limit.
But when no search value is set, this `name_get` query is useless since only the domain will limit the result.

With this PR, when the field input is empty and when the user clicks on "Search More...", we let the Form doing its `web/dataset/search_read` query without locking the domain on `'[id', 'in', (...)]`. And since the `name_get` is not called, it should be faster.