### PR TITLE
[12.0] web_widget_digitized_signature: Allow employee user to set their own signature in preferences view

### DIFF
--- a/web_widget_digitized_signature/models/mail_thread.py
+++ b/web_widget_digitized_signature/models/mail_thread.py
@@ -36,4 +36,4 @@ class MailThread(models.AbstractModel):
                 msg_body += message
                 msg_body += '</li>'
             msg_body += '</ul>'
-            self.message_post(body=msg_body, attachments=attachments)
+            self.sudo().message_post(body=msg_body, attachments=attachments)

--- a/web_widget_digitized_signature/models/res_users.py
+++ b/web_widget_digitized_signature/models/res_users.py
@@ -24,3 +24,12 @@ class ResUsers(models.Model):
     def write(self, vals):
         self._track_signature(vals, 'digital_signature')
         return super(ResUsers, self).write(vals)
+
+    def __init__(self, pool, cr):
+        super(ResUsers, self).__init__(pool, cr)
+        # duplicate list to avoid modifying the original reference
+        type(self).SELF_WRITEABLE_FIELDS = list(self.SELF_WRITEABLE_FIELDS)
+        type(self).SELF_WRITEABLE_FIELDS.extend(['digital_signature'])
+        # duplicate list to avoid modifying the original reference
+        type(self).SELF_READABLE_FIELDS = list(self.SELF_READABLE_FIELDS)
+        type(self).SELF_READABLE_FIELDS.extend(['digital_signature'])

--- a/web_widget_digitized_signature/tests/test_signature_tracking.py
+++ b/web_widget_digitized_signature/tests/test_signature_tracking.py
@@ -35,3 +35,10 @@ class TestSignatureTracking(common.SavepointCase):
         current_messages = self.message_obj.search([])
         message = current_messages - prev_messages
         self.assertIn('Signature has been deleted.', message.body)
+
+    def test_self_signature_write(self):
+        """Ensure users are able to set its own signature"""
+        user = self.env.ref('base.user_demo')
+        user = user.sudo(user)
+        user.write({"digital_signature": b'TEST'})
+        self.assertEqual(user.digital_signature, b'TEST')

--- a/web_widget_digitized_signature/views/res_users_view.xml
+++ b/web_widget_digitized_signature/views/res_users_view.xml
@@ -23,7 +23,7 @@
             <xpath expr="//field[@name='signature']" position="after">
                 <label for="digital_signature" string="Signature" class="oe_edit_only"/>
                 <h2>
-                    <field name="digital_signature" widget="signature"/>
+                    <field name="digital_signature" widget="signature" readonly="0" />
                 </h2>
             </xpath>
         </field>


### PR DESCRIPTION
Before this pull request, connect as demo/demo user you won't be able to set its digitized signature in the preferences form (click on user name on the top right corner > preferences)

Using this PR each user is able to set it own signature without administrator access right !
