### PR TITLE
[12.0][FIX]web_widget_digitized_signature:Respect custom width-height set f…

### DIFF
--- a/web_widget_digitized_signature/static/src/js/digital_sign.js
+++ b/web_widget_digitized_signature/static/src/js/digital_sign.js
@@ -26,8 +26,8 @@ odoo.define('web_widget_digitized_signature.web_digital_sign', function(require)
                 'decor-color': '#D1D0CE',
                 'color': '#000',
                 'background-color': '#fff',
-                'height': '150',
-                'width': '550'
+                'height': this.attrs['height'] || '150',
+                'width': this.attrs['width'] || '550'
             };
             this.empty_sign = [];
         },
@@ -49,8 +49,8 @@ odoo.define('web_widget_digitized_signature.web_digital_sign', function(require)
                 'decor-color': '#D1D0CE',
                 'color': '#000',
                 'background-color': '#fff',
-                'height': '150',
-                'width': '550',
+                'height': this.attrs['height'] || '150',
+                'width': this.attrs['width'] || '550',
                 'clear': true
             };
             this.$(".signature").jSignature(sign_options);
@@ -120,8 +120,8 @@ odoo.define('web_widget_digitized_signature.web_digital_sign', function(require)
                         'decor-color': '#D1D0CE',
                         'color': '#000',
                         'background-color': '#fff',
-                        'height': '150',
-                        'width': '550'
+                        'height': this.attrs['height'] || '150',
+                        'width': this.attrs['width'] || '550'
                     };
                     this.$(".signature").jSignature("init", sign_options);
                 }
@@ -133,8 +133,8 @@ odoo.define('web_widget_digitized_signature.web_digital_sign', function(require)
                         'decor-color': '#D1D0CE',
                         'color': '#000',
                         'background-color': '#fff',
-                        'height': '150',
-                        'width': '550'
+                        'height': this.attrs['height'] || '150',
+                        'width': this.attrs['width'] || '550'
                     });
                 }
             }

--- a/web_widget_digitized_signature/views/web_digital_sign_view.xml
+++ b/web_widget_digitized_signature/views/web_digital_sign_view.xml
@@ -4,6 +4,11 @@
         <xpath expr="." position="inside">
             <script type="text/javascript"
                     src="/web_widget_digitized_signature/static/src/js/digital_sign.js"/>
+            <style type="text/css">
+                .jSignature {
+                    border: 2px dotted gray !important;
+                }
+            </style>
         </xpath>
     </template>
 


### PR DESCRIPTION
…or widget, add border

Although widget allowed to set size in view (width, height) it was hardcoded to 550x150.
Allow setting width and height for widget and fallback to previous default of 550x150
Set border on signature widget to explicitly show widget limits