### PR TITLE
[ADD] github stale action: Work on oldest issues/prs first

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.2.0
+_commit: v1.2.1
 _src_path: gh:oca/oca-addons-repo-template
 dependency_installation_mode: PIP
 generate_requirements_txt: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # General settings.
+          ascending: true
           remove-stale-when-updated: true
           # Pull Requests settings.
           # 120+30 day stale policy for PRs
@@ -50,6 +51,7 @@ jobs:
         uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ascending: true
           only-labels: "needs more information"
           exempt-issue-labels: "no stale"
           days-before-stale: 15

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,18 +8,18 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      # 120+30 day stale policy for PRs
-      # * Except PRs marked as "no stale"
-      - name: Stale PRs policy
+      - name: Stale PRs and issues policy
         uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          exempt-pr-labels: "no stale"
-          days-before-stale: 120
-          days-before-close: 30
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
+          # General settings.
           remove-stale-when-updated: true
+          # Pull Requests settings.
+          # 120+30 day stale policy for PRs
+          # * Except PRs marked as "no stale"
+          days-before-pr-stale: 120
+          days-before-pr-close: 30
+          exempt-pr-labels: "no stale"
           stale-pr-label: "stale"
           stale-pr-message: >
             There hasn't been any activity on this pull request in the past 4 months, so
@@ -28,19 +28,12 @@ jobs:
 
             If you want this PR to never become stale, please ask a PSC member to apply
             the "no stale" label.
-
-      # 180+30 day stale policy for open issues
-      # * Except Issues marked as "no stale"
-      - name: Stale Issues policy
-        uses: actions/stale@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Issues settings.
+          # 180+30 day stale policy for open issues
+          # * Except Issues marked as "no stale"
+          days-before-issue-stale: 180
+          days-before-issue-close: 30
           exempt-issue-labels: "no stale,needs more information"
-          days-before-stale: 180
-          days-before-close: 30
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
-          remove-stale-when-updated: true
           stale-issue-label: "stale"
           stale-issue-message: >
             There hasn't been any activity on this issue in the past 6 months, so it has


### PR DESCRIPTION
the action from #2034 ran for the first time, that's nice. But with the amount of open issues we have here (and in a couple of other repos), this runs into limits: https://github.com/OCA/web/runs/3712831044?check_suite_focus=true#step:2:1310

With this proposal, the action looks at oldest issues/prs first, and this way we hopefully don't have to increase the amount of operations, as I can't judge how many this will be over all of OCA.