### PR TITLE
[13.0][FIX] web_time_range_menu_custom: Mix custom and 'no custom' periods

### DIFF
--- a/web_time_range_menu_custom/static/src/js/control_panel_model.js
+++ b/web_time_range_menu_custom/static/src/js/control_panel_model.js
@@ -52,6 +52,21 @@ odoo.define("web_time_range_menu_custom.ControlPanelModel", function(require) {
                             context.timeRangeMenuData.timeRange
                         );
                     }
+                    if (filter.comparisonTimeRangeId !== "custom_comparison_period") {
+                        context.timeRangeMenuData.comparisonTimeRange = Domain.prototype.constructCustomDomain(
+                            filter.fieldName,
+                            filter.timeRangeId,
+                            filter.fieldType,
+                            filter.comparisonTimeRangeId,
+                            filter.timeRangeCustom,
+                            filter.comparisonTimeRangeCustom
+                        );
+                        if (evaluation) {
+                            context.timeRangeMenuData.comparisonTimeRange = Domain.prototype.stringToArray(
+                                context.timeRangeMenuData.comparisonTimeRange
+                            );
+                        }
+                    }
                 }
                 if (filter.comparisonTimeRangeId === "custom_comparison_period") {
                     context.timeRangeMenuData.comparisonTimeRange = Domain.prototype.constructCustomDomain(


### PR DESCRIPTION
Apply correct periods when mix "custom" with "no custom" periods.

Steps to reproduce:
- Go to pivot view
- Select a custom time range
- Select a predefined comparison period (Ex. Previous Period)

Now you see that the comparison period is not being applied.

After this PR the comparison period is applied correctly.

cc @tecnativa TT29249