### PR TITLE
[10.0][FIX] web_responsive: Restore Odoo navbar id

### DIFF
--- a/web_responsive/views/web.xml
+++ b/web_responsive/views/web.xml
@@ -27,7 +27,7 @@
 
             <t t-set="body_classname" t-value="'drawer drawer--left o_web_client'" />
 
-            <header role="banner">
+            <header role="banner" id="oe_main_menu_navbar">
                 <nav id="odooAppDrawer" class="app-drawer-nav drawer-nav" role="navigation">
                     <t t-call="web.menu" />
                 </nav>


### PR DESCRIPTION
Restore the navbar id to be used by other modules.

cc @tecnativa TT32200