### PR TITLE
[12.0][FIX] web_widget_one2many_product_picker, typo on configuration

### DIFF
--- a/web_widget_one2many_product_picker/readme/CONFIGURE.rst
+++ b/web_widget_one2many_product_picker/readme/CONFIGURE.rst
@@ -5,7 +5,7 @@ You need to define the view fields. The view must be of ``form`` type.
 Widget options:
 ~~~~~~~~~~~~~~~
 
-* product_per_page > Integer -> Used to control the load more behaviour (16 by default)
+* records_per_page > Integer -> Used to control the load more behaviour (16 by default)
 * groups > Array of dictionaries -> Declare the groups
 
     * name -> The group name


### PR DESCRIPTION
`product_per_page` has been changed to `records_per_page` like in v 13.0

@pedrobaeza @Tardo could you please quick review and merge?