### PR TITLE
[UPD] web_m2x_options_manager: Add option to prevent Create/Edit wizard to pop up

### DIFF
--- a/web_m2x_options_manager/i18n/web_m2x_options_manager.pot
+++ b/web_m2x_options_manager/i18n/web_m2x_options_manager.pot
@@ -26,6 +26,11 @@ msgid "Add"
 msgstr ""
 
 #. module: web_m2x_options_manager
+#: model:ir.model.fields,field_description:web_m2x_options_manager.field_m2x_create_edit_option__option_create_edit_wizard
+msgid "Create & Edit Wizard"
+msgstr ""
+
+#. module: web_m2x_options_manager
 #: model:ir.model.fields,field_description:web_m2x_options_manager.field_m2x_create_edit_option__option_create_edit
 msgid "Create & Edit Option"
 msgstr ""
@@ -48,6 +53,13 @@ msgstr ""
 #. module: web_m2x_options_manager
 #: model:ir.model.fields,field_description:web_m2x_options_manager.field_m2x_create_edit_option__create_date
 msgid "Created on"
+msgstr ""
+
+#. module: web_m2x_options_manager
+#: model:ir.model.fields,help:web_m2x_options_manager.field_m2x_create_edit_option__option_create_edit_wizard
+msgid ""
+"Defines behaviour for 'Create & Edit' Wizard\n"
+"Set to False to prevent 'Create & Edit' Wizard to pop up"
 msgstr ""
 
 #. module: web_m2x_options_manager

--- a/web_m2x_options_manager/models/m2x_create_edit_option.py
+++ b/web_m2x_options_manager/models/m2x_create_edit_option.py
@@ -77,6 +77,13 @@ class M2xCreateEditOption(models.Model):
         string="Create & Edit Option",
     )
 
+    option_create_edit_wizard = fields.Boolean(
+        default=True,
+        help="Defines behaviour for 'Create & Edit' Wizard\n"
+        "Set to False to prevent 'Create & Edit' Wizard to pop up",
+        string="Create & Edit Wizard",
+    )
+
     _sql_constraints = [
         (
             "model_field_uniqueness",
@@ -142,6 +149,9 @@ class M2xCreateEditOption(models.Model):
             if mode == "force" or k not in options:
                 options[k] = val == "true"
         node.set("options", str(options))
+        if not self.option_create_edit_wizard:
+            node.set("can_create", "false")
+            node.set("can_write", "false")
 
     @api.model
     def get(self, model_name, field_name):

--- a/web_m2x_options_manager/tests/test_m2x_create_edit_option.py
+++ b/web_m2x_options_manager/tests/test_m2x_create_edit_option.py
@@ -29,6 +29,7 @@ class TestM2xCreateEditOption(SavepointCase):
                 "model_id": self.res_partner_model.id,
                 "option_create": "set_true",
                 "option_create_edit": "set_true",
+                "option_create_edit_wizard": True,
             }
         )
         self.categories_opt = self.env["m2x.create.edit.option"].create(
@@ -37,6 +38,7 @@ class TestM2xCreateEditOption(SavepointCase):
                 "model_id": self.res_partner_model.id,
                 "option_create": "set_true",
                 "option_create_edit": "set_true",
+                "option_create_edit_wizard": True,
             }
         )
         self.company_opt = self.env["m2x.create.edit.option"].create(
@@ -45,6 +47,7 @@ class TestM2xCreateEditOption(SavepointCase):
                 "model_id": self.res_users_model.id,
                 "option_create": "force_true",
                 "option_create_edit": "set_true",
+                "option_create_edit_wizard": False,
             }
         )
 
@@ -82,10 +85,24 @@ class TestM2xCreateEditOption(SavepointCase):
             safe_eval(title_node.attrib.get("options"), nocopy=True),
             {"create": True, "create_edit": True},
         )
+        self.assertEqual(
+            (
+                title_node.attrib.get("can_create"),
+                title_node.attrib.get("can_write"),
+            ),
+            ("true", "true"),
+        )
         categ_node = form_doc.xpath("//field[@name='category_id']")[0]
         self.assertEqual(
             safe_eval(categ_node.attrib.get("options"), nocopy=True),
             {"create": False, "create_edit": True},
+        )
+        self.assertEqual(
+            (
+                categ_node.attrib.get("can_create"),
+                categ_node.attrib.get("can_write"),
+            ),
+            ("true", "true"),
         )
 
         # Check fields on res.users tree view (contained in ``user_ids`` field)
@@ -95,6 +112,13 @@ class TestM2xCreateEditOption(SavepointCase):
         self.assertEqual(
             safe_eval(company_node.attrib.get("options"), nocopy=True),
             {"create": True, "create_edit": True},
+        )
+        self.assertEqual(
+            (
+                company_node.attrib.get("can_create"),
+                company_node.attrib.get("can_write"),
+            ),
+            ("false", "false"),
         )
 
         # Update options, check that node has been updated too

--- a/web_m2x_options_manager/views/ir_model.xml
+++ b/web_m2x_options_manager/views/ir_model.xml
@@ -27,6 +27,7 @@
                             />
                             <field name="option_create" />
                             <field name="option_create_edit" />
+                            <field name="option_create_edit_wizard" />
                         </tree>
                     </field>
                 </page>


### PR DESCRIPTION
Even if Create or Create & Edit Options are disabled (they don't appear in field's records dropdown list) there is still an opportunity to trigger Create/Edit wizard to pop up.

Two steps to reproduce:
1. Choose value on field's dropdown selection recordset. Edit value (for instance remove characters).
2. Unfocus cursor (mouse) from dropdown, click.
3. New Many2one Dialog is created.

New boolean field Create & Edit Wizard is introduced to be specified with Create or Create & Edit Options. Default value for this boolean is True to follow standard workflow.
To prevent 'Create & Edit' Wizard to pop up set it to False.
