### PR TITLE
[13.0][IMP] web_disable_export_group: Differenciate between the XLSX export and export all

### DIFF
--- a/web_disable_export_group/__manifest__.py
+++ b/web_disable_export_group/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Web Disable Export Group",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.1.0",
     "license": "AGPL-3",
     "author": "Onestein, " "Tecnativa, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",

--- a/web_disable_export_group/migrations/13.0.2.1.0/post-migration.py
+++ b/web_disable_export_group/migrations/13.0.2.1.0/post-migration.py
@@ -1,0 +1,10 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    group = env.ref("web_disable_export_group.group_export_data")
+    new_group = env.ref("web_disable_export_group.group_export_xlsx_data")
+    groups = env["res.groups"].search([("implied_ids", "=", group.id)])
+    groups.write({"implied_ids": [(4, new_group.id)]})
+    group.users.write({"groups_id": [(4, new_group.id)]})

--- a/web_disable_export_group/models/ir_http.py
+++ b/web_disable_export_group/models/ir_http.py
@@ -15,6 +15,8 @@ class Http(models.AbstractModel):
             {
                 "group_export_data": user
                 and user.has_group("web_disable_export_group.group_export_data"),
+                "group_xlsx_export_data": user
+                and user.has_group("web_disable_export_group.group_export_xlsx_data"),
             }
         )
         return res

--- a/web_disable_export_group/security/groups.xml
+++ b/web_disable_export_group/security/groups.xml
@@ -2,8 +2,21 @@
 <!-- Copyright 2016 Onestein
      License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).-->
 <odoo>
+    <record model="ir.module.category" id="category_export_data">
+        <field name="name">Export</field>
+    </record>
+
+    <record id="group_export_xlsx_data" model="res.groups">
+        <field name="name">Direct Export</field>
+        <field name="category_id" ref="category_export_data" />
+        <field
+            name="users"
+            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
+        />
+    </record>
     <record id="group_export_data" model="res.groups">
-        <field name="name">Export Data</field>
+        <field name="name">Advanced Export</field>
+        <field name="category_id" ref="category_export_data" />
         <field
             name="users"
             eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"

--- a/web_disable_export_group/static/src/js/disable_export_group.js
+++ b/web_disable_export_group/static/src/js/disable_export_group.js
@@ -37,6 +37,14 @@ odoo.define("web_disable_export_group", function(require) {
             if (
                 !session.is_superuser &&
                 action &&
+                action.startsWith("export_xlsx") &&
+                !session.group_xlsx_export_data
+            ) {
+                return false;
+            } else if (
+                !session.is_superuser &&
+                action &&
+                !action.startsWith("export_xlsx") &&
                 action.startsWith("export_") &&
                 !session.group_export_data
             ) {

--- a/web_disable_export_group/static/src/js/web_disable_export_group_tour.js
+++ b/web_disable_export_group/static/src/js/web_disable_export_group_tour.js
@@ -67,5 +67,34 @@ odoo.define("web_disable_export_group.tour", function(require) {
             },
         ]
     );
+    tour.register(
+        "export_tour_demo_xlsx",
+        {
+            test: true,
+            url:
+                "/web#model=ir.ui.view&view_type=list&cids=&action=base.action_ui_view",
+        },
+        [
+            {
+                content: "Check if 'Export all' button exists",
+                trigger: ".o_list_buttons:has(.o_list_export_xlsx)",
+            },
+            {
+                content: "Select all records",
+                trigger: ".custom-control-input:first",
+            },
+            {
+                content: "Open actions",
+                trigger: ".o_dropdown_toggler_btn",
+            },
+            {
+                content: "Check if Export button does not exist",
+                trigger:
+                    '.o_control_panel div.o_dropdown_menu a:first:not(:contains("' +
+                    _t("Export") +
+                    '"))',
+            },
+        ]
+    );
     return {};
 });

--- a/web_disable_export_group/tests/test_tour.py
+++ b/web_disable_export_group/tests/test_tour.py
@@ -10,3 +10,20 @@ class TestTour(odoo.tests.HttpCase):
 
     def test_demo(self):
         self.start_tour("/web", "export_tour_demo", login="demo")
+
+    def test_demo_xlsx(self):
+        user = self.env.ref("base.user_demo")
+        user.write(
+            {
+                "groups_id": [
+                    (
+                        4,
+                        self.env.ref(
+                            "web_disable_export_group.group_export_xlsx_data"
+                        ).id,
+                    )
+                ]
+            }
+        )
+        user.flush()
+        self.start_tour("/web", "export_tour_demo_xlsx", login="demo")


### PR DESCRIPTION
With this change, we have now two groups, one for the excel and one for the Export from Actions:

![image](https://user-images.githubusercontent.com/28590170/138908930-27cd7bec-ce98-452e-bf8a-947b71887c82.png)


A JS test has been added