### PR TITLE
[FIX] web_drop_target: Fix check files and set the main element as parent

### DIFF
--- a/web_drop_target/static/src/js/web_drop_target.js
+++ b/web_drop_target/static/src/js/web_drop_target.js
@@ -16,8 +16,8 @@ odoo.define("web_drop_target", function(require) {
         // Add the mime types you want to support here, leave empty for
         // All types. For more control, override _get_drop_items in your class
         _drop_allowed_types: [],
-        // Determine the zone where can drop files
-        _drop_zone_selector: ".o_content",
+        // Determine the zone where can drop files, if not defined, we use the element
+        _drop_zone_selector: undefined,
 
         /**
          * @override
@@ -82,7 +82,9 @@ odoo.define("web_drop_target", function(require) {
          */
         _add_overlay: function() {
             if (!this._drop_overlay || this._drop_overlay.length === 0) {
-                this.$drop_zone = this.$(this._drop_zone_selector).last();
+                if (this._drop_zone_selector)
+                    this.$drop_zone = this.$(this._drop_zone_selector).last();
+                else this.$drop_zone = this.$el;
                 // Element that represents the zone where you can drop files
                 // TODO: This name is preserved for not breaking the compatibility with other modules,
                 // but should be changed in new versions to follow the standard ($name)
@@ -138,7 +140,7 @@ odoo.define("web_drop_target", function(require) {
          */
         _onBodyFileDragover: function(ev) {
             ev.preventDefault();
-            if (!_.isEmpty(this._get_drop_items(ev))) {
+            if (_.isEmpty(this._get_drop_items(ev))) {
                 const drop_zone_offset = this.$drop_zone.offset();
                 const overlay_css = {
                     top: drop_zone_offset.top,
@@ -191,13 +193,12 @@ odoo.define("web_drop_target", function(require) {
             let drop_items = [];
             if (this._get_record_id()) {
                 const dataTransfer = ev.originalEvent.dataTransfer;
-                if (_.isEmpty(this._drop_allowed_types)) {
-                    drop_items = _.clone(dataTransfer.files);
-                } else {
-                    drop_items = _.filter(dataTransfer.files, item =>
+                drop_items = _.filter(
+                    dataTransfer.files,
+                    item =>
+                        _.isEmpty(this._drop_allowed_types) ||
                         _.contains(this._drop_allowed_types, item.type)
-                    );
-                }
+                );
             }
             return drop_items;
         },


### PR DESCRIPTION
This commit implements two changes: 

The first one is to use element as drop zone if no overlay zone is defined. We cannot find o_content otherwise.

The second one is to fix the check if a file exists. This is important because if the filter was added, the _.empty failed

It solves https://github.com/OCA/web/issues/2057