### PR TITLE
[11.0][IMP] web_widget_x2many_2d_matrix - modifiers of the field_value now get evaluated and registered on the matrix cell.

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -49,6 +49,9 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 node.y_axis_clickable || '1'
             );
             this.field_value = node.field_value || this.field_value;
+            // get modifiers of field_value, so we can later
+            // evaluate and register them for each cell.
+            this.field_value_modifiers = this.view.fieldsInfo[this.view.type][this.field_value].modifiers;
             // TODO: is this really needed? Holger?
             for (var property in node) {
                 if (property.startsWith("field_att_")) {
@@ -125,6 +128,10 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 'attrs': {
                     'name': this.field_x_axis,
                     'string': x,
+                    // we set the modifiers on the column,
+                    // because it later gets used, to register
+                    // the modifiers on the cell (_renderBodyCell of the renderer).
+                    'modifiers': this.field_value_modifiers,
                 },
             };
         },


### PR DESCRIPTION
Respect `field_value` field attributes.

```
<field name="my_field" widget="x2many_2d_matrix" field_x_axis="my_field1" field_y_axis="my_field2" field_value="my_field3">
        <tree>
            <field name="my_field1"/>
            <field name="my_field2"/>
            <field name="my_field3" attrs="{'readonly': [('my_field4', '=', True)]}"/>
            <field name="my_field4"/> 
        </tree>
 </field>
```
Right now the attrs (or every other attribute you set) attribute in the field_value field just gets lost.