### PR TITLE
[FIX][12.0] web_dashboard_tile : fix CSS

### DIFF
--- a/web_dashboard_tile/__manifest__.py
+++ b/web_dashboard_tile/__manifest__.py
@@ -16,6 +16,7 @@
     "data": [
         "security/ir.model.access.csv",
         "security/ir_rule.xml",
+        "views/templates.xml",
         "views/menu.xml",
         "views/tile_tile.xml",
         "views/tile_category.xml",
@@ -24,5 +25,4 @@
         "demo/tile_category.xml",
         "demo/tile_tile.xml",
     ],
-    "qweb": ["static/src/xml/web_dashboard_tile.xml"],
 }

--- a/web_dashboard_tile/views/templates.xml
+++ b/web_dashboard_tile/views/templates.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="assets_backend" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" href="/web_dashboard_tile/static/src/css/web_dashboard_tile.css"/>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
trivial patch : 
- remove obsolete qweb reference to xml file ;
- restore templates.xml file to include css file