### PR TITLE
[11.0][FIX] Modal window suddenly closes

### DIFF
--- a/web_widget_color/static/src/js/widget.js
+++ b/web_widget_color/static/src/js/widget.js
@@ -16,7 +16,14 @@ odoo.define('web.web_widget_color', function(require) {
 
         _renderEdit: function() {
             this.$input = this.$el.find('input');
-            this.jscolor = new jscolor(this.$input[0], {hash:true, zIndex:2000});
+            $wrapper = $('<div>').css('position', 'absolute');
+            this.$el.css('position', 'relative');
+            this.$el.append($wrapper);
+            this.jscolor = new jscolor(this.$input[0], {
+                hash:true, 
+                zIndex:2000,
+                container: this.$el.find('div:first')[0]
+            });
         },
     });
     field_registry.add('color', FieldColor);


### PR DESCRIPTION
The modal window suddenly closes when trying to change color via a color picker.

**What is the current bug behavior?**
The modal window closes when trying to change color via color picker, When selecting a color, the window will close instantly.

**Steps to reproduce**

1. Add color field anywhere in modal window  or nested modal windows
2. Once you select any color, the most recent opened modal will be closed automatically.

**What is the expected correct behavior?**
The modal window remains open when changing the color via the color picker