### PR TITLE
[13.0] web_notify: bump dev status

### DIFF
--- a/web_notify/__manifest__.py
+++ b/web_notify/__manifest__.py
@@ -9,6 +9,7 @@
     "version": "13.0.1.0.1",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV," "AdaptiveCity," "Odoo Community Association (OCA)",
+    "development_status": "Production/Stable",
     "website": "https://github.com/OCA/web",
     "depends": ["web", "bus", "base"],
     "data": ["views/web_notify.xml"],


### PR DESCRIPTION
It exists since many version and is actively maintained.

Backport of #2125 