### PR TITLE
[FIX] 14.0 tree many2one clickable context eval

### DIFF
--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -58,7 +58,6 @@ odoo.define("web_tree_many2one_clickable.many2one_clickable", function (require)
                         res_id: self.value.res_id,
                         views: [[false, "form"]],
                         target: "target",
-                        context: self.attrs.context || {},
                     });
                 });
                 this.$el.append($a);


### PR DESCRIPTION
On some fields there is a context that can make the action fail and display an error like this one:

![Capture d’écran de 2022-02-02 12-48-18](https://user-images.githubusercontent.com/8819682/152148154-aeece9ff-75bc-4bcd-b294-e4d88e942222.png)

For instance, this field cannot be opened with the module https://github.com/odoo/odoo/blob/14.0/addons/purchase/views/purchase_views.xml#L233 

This is a temporary fix as it would be better to evaluate the context before passing it, but at least there is no error displayed to the user.