### PR TITLE
[14.0][IMP/FIX] web_widget_domain_editor_dialog: work in dialog

### DIFF
--- a/web_widget_domain_editor_dialog/static/src/js/basic_fields.js
+++ b/web_widget_domain_editor_dialog/static/src/js/basic_fields.js
@@ -27,6 +27,7 @@ odoo.define("web_widget_domain_editor_dialog.basic_fields", function (require) {
                 disable_multiple_selection: false,
                 no_create: true,
                 on_selected: function (selected_ids) {
+                    _this.inDomainEditor = true;
                     _this.domainSelector
                         .setDomain(this.get_domain(selected_ids))
                         .then(_this._replaceContent.bind(_this));
@@ -38,6 +39,15 @@ odoo.define("web_widget_domain_editor_dialog.basic_fields", function (require) {
             }).open();
             this.trigger("dialog_opened", dialog);
             return dialog;
+        },
+        _onDomainSelectorValueChange: function () {
+            // This allows the domain editor to work with in dialog mode
+            const inDialog = this.inDialog;
+            if (this.inDomainEditor) {
+                this.inDialog = false;
+            }
+            this._super.apply(this, arguments);
+            this.inDialog = inDialog;
         },
     });
 });

--- a/web_widget_domain_editor_dialog/static/src/js/widget_domain_editor_dialog.js
+++ b/web_widget_domain_editor_dialog/static/src/js/widget_domain_editor_dialog.js
@@ -13,13 +13,24 @@ odoo.define("web_widget_domain_editor_dialog.DomainEditorDialog", function (requ
         init: function () {
             this._super.apply(this, arguments);
             const _this = this;
+            let domain = Domain.prototype.stringToArray(_this.options.default_domain);
+            // HACK: dynamicFilters don't work fine with booleans as they pass through
+            // pyeval as a jason domain. This way, they're full compatible and we avoid
+            // making an _rpc call.
+            domain = domain.map((tuple) => {
+                if (tuple[2] === true) {
+                    tuple[2] = 1;
+                }
+                if (tuple[2] === false) {
+                    tuple[2] = 0;
+                }
+                return tuple;
+            });
             this.options = _.defaults(this.options, {
                 dynamicFilters: [
                     {
                         description: _.str.sprintf(_t("Selected domain")),
-                        domain: Domain.prototype.stringToArray(
-                            _this.options.default_domain
-                        ),
+                        domain: domain,
                     },
                 ],
             });


### PR DESCRIPTION
- IMP: Now it's possible to work with the domain editor when the widget
has de in_dialog option.
- FIX: When a boolean opertator was present in the domain, the editor dialog
would raise an error as the default filter couldn't be interpretated.

cc @Tecnativa TT34184

please review @Tardo @CarlosRoca13 