### PR TITLE
[14.0][FIX] web_widget_ckeditor: `ir.config_paramter` permissions and typo

### DIFF
--- a/web_widget_ckeditor/__init__.py
+++ b/web_widget_ckeditor/__init__.py
@@ -1,1 +1,1 @@
-# from . import models
+from . import models

--- a/web_widget_ckeditor/models/__init__.py
+++ b/web_widget_ckeditor/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_config_parameter

--- a/web_widget_ckeditor/models/ir_config_parameter.py
+++ b/web_widget_ckeditor/models/ir_config_parameter.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class IrConfigParameter(models.Model):
+    _inherit = "ir.config_parameter"
+
+    @api.model
+    def get_web_widget_ckeditor_config(self):
+        get_param = self.sudo().get_param
+        return {
+            "toolbar": get_param("web_widget_ckeditor.toolbar"),
+        }

--- a/web_widget_ckeditor/static/src/js/field_ckeditor.js
+++ b/web_widget_ckeditor/static/src/js/field_ckeditor.js
@@ -17,15 +17,14 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
     const TranslatableFieldMixin = basic_fields.TranslatableFieldMixin;
 
     // Load configuration for the editor
-    const defaultCKEditorToolbarPromise = rpc.query({
+    const getCKEditorConfigPromise = rpc.query({
         model: "ir.config_parameter",
-        method: "get_param",
-        args: ["web_widget_ckeditor.toolbar"],
+        method: "get_web_widget_ckeditor_config",
     });
 
     // Load CKEditor localization files
     async function loadCKEditorLanguageSource(languageCode) {
-        if (languageCode == "en") {
+        if (languageCode === "en") {
             return;
         }
         const languageURL = `/web_widget_ckeditor/static/lib/ckeditor/build/translations/${languageCode}.js`;
@@ -87,9 +86,10 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
              * @override
              */
             isSet: function () {
-                var value =
+                // Removing spaces & html spaces
+                const value =
                     this.value &&
-                    this.value.split("&nbsp;").join("").replace(/\s/g, ""); // Removing spaces & html spaces
+                    this.value.split("&nbsp;").join("").replace(/\s/g, "");
                 return (
                     value &&
                     value !== "<p></p>" &&
@@ -143,9 +143,9 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
              */
             _getCKEditorToolbarItems: async function () {
                 try {
-                    const toolbarConfig = await defaultCKEditorToolbarPromise;
-                    if (toolbarConfig) {
-                        return toolbarConfig.split(/[\s,]+/).filter((item) => item);
+                    const ckconfig = await getCKEditorConfigPromise;
+                    if (ckconfig.toolbar) {
+                        return ckconfig.toolbar.split(/[\s,]+/).filter((item) => item);
                     }
                 } catch (error) {
                     console.warn(

--- a/web_widget_ckeditor/static/src/js/field_ckeditor.js
+++ b/web_widget_ckeditor/static/src/js/field_ckeditor.js
@@ -32,7 +32,7 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
         try {
             ajax.loadJS(languageURL);
         } catch (error) {
-            console.warning("Unable to load CKEditor language: ", languageCode);
+            console.warn("Unable to load CKEditor language: ", languageCode);
         }
     }
     const CKEditorLanguageCode = session.user_context.lang.split("_")[0];
@@ -148,14 +148,14 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
                         return toolbarConfig.split(/[\s,]+/).filter((item) => item);
                     }
                 } catch (error) {
-                    console.warning(
+                    console.warn(
                         "Unable to use CKEditor toolbar configuration: ",
                         error
                     );
-                    console.warning(
+                    console.warn(
                         "Please check the value for ir.config_parameter 'web_widget_ckeditor.toolbar' is correct"
                     );
-                    console.warning("Using default toolbar configuration");
+                    console.warn("Using default toolbar configuration");
                 }
                 return [
                     "heading",


### PR DESCRIPTION
JS fails if user doesn't have admin rights, as `ir.config_parameter` can't be read otherwise.

Also, a typo ~`console.warning`~ `console.warn`