### PR TITLE
[14.0] [FIX] Fields with complex context

### DIFF
--- a/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
+++ b/web_tree_many2one_clickable/static/src/js/web_tree_many2one_clickable.js
@@ -58,7 +58,9 @@ odoo.define("web_tree_many2one_clickable.many2one_clickable", function (require)
                         res_id: self.value.res_id,
                         views: [[false, "form"]],
                         target: "target",
-                        context: self.attrs.context || {},
+                        context: self.record.getContext({
+                            additionalContext: self.attrs.context || {},
+                        }),
                     });
                 });
                 this.$el.append($a);


### PR DESCRIPTION
Hello @rven, @StefanRijnhart and @legalsylvain,
I've using that awesome feature for a while (pass the context used in the field), but I've found that if you click on a field with a context like this `{'default_product_id': [56]}` (note the id of the product), the `self.attrs.context` works perfectly, but if you click on a field with a conext like this one `{'default_product_id': product_id}`, throws a javascript error.
The reason is because the context goes in a direct action before being parsed.

The change I've introduced, parses the context before sending the action, so the resulting context will be the integer of the record:
`{'default_product_id': product_id}` converts to `{'default_product_id': [56]}`.

With this small change can deal with any type of context.

MT-288 @moduon
