### PR TITLE
[14.0][FIX] web_company_color: Recalculated color when we do not want

### DIFF
--- a/web_company_color/i18n/es.po
+++ b/web_company_color/i18n/es.po
@@ -4,84 +4,72 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 14.0\n"
+"Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-03-02 15:55+0000\n"
-"PO-Revision-Date: 2022-03-02 15:55+0000\n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"PO-Revision-Date: 2022-03-02 16:56+0100\n"
+"Last-Translator: claudiagn <claudia.gargallo@qubiq.es>\n"
+"Language-Team: none\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: web_company_color
 #: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
 msgid ""
 "<span class=\"fa fa-info fa-2x\"/>\n"
-"                        In order for the changes to take effect, please refresh\n"
+"                        In order for the changes to take effect, please "
+"refresh\n"
 "                        the page."
 msgstr ""
+"<span class = \"fa fa-info fa-2x\" />\n"
+"                        Para que los cambios surtan efecto, actualice\n"
+"                        la página."
 
 #. module: web_company_color
 #: model:ir.model,name:web_company_color.model_res_company
 msgid "Companies"
-msgstr ""
+msgstr "Compañías"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__company_colors
 msgid "Company Colors"
-msgstr ""
+msgstr "Colores de la compañía"
 
 #. module: web_company_color
 #: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
 msgid "Company Styles"
-msgstr ""
+msgstr "Estilos de compañía"
 
 #. module: web_company_color
 #: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
 msgid "Compute colors from logo"
-msgstr ""
-
-#. module: web_company_color
-#: model:ir.model.fields,field_description:web_company_color.field_ir_qweb__display_name
-#: model:ir.model.fields,field_description:web_company_color.field_res_company__display_name
-msgid "Display Name"
-msgstr ""
-
-#. module: web_company_color
-#: model:ir.model.fields,field_description:web_company_color.field_ir_qweb__id
-#: model:ir.model.fields,field_description:web_company_color.field_res_company__id
-msgid "ID"
-msgstr ""
-
-#. module: web_company_color
-#: model:ir.model.fields,field_description:web_company_color.field_ir_qweb____last_update
-#: model:ir.model.fields,field_description:web_company_color.field_res_company____last_update
-msgid "Last Modified on"
-msgstr ""
+msgstr "Calcular colores a partir del logo"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_navbar_bg
 msgid "Navbar Background Color"
-msgstr ""
+msgstr "Color de fondo de la barra de navegación"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_navbar_bg_hover
 msgid "Navbar Background Color Hover"
-msgstr ""
+msgstr "Desplazamiento del color de fondo de la barra de navegación"
 
 #. module: web_company_color
 #: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
 msgid "Navbar Colors"
-msgstr ""
+msgstr "Colores de la barra de navegación"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_navbar_text
 msgid "Navbar Text Color"
-msgstr ""
+msgstr "Color de texto de la barra de navegación"
 
 #. module: web_company_color
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
-msgstr ""
+msgstr "Qweb"

--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -74,33 +74,35 @@ class ResCompany(models.Model):
                 "color_navbar_bg_hover",
                 "color_navbar_text",
             )
-            if "logo" in values:
-                if values["logo"]:
-                    _r, _g, _b = image_to_rgb(convert_to_image(values["logo"]))
-                    # Make color 10% darker
-                    _h, _l, _s = rgb_to_hls(_r, _g, _b)
-                    _l = max(0, _l - 0.1)
-                    _rd, _gd, _bd = hls_to_rgb(_h, _l, _s)
-                    # Calc. optimal text color (b/w)
-                    # Grayscale human vision perception (Rec. 709 values)
-                    _a = 1 - (0.2126 * _r + 0.7152 * _g + 0.0722 * _b)
-                    values.update(
-                        {
-                            "color_navbar_bg": n_rgb_to_hex(_r, _g, _b),
-                            "color_navbar_bg_hover": n_rgb_to_hex(_rd, _gd, _bd),
-                            "color_navbar_text": "#000" if _a < 0.5 else "#fff",
-                        }
-                    )
-                else:
-                    values.update(self.default_get(fields_to_check))
-
             result = super().write(values)
-
             if any([field in values for field in fields_to_check]):
                 self.scss_create_or_update_attachment()
         else:
             result = super().write(values)
         return result
+
+    def button_compute_color(self):
+        self.ensure_one()
+        values = self.default_get(
+            ["color_navbar_bg", "color_navbar_bg_hover", "color_navbar_text"]
+        )
+        if self.logo:
+            _r, _g, _b = image_to_rgb(convert_to_image(self.logo))
+            # Make color 10% darker
+            _h, _l, _s = rgb_to_hls(_r, _g, _b)
+            _l = max(0, _l - 0.1)
+            _rd, _gd, _bd = hls_to_rgb(_h, _l, _s)
+            # Calc. optimal text color (b/w)
+            # Grayscale human vision perception (Rec. 709 values)
+            _a = 1 - (0.2126 * _r + 0.7152 * _g + 0.0722 * _b)
+            values.update(
+                {
+                    "color_navbar_bg": n_rgb_to_hex(_r, _g, _b),
+                    "color_navbar_bg_hover": n_rgb_to_hex(_rd, _gd, _bd),
+                    "color_navbar_text": "#000" if _a < 0.5 else "#fff",
+                }
+            )
+        self.write(values)
 
     def _scss_get_sanitized_values(self):
         self.ensure_one()

--- a/web_company_color/readme/CONTRIBUTORS.rst
+++ b/web_company_color/readme/CONTRIBUTORS.rst
@@ -1,5 +1,9 @@
 * Jordi Ballester Alomar <jordi.ballester@forgeflow.com> (ForgeFlow)
 * Lois Rilo <lois.rilo@forgefloww.com> (ForgeFlow)
 * Simone Orsi <simone.orsi@camptocamp.com>
-* Jairo Llopis <jairo.llopis@tecnativa.com>
 * Iván Antón <ozono@ozonomultimedia.com>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Jairo Llopis
+  * Alexandre Díaz
+  * Carlos Roca

--- a/web_company_color/tests/test_res_company.py
+++ b/web_company_color/tests/test_res_company.py
@@ -25,6 +25,7 @@ class TestResCompany(common.TransactionCase):
         )
         self._test_scss_attachment()
         company_id.sudo().write({"logo": self.IMG_GREEN})
+        company_id.button_compute_color()
         self.assertEqual(
             company_id.color_navbar_bg, "#00ff00", "Invalid Navbar Background Color"
         )
@@ -36,6 +37,7 @@ class TestResCompany(common.TransactionCase):
     def test_change_logo(self):
         company_id = self.env["res.company"].search([], limit=1)
         company_id.sudo().write({"logo": self.IMG_GREEN})
+        company_id.button_compute_color()
         self.assertEqual(
             company_id.color_navbar_bg, "#00ff00", "Invalid Navbar Background Color"
         )

--- a/web_company_color/view/res_company.xml
+++ b/web_company_color/view/res_company.xml
@@ -19,6 +19,12 @@
                         <field name="color_navbar_bg" widget="color" />
                         <field name="color_navbar_bg_hover" widget="color" />
                         <field name="color_navbar_text" widget="color" />
+                        <button
+                            class="btn-primary"
+                            name="button_compute_color"
+                            type="object"
+                            string="Compute colors from logo"
+                        />
                     </group>
                     <div class="alert alert-info info_icon" role="alert">
                         <span class="fa fa-info fa-2x" />


### PR DESCRIPTION
If we change something with base.document.layout wizard, this will launch the colors computing even without changing the logo. This procedure will change the value of the colors if they were set by hand.

This change forces the user to press a button to recompute the colors and avoid possible undesired changes.

cc @Tecnativa TT34902

fw-port of https://github.com/OCA/web/pull/2157

ping @pedrobaeza 