### PR TITLE
[15.0][FIX] web_widget_bokeh_chart: Activate script once DOM is loaded

### DIFF
--- a/web_widget_bokeh_chart/static/src/js/web_widget_bokeh_chart.esm.js
+++ b/web_widget_bokeh_chart/static/src/js/web_widget_bokeh_chart.esm.js
@@ -20,7 +20,7 @@ const BokehChartWidget = basicFields.FieldChar.extend({
             script.setAttribute("type", "text/javascript");
             if ("textContent" in script) script.textContent = val.script;
             else script.text = val.script;
-            $("head").append(script);
+            this.$el.append(script);
         } catch (error) {
             return this._super(...arguments);
         }


### PR DESCRIPTION
**Solution**
**ready()** --> this function allows javascript code to be activated once the DOM tree is loaded, without waiting for images or other resources. 

**Previous behaviour:** 
Sometimes get error because it's trying to activate script before DOM is loaded.
![Captura de pantalla de 2022-03-09 09-52-27](https://user-images.githubusercontent.com/90243017/157409867-174bc03d-18d3-40cf-8493-92bb31e8ee0e.png)

**Current behaviour:**
No errors anymore, because we make `$("head").append(script);` inside `ready()` function.