### PR TITLE
[FIX] web_widget_x2many_2d_matrix: make the possibility to have alternative values for headers 

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/2d_matrix_renderer.js
@@ -220,7 +220,7 @@ odoo.define('web_widget_x2many_2d_matrix.X2Many2dMatrixRenderer', function (requ
          */
         _renderLabelCell: function (record) {
             var $td = $('<td>');
-            var value = record.data[this.matrix_data.field_y_axis];
+            var value = record.data[this.matrix_data.field_label_y_axis];
             if (value.type === 'record') {
                 // We have a related record
                 value = value.data.display_name;

--- a/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
+++ b/web_widget_x2many_2d_matrix/static/src/js/widget_x2many_2d_matrix.js
@@ -94,8 +94,8 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
             this.x_axis = [];
             this.y_axis = [];
             _.each(records, function (record) {
-                var x = record.data[this.field_x_axis],
-                    y = record.data[this.field_y_axis];
+                var x = record.data[this.field_label_x_axis],
+                    y = record.data[this.field_label_y_axis];
                 if (x.type === 'record') {
                     // We have a related record
                     x = x.data.display_name;
@@ -126,6 +126,8 @@ odoo.define('web_widget_x2many_2d_matrix.widget', function (require) {
                 'field_value': this.field_value,
                 'field_x_axis': this.field_x_axis,
                 'field_y_axis': this.field_y_axis,
+                'field_label_x_axis': this.field_label_x_axis,
+                'field_label_y_axis': this.field_label_y_axis,
                 'columns': this.columns,
                 'rows': this.rows,
                 'show_row_totals': this.show_row_totals,

--- a/web_widget_x2many_2d_matrix_example/models/__init__.py
+++ b/web_widget_x2many_2d_matrix_example/models/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from . import x2m_demo
+from . import res_users

--- a/web_widget_x2many_2d_matrix_example/models/res_users.py
+++ b/web_widget_x2many_2d_matrix_example/models/res_users.py
@@ -1,0 +1,13 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models, api, fields
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    matrix_display_name = fields.Char(compute="_compute_matrix_display_name")
+
+    @api.depends("name", "email")
+    def _compute_matrix_display_name(self):
+        for user in self:
+            user.matrix_display_name = "%s (%s)" % (user.name, user.email)

--- a/web_widget_x2many_2d_matrix_example/models/x2m_demo.py
+++ b/web_widget_x2many_2d_matrix_example/models/x2m_demo.py
@@ -7,7 +7,15 @@ class X2MDemo(models.Model):
     _description = 'X2Many Demo'
 
     name = fields.Char()
+
+    display_name = fields.Char(compute="_compute_display_name")
+
     line_ids = fields.One2many('x2m.demo.line', 'demo_id')
+
+    @api.depends("name")
+    def _compute_display_name(self):
+        for demo in self:
+            demo.display_name = "%s (#%s)" % (demo.name, demo.id)
 
     @api.multi
     def _open_x2m_matrix(self, view_xmlid):
@@ -46,7 +54,9 @@ class X2MDemoLine(models.Model):
 
     name = fields.Char()
     demo_id = fields.Many2one('x2m.demo')
+    demo_display_name = fields.Char(related="demo_id.display_name")
     user_id = fields.Many2one('res.users')
+    user_display_name = fields.Char(related="user_id.matrix_display_name")
     value = fields.Integer()
     value_selection = fields.Selection(
         [('val1', 'Value 1'), ('val2', 'Value 2')],

--- a/web_widget_x2many_2d_matrix_example/wizard/x2m_matrix.py
+++ b/web_widget_x2many_2d_matrix_example/wizard/x2m_matrix.py
@@ -19,6 +19,7 @@ class X2mMatrixDemoWiz(models.TransientModel):
                 'name': "{}'s task on {}".format(usr.name, rec.name),
                 'demo_id': rec.id,
                 'user_id': usr.id,
+                'user_display_name': usr.matrix_display_name,
             })
             # if there isn't a demo line record for the user, create a new one
             if not rec.line_ids.filtered(lambda x: x.user_id == usr) else

--- a/web_widget_x2many_2d_matrix_example/wizard/x2m_matrix.xml
+++ b/web_widget_x2many_2d_matrix_example/wizard/x2m_matrix.xml
@@ -8,10 +8,12 @@
         <field name="arch" type="xml">
             <form>
                 <field name="line_ids" widget="x2many_2d_matrix"
-                       field_x_axis="demo_id" field_y_axis="user_id" field_value="value">
+                       field_x_axis="demo_id" field_y_axis="user_id" field_value="value" field_label_x_axis="demo_display_name" field_label_y_axis="user_display_name">
                     <tree>
                         <field name="demo_id"/>
+                        <field name="demo_display_name"/>
                         <field name="user_id"/>
+                        <field name="user_display_name"/>
                         <field name="value"/>
                     </tree>
                 </field>
@@ -26,10 +28,12 @@
         <field name="arch" type="xml">
             <form>
                 <field name="line_ids" widget="x2many_2d_matrix"
-                       field_x_axis="demo_id" field_y_axis="user_id" field_value="value_selection">
+                       field_x_axis="demo_id" field_y_axis="user_id" field_value="value_selection" field_label_x_axis="demo_display_name" field_label_y_axis="user_display_name">
                     <tree>
                         <field name="demo_id"/>
+                        <field name="demo_display_name"/>
                         <field name="user_id"/>
+                        <field name="user_display_name"/>
                         <field name="value_selection"/>
                     </tree>
                 </field>
@@ -44,10 +48,12 @@
         <field name="arch" type="xml">
             <form>
                 <field name="line_ids" widget="x2many_2d_matrix"
-                       field_x_axis="demo_id" field_y_axis="user_id" field_value="value_many2one">
+                       field_x_axis="demo_id" field_y_axis="user_id" field_value="value_many2one" field_label_x_axis="demo_display_name" field_label_y_axis="user_display_name">
                     <tree>
                         <field name="demo_id"/>
+                        <field name="demo_display_name"/>
                         <field name="user_id"/>
+                        <field name="user_display_name"/>
                         <field name="value_many2one" domain="[('users', '=', user_id)]"/>
                     </tree>
                 </field>


### PR DESCRIPTION
In the current implementation, ``field_label_y_axis`` and ``field_label_x_axis`` can be defined, but there are not used in the javascript algorithm, and so defining those values doesn't work.
this patch fixes the problem.
