### PR TITLE
[12.0] [FIX] web_advanced_filter: prevent error on filter delete

### DIFF
--- a/web_advanced_filter/wizards/ir_filters_combine_with_existing.py
+++ b/web_advanced_filter/wizards/ir_filters_combine_with_existing.py
@@ -18,7 +18,13 @@ class IrFiltersCombineWithExisting(models.TransientModel):
     domain = fields.Char('Domain', required=True)
     context = fields.Char('Context', required=True, default='{}')
     model = fields.Char('Model', required=True)
-    filter_id = fields.Many2one('ir.filters', 'Filter', required=True)
+    filter_id = fields.Many2one(
+        comodel_name='ir.filters',
+        string='Filter',
+        ondelete='cascade',
+        index=True,
+        required=True
+    )
 
     @api.multi
     def button_save(self):


### PR DESCRIPTION
The wizard that adds criteria to a filter maintains a reference to that filter. That makes it
impossible to delete the filter pointed to. By changing the filter_id field to delete cascade,
this problem is solved.