### PR TITLE
[12.0] web_widget_mpld3_chart: fix mpld3 dependency

### DIFF
--- a/setup/web_widget_mpld3_chart/setup.py
+++ b/setup/web_widget_mpld3_chart/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        "external_dependencies_override": {
+            "python": {
+                "mpld3": "mpld3==0.3",
+            },
+        },
+    },
 )

--- a/setup/web_widget_mpld3_chart/setup.py
+++ b/setup/web_widget_mpld3_chart/setup.py
@@ -6,6 +6,7 @@ setuptools.setup(
         "external_dependencies_override": {
             "python": {
                 "mpld3": "mpld3==0.3",
+                "matplotlib": "matplotlib==3.0.3; python_version < '3.7'",
             },
         },
     },

--- a/web_widget_mpld3_chart/__manifest__.py
+++ b/web_widget_mpld3_chart/__manifest__.py
@@ -14,7 +14,7 @@
         "views/web_widget_mpld3_chart.xml",
     ],
     "external_dependencies": {
-        "python": ['mpld3'],
+        "python": ['mpld3', 'matplotlib'],
     },
     "auto_install": False,
     "license": "LGPL-3",


### PR DESCRIPTION
Coming from https://github.com/OCA/web/pull/2146#issuecomment-1075182792

This is an attempt to fix an installation issue on runboat.
The reason for the pin is unknown at the moment, unfortunately.

@ypapouin 