### PR TITLE
[15.0][FIX]kanban: valid attribute 'records_draggable'

### DIFF
--- a/web_responsive/static/src/legacy/js/kanban_renderer_mobile.js
+++ b/web_responsive/static/src/legacy/js/kanban_renderer_mobile.js
@@ -94,7 +94,7 @@ odoo.define("web_responsive.KanbanRendererMobile", function (require) {
             this._super.apply(this, arguments);
             core.bus.on("UI_CONTEXT:IS_SMALL_CHANGED", this, () => {
                 this.widgets = [];
-                this.columnOptions.recordsDraggable = !config.device.isMobile;
+                this.columnOptions.recordsDraggable = config.device.isMobile ? false : this.columnOptions.recordsDraggable;
                 this._renderView();
             });
         },
@@ -176,7 +176,7 @@ odoo.define("web_responsive.KanbanRendererMobile", function (require) {
          */
         _setState: function () {
             const res = this._super.apply(this, arguments);
-            this.columnOptions.recordsDraggable = !config.device.isMobile;
+            this.columnOptions.recordsDraggable = config.device.isMobile ? false : this.columnOptions.recordsDraggable;
             return res;
         },
         /**


### PR DESCRIPTION
Kanban View has an attribute `records_draggable`, means 'whether it should be possible to drag records when kanban is grouped'.
But code at line 97 and line 179 assume the option `recordsDraggable` dur to the value of `config.device.isMobile`, thus the attribute `records_draggable` has no effect on destop platform.
Sorry for terrible English.