### PR TITLE
[15.0][FIX]-web_responsive module: Go to wrong action menu when access from Root Screen Search Bar when user is set with Home Action Menu

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.xml
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.xml
@@ -62,7 +62,7 @@
                     <a
                         t-attf-class="search-result {{result_index == state.offset ? 'highlight' : ''}}"
                         t-att-style="menu.webIconData ? &quot;background-image:url('data:image/png;base64,&quot; + menu.webIconData + &quot;')&quot; : ''"
-                        t-attf-href="#menu_id={{menu.id}}&amp;action_id={{menu.actionID}}"
+                        t-attf-href="#menu_id={{menu.id}}&amp;action={{menu.actionID}}"
                         t-att-data-menu-id="menu.id"
                         t-att-data-action-id="menu.actionID"
                         draggable="false"


### PR DESCRIPTION


# How to reproduce

- Install module web_responsive
- Set Home Action for user in the tab Preferences
- Refresh the page
- Type menu on the Search Bar
- Click on the menu we want
- Redirect us to wrong menu
