### PR TITLE
[14.0] [ADD] `web_widget_domain_dynamic`

### DIFF
--- a/setup/web_widget_domain_dynamic/odoo/addons/web_widget_domain_dynamic
+++ b/setup/web_widget_domain_dynamic/odoo/addons/web_widget_domain_dynamic
@@ -1,0 +1,1 @@
+../../../../web_widget_domain_dynamic

--- a/setup/web_widget_domain_dynamic/setup.py
+++ b/setup/web_widget_domain_dynamic/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/web_widget_ckeditor/static/src/js/field_ckeditor.js
+++ b/web_widget_ckeditor/static/src/js/field_ckeditor.js
@@ -34,7 +34,9 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
             console.warn("Unable to load CKEditor language: ", languageCode);
         }
     }
-    const CKEditorLanguageCode = session.user_context.lang.split("_")[0];
+    const CKEditorLanguageCode = session.user_context.lang
+        ? session.user_context.lang.split("_")[0]
+        : "en";
     const loadCKEditorLanguagePromise = loadCKEditorLanguageSource(
         CKEditorLanguageCode
     );

--- a/web_widget_domain_dynamic/__manifest__.py
+++ b/web_widget_domain_dynamic/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Web Widget Domain Dynamic",
+    "summary": "Allow to use dynamic expressions in the domain widget",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/web",
+    "license": "AGPL-3",
+    "category": "Web",
+    "depends": ["web"],
+    "data": ["views/assets.xml"],
+}

--- a/web_widget_domain_dynamic/readme/CONTRIBUTORS.rst
+++ b/web_widget_domain_dynamic/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+    * Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/web_widget_domain_dynamic/readme/DESCRIPTION.rst
+++ b/web_widget_domain_dynamic/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module backports a feature implemented in Odoo 15.0, that allows to use
+dynamic domain expressions in the domain editor widget (in debug mode).
+
+In Odoo >= 15.0, this is implemented here:
+https://github.com/odoo/odoo/commit/15301a1dd

--- a/web_widget_domain_dynamic/static/src/js/basic_fields.js
+++ b/web_widget_domain_dynamic/static/src/js/basic_fields.js
@@ -1,0 +1,22 @@
+/*
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+*/
+odoo.define("web_widget_domain_dynamic.basic_fields", function (require) {
+    "use strict";
+
+    const basic_fields = require("web.basic_fields");
+
+    basic_fields.FieldDomain.include({
+        /**
+         * @override completely to set the string, unparsed, value.
+         */
+        _onDomainSelectorValueChange: function () {
+            if (this.inDialog) return;
+            this._setValue(this.domainSelector.rawDomain);
+        },
+    });
+
+    return basic_fields;
+});

--- a/web_widget_domain_dynamic/static/src/js/domain_selector.js
+++ b/web_widget_domain_dynamic/static/src/js/domain_selector.js
@@ -1,0 +1,51 @@
+/*
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+*/
+odoo.define("web_widget_domain_dynamic.DomainSelector", function (require) {
+    "use strict";
+
+    const DomainSelector = require("web.DomainSelector");
+    const Domain = require("web.Domain");
+
+    DomainSelector.include({
+        /**
+         * @override
+         */
+        init(parent, model, domain) {
+            this._super.apply(this, arguments);
+            this.rawDomain = domain;
+        },
+        /**
+         * @override
+         */
+        _postRender: function () {
+            this._super.apply(this, arguments);
+            // Replace technical domain if in debug mode
+            if (this.$debugInput.length) {
+                this.$debugInput.val(this.rawDomain);
+                // Original method would do this instead:
+                // this.$debugInput.val(Domain.prototype.arrayToString(this.getDomain()));
+            }
+        },
+        /**
+         * @override
+         */
+        _onDebugInputChange: function (e) {
+            this.rawDomain = e.currentTarget.value;
+            return this._super.apply(this, arguments);
+        },
+        /**
+         * @override
+         */
+        _onDomainChange: function (e) {
+            if (!e.data.alreadyRedrawn) {
+                this.rawDomain = Domain.prototype.arrayToString(this.getDomain());
+            }
+            return this._super.apply(this, arguments);
+        },
+    });
+
+    return DomainSelector;
+});

--- a/web_widget_domain_dynamic/static/tests/web_widget_domain_dynamic_tests.js
+++ b/web_widget_domain_dynamic/static/tests/web_widget_domain_dynamic_tests.js
@@ -1,0 +1,104 @@
+odoo.define("web_widget_domain_dynamic.tests", function (require) {
+    "use strict";
+
+    const FormView = require("web.FormView");
+    const testUtils = require("web.test_utils");
+    const {date_to_str} = require("web.time");
+    const {createView} = testUtils;
+    const {QUnit} = window;
+
+    QUnit.module(
+        "web_widget_domain_dynamic",
+        {
+            beforeEach: function () {
+                this.data = {
+                    partner: {
+                        fields: {
+                            date: {string: "A date", type: "date", searchable: true},
+                            domain: {
+                                string: "Domain",
+                                type: "char",
+                                default: "[]",
+                                searchable: true,
+                                trim: true,
+                            },
+                            model: {
+                                string: "Model",
+                                type: "char",
+                                default: "partner",
+                                searchable: true,
+                            },
+                        },
+                        records: [
+                            {
+                                id: 1,
+                                date: "2017-02-03",
+                            },
+                            {
+                                id: 2,
+                                date: date_to_str(new Date()),
+                            },
+                            {
+                                id: 3,
+                                date: date_to_str(moment().add(10, "days").toDate()),
+                            },
+                        ],
+                        onchanges: {},
+                    },
+                };
+            },
+        },
+        function () {
+            QUnit.test(
+                "domain field: edit domain with dynamic content",
+                async function (assert) {
+                    assert.expect(2);
+
+                    const originalDebug = odoo.debug;
+                    odoo.debug = true;
+
+                    let rawDomain = `[["date", ">=", datetime.datetime.combine(context_today() + relativedelta(days = -365), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")]]`;
+                    const partner1 = this.data.partner.records[0];
+                    partner1.domain = rawDomain;
+                    partner1.model = "partner";
+
+                    const form = await createView({
+                        View: FormView,
+                        model: "partner",
+                        data: this.data,
+                        arch: `
+                        <form>
+                            <field name="model"/>
+                            <field name="domain" widget="domain" options="{'model': 'model'}"/>
+                        </form>
+                    `,
+                        mockRPC(route, args) {
+                            if (args.method === "write") {
+                                assert.strictEqual(args.args[1].domain, rawDomain);
+                            }
+                            return this._super.apply(this, arguments);
+                        },
+                        res_id: 1,
+                        viewOptions: {mode: "edit"},
+                    });
+
+                    assert.strictEqual(
+                        form.$(".o_domain_debug_input").val(),
+                        rawDomain
+                    );
+
+                    rawDomain = `[["date", ">=", datetime.datetime.combine(context_today() + relativedelta(days = -1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")]]`;
+                    await testUtils.fields.editAndTrigger(
+                        form.$(".o_domain_debug_input"),
+                        rawDomain,
+                        ["input", "change", "focusout"]
+                    );
+                    await testUtils.form.clickSave(form);
+
+                    form.destroy();
+                    odoo.debug = originalDebug;
+                }
+            );
+        }
+    );
+});

--- a/web_widget_domain_dynamic/tests/__init__.py
+++ b/web_widget_domain_dynamic/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_qunit

--- a/web_widget_domain_dynamic/tests/test_qunit.py
+++ b/web_widget_domain_dynamic/tests/test_qunit.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestWebWidgetDomainDynamic(HttpCase):
+    def test_qunit(self):
+        self.browser_js(
+            "/web/tests?module=web_widget_domain_dynamic&failfast",
+            "",
+            "",
+            login="admin",
+        )

--- a/web_widget_domain_dynamic/views/assets.xml
+++ b/web_widget_domain_dynamic/views/assets.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <template id="assets_backend" inherit_id="web.assets_backend">
+        <xpath expr="//script[last()]" position="after">
+            <script
+                type="text/javascript"
+                src="/web_widget_domain_dynamic/static/src/js/basic_fields.js"
+            />
+            <script
+                type="text/javascript"
+                src="/web_widget_domain_dynamic/static/src/js/domain_selector.js"
+            />
+        </xpath>
+    </template>
+
+    <template id="qunit_suite_tests" inherit_id="web.qunit_suite_tests">
+        <xpath expr="//script[last()]" position="after">
+            <script
+                type="text/javascript"
+                src="/web_widget_domain_dynamic/static/tests/web_widget_domain_dynamic_tests.js"
+            />
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
This module backports a feature implemented in Odoo `>= 15.0`, that allows to use dynamic domain expressions in the domain editor widget (in debug mode).

In Odoo `>= 15.0`, this is implemented here: https://github.com/odoo/odoo/commit/15301a1dd
