### PR TITLE
[14.0][FIX] web_action_conditionable: Create and delete attribute not work

### DIFF
--- a/web_action_conditionable/static/src/js/field_one2many.js
+++ b/web_action_conditionable/static/src/js/field_one2many.js
@@ -16,6 +16,9 @@ odoo.define("web.web_action_conditionable", function (require) {
                 if (arch) {
                     ["create", "delete"].forEach(function (item) {
                         if (!_.has(arch.attrs, item)) {
+                            self.activeActions[item] = arch.attrs[item]
+                                ? Boolean(JSON.parse(arch.attrs[item]))
+                                : true;
                             return;
                         }
                         var expr = arch.attrs[item];
@@ -32,7 +35,11 @@ odoo.define("web.web_action_conditionable", function (require) {
                         }
                     });
                     this.editable = arch.attrs.editable;
+                    this._canQuickEdit = arch.tag === "tree";
+                } else {
+                    this._canQuickEdit = false;
                 }
+                this._computeAvailableActions(self.record);
                 if (this.attrs.columnInvisibleFields) {
                     this._processColumnInvisibleFields();
                 }


### PR DESCRIPTION
Add create="state='draft'" in sale order line
![Selection_791](https://user-images.githubusercontent.com/24691983/175253138-87ecdaf6-6580-45d7-a80d-71e332a57572.png)

**Before Fix**
![Selection_792](https://user-images.githubusercontent.com/24691983/175253815-a9b0e190-f9d3-4f07-9b96-f9e1f796a071.png)

**After Fix**
![Selection_793](https://user-images.githubusercontent.com/24691983/175254448-577f2bfc-def2-44ad-a208-9bfaaf8b23b8.png)

