### PR TITLE
[12.0][IMP] web_ir_actions_act_view_reload: support wizards

### DIFF
--- a/web_ir_actions_act_view_reload/static/src/js/web_ir_actions_act_view_reload.js
+++ b/web_ir_actions_act_view_reload/static/src/js/web_ir_actions_act_view_reload.js
@@ -25,7 +25,7 @@ odoo.define('web_ir_actions_act_view_reload.ir_actions_act_view_reload', functio
          * @returns {$.Promise}
          */
         _executeReloadAction: function () {
-            var controller = this.getCurrentController();
+            var controller = this.currentDialogController || this.getCurrentController();
             if (controller && controller.widget) {
                 controller.widget.reload();
             }


### PR DESCRIPTION
when the action is returned from a button on a wizard, we need to reload the wizard's controller, not the underlying action's