### PR TITLE
[15.0][IMP] web_advanced_search: add legacy compability to avoid issues on pivot

### DIFF
--- a/web_advanced_search/__manifest__.py
+++ b/web_advanced_search/__manifest__.py
@@ -16,6 +16,7 @@
     "assets": {
         "web.assets_backend": [
             "web_advanced_search/static/src/js/**/*.js",
+            "web_advanced_search/static/src/legacy/**/*.js",
         ],
         "web.assets_qweb": [
             "web_advanced_search/static/src/xml/**/*.xml",

--- a/web_advanced_search/static/src/legacy/CustomFilterItem.js
+++ b/web_advanced_search/static/src/legacy/CustomFilterItem.js
@@ -1,0 +1,84 @@
+odoo.define("web_advanced_search.CustomFilterItem", function (require) {
+    "use strict";
+
+    const CustomFilterItem = require("web.CustomFilterItem");
+    const {patch} = require("web.utils");
+    const RecordPicker = require("web_advanced_search.RecordPicker");
+    patch(CustomFilterItem.prototype, "web_advanced_search.CustomFilterItem", {
+        /**
+         * Ideally we'd want this in setup, but CustomFilterItem does its initialization
+         * in the constructor, which can't be patched.
+         *
+         * Doing it here works just as well.
+         *
+         * @override
+         */
+        async willStart() {
+            this.OPERATORS.relational = this.OPERATORS.char;
+            this.FIELD_TYPES.many2one = "relational";
+            return this._super(...arguments);
+        },
+        /**
+         * @override
+         */
+        _setDefaultValue(condition) {
+            const res = this._super(...arguments);
+            const fieldType = this.fields[condition.field].type;
+            const genericType = this.FIELD_TYPES[fieldType];
+            if (genericType === "relational") {
+                condition.value = 0;
+                condition.displayedValue = "";
+            }
+            return res;
+        },
+        /**
+         * Add displayed value to preFilters for "relational" types.
+         *
+         * @override
+         */
+        onApply() {
+            // To avoid the complete override, we patch this.conditions.map()
+            const originalMapFn = this.conditions.map;
+            const self = this;
+            this.conditions.map = function () {
+                const preFilters = originalMapFn.apply(this, arguments);
+                for (const condition of this) {
+                    const field = self.fields[condition.field];
+                    const type = self.FIELD_TYPES[field.type];
+                    if (type === "relational") {
+                        const idx = this.indexOf(condition);
+                        const preFilter = preFilters[idx];
+                        const operator = self.OPERATORS[type][condition.operator];
+                        const descriptionArray = [
+                            field.string,
+                            operator.description,
+                            `"${condition.displayedValue}"`,
+                        ];
+                        preFilter.description = descriptionArray.join(" ");
+                    }
+                }
+                return preFilters;
+            };
+            const res = this._super(...arguments);
+            // Restore original map()
+            this.conditions.map = originalMapFn;
+            return res;
+        },
+        /**
+         * @private
+         * @param {Object} condition
+         * @param {OwlEvent} ev
+         */
+        onRelationalChanged(condition, ev) {
+            condition.value = ev.detail.id;
+            condition.displayedValue = ev.detail.display_name;
+        },
+    });
+    patch(CustomFilterItem, "web_advanced_search.CustomFilterItem", {
+        components: {
+            ...CustomFilterItem.components,
+            RecordPicker,
+        },
+    });
+    return CustomFilterItem;
+});

--- a/web_advanced_search/static/src/legacy/RecordPicker.js
+++ b/web_advanced_search/static/src/legacy/RecordPicker.js
@@ -1,0 +1,149 @@
+odoo.define("web_advanced_search.RecordPicker", function (require) {
+    "use strict";
+
+    const BasicModel = require("web.BasicModel");
+    const {ComponentAdapter} = require("web.OwlCompatibility");
+    const {FieldMany2One} = require("web.relational_fields");
+    const FieldManagerMixin = require("web.FieldManagerMixin");
+    const {SelectCreateDialog} = require("web.view_dialogs");
+
+    const {Component} = owl;
+    const {xml} = owl.tags;
+
+    const FakeMany2oneFieldWidget = FieldMany2One.extend(FieldManagerMixin, {
+        /**
+         * @override
+         */
+        init: function (parent) {
+            this.componentAdapter = parent;
+            const options = this.componentAdapter.props.attrs;
+            // Create a dummy record with only a dummy m2o field to search on
+            const model = new BasicModel("dummy");
+            const params = {
+                fieldNames: ["dummy"],
+                modelName: "dummy",
+                context: {},
+                type: "record",
+                viewType: "default",
+                fieldsInfo: {default: {dummy: {}}},
+                fields: {
+                    dummy: {
+                        string: options.string,
+                        relation: options.model,
+                        context: options.context,
+                        domain: options.domain,
+                        type: "many2one",
+                    },
+                },
+            };
+            // Emulate `model.load()`, without RPC-calling `default_get()`
+            this.dataPointID = model._makeDataPoint(params).id;
+            model.generateDefaultValues(this.dataPointID, {});
+            this._super(this.componentAdapter, "dummy", this._get_record(model), {
+                mode: "edit",
+                attrs: {
+                    options: {
+                        no_create_edit: true,
+                        no_create: true,
+                        no_open: true,
+                        no_quick_create: true,
+                    },
+                },
+            });
+            FieldManagerMixin.init.call(this, model);
+        },
+        /**
+         * Get record
+         *
+         * @param {BasicModel} model
+         */
+        _get_record: function (model) {
+            return model.get(this.dataPointID);
+        },
+        /**
+         * @override
+         */
+        _confirmChange: function (id, fields, event) {
+            this.componentAdapter.trigger("change", event.data.changes[fields[0]]);
+            this.dataPointID = id;
+            return this.reset(this._get_record(this.model), event);
+        },
+        /**
+         * Stop propagation of the autocompleteselect event.
+         * Otherwise, the filter's dropdown will be closed after a selection.
+         *
+         * @override to stop propagating autocompleteselect event
+         */
+        start: function () {
+            this._super(...arguments);
+            this.$input.on("autocompleteselect", (event) => event.stopPropagation());
+        },
+        /**
+         * Stop propagation of the 'Search more..' dialog click event.
+         * Otherwise, the filter's dropdown will be closed after a selection.
+         *
+         * @override
+         */
+        _searchCreatePopup: function (view, ids, context, dynamicFilters) {
+            const options = this._getSearchCreatePopupOptions(
+                view,
+                ids,
+                context,
+                dynamicFilters
+            );
+            const dialog = new SelectCreateDialog(
+                this,
+                _.extend({}, this.nodeOptions, options)
+            );
+            // Hack to stop click event propagation
+            dialog._opened.then(() =>
+                dialog.$el
+                    .get(0)
+                    .addEventListener("click", (event) => event.stopPropagation())
+            );
+            return dialog.open();
+        },
+    });
+
+    class FakeMany2oneFieldWidgetAdapter extends ComponentAdapter {
+        async updateWidget() {
+            /* eslint-disable no-empty-function */
+        }
+        async renderWidget() {
+            /* eslint-disable no-empty-function */
+        }
+    }
+
+    /**
+     * A record selector widget.
+     *
+     * Underneath, it implements and extends the `FieldManagerMixin`, and acts as if it
+     * were a reduced dummy controller. Some actions "mock" the underlying model, since
+     * sometimes we use a char widget to fill related fields (which is not supported by
+     * that widget), and fields need an underlying model implementation, which can only
+     * hold fake data, given a search view has no data on it by definition.
+     *
+     * @extends Component
+     */
+    class RecordPicker extends Component {
+        setup() {
+            this.attrs = {
+                string: this.props.string,
+                model: this.props.model,
+                domain: this.props.domain,
+                context: this.props.context,
+            };
+            this.FakeMany2oneFieldWidget = FakeMany2oneFieldWidget;
+        }
+    }
+
+    RecordPicker.template = xml`
+        <div>
+            <FakeMany2oneFieldWidgetAdapter
+                Component="FakeMany2oneFieldWidget"
+                class="d-block"
+                attrs="attrs"
+            />
+        </div>`;
+    RecordPicker.components = {FakeMany2oneFieldWidgetAdapter};
+});


### PR DESCRIPTION
Steps to reproduce the issue:

1. Open on any model pivot view.
2. Try `Add custom filter`, for example choose `company` field -> any domain.
3. Get error `Uncaught Promise > Cannot find the definition of component "RecordPicker"`

https://user-images.githubusercontent.com/29202630/178727750-a7e036a3-f833-4d8b-aa9b-9f9dbdf03a36.mp4


