### PR TITLE
[13.0][FIX] web_timeline: Don't crash when restoring timeline from breadcrumb

### DIFF
--- a/web_timeline/static/src/js/timeline_controller.js
+++ b/web_timeline/static/src/js/timeline_controller.js
@@ -44,8 +44,8 @@ odoo.define("web_timeline.TimelineController", function(require) {
                 adjust_window: true,
             });
             const domains = params.domain;
-            const contexts = params.context;
-            const group_bys = params.groupBy;
+            const contexts = params.context || [];
+            const group_bys = params.groupBy || [];
             this.last_domains = domains;
             this.last_contexts = contexts;
             // Select the group by

--- a/web_timeline/static/src/js/timeline_controller.js
+++ b/web_timeline/static/src/js/timeline_controller.js
@@ -43,9 +43,9 @@ odoo.define("web_timeline.TimelineController", function(require) {
             const defaults = _.defaults({}, options, {
                 adjust_window: true,
             });
-            const domains = params.domain;
+            const domains = params.domain || this.renderer.last_domains || [];
             const contexts = params.context || [];
-            const group_bys = params.groupBy || [];
+            const group_bys = params.groupBy || this.renderer.last_group_bys || [];
             this.last_domains = domains;
             this.last_contexts = contexts;
             // Select the group by


### PR DESCRIPTION
this avoids a crash when switching from a timeline view to some other view, and then back to the timeline view again. 