### PR TITLE
[13.0][FIX] web_responsive: mentions overlapping

### DIFF
--- a/web_responsive/static/src/scss/web_responsive.scss
+++ b/web_responsive/static/src/scss/web_responsive.scss
@@ -317,6 +317,18 @@ $chatter_zone_width: 35%;
     }
 }
 
+// Put mentions dialog below the chatter to avoid overlapping it with other elements
+.o_thread_composer {
+    .o_composer_mention_dropdown {
+        position: absolute;
+        top: 100%;
+        .dropdown-menu {
+            top: 100%;
+            bottom: auto;
+        }
+    }
+}
+
 // Scroll all but top bar
 html .o_web_client .o_action_manager .o_action {
     @include media-breakpoint-down(sm) {


### PR DESCRIPTION
When we have the chatter in the right side, mentions tend to overlap with other screen elements, so the dialog is not fully visible. With this change, we move the mentions dialog to the bottom of the composer window to avoid such problem.

Before:
![image](https://user-images.githubusercontent.com/5040182/179676929-ed25aa02-5123-4d0f-80ce-977d9f217c10.png)

After:
![image](https://user-images.githubusercontent.com/5040182/179676954-56afd0e8-9f5f-4dc6-bf84-0233ebe595ab.png)

In future versions is already fixed to behave like this

cc @Tecnativa TT38108

please review @pedrobaeza @CarlosRoca13 