### PR TITLE
[13.0][FIX] web_widget_one2many_product_picker: Don't apply limit on name_search

### DIFF
--- a/web_widget_one2many_product_picker/static/src/js/views/basic_model.js
+++ b/web_widget_one2many_product_picker/static/src/js/views/basic_model.js
@@ -500,7 +500,9 @@ odoo.define("web_widget_one2many_product_picker.BasicModel", function(require) {
                     name: search_val,
                     args: domain || [],
                     operator: operator || "ilike",
-                    limit: this.limit,
+                    // The limit will be applied later on the read
+                    // TODO: Look to replace this with a direct search_read in one step
+                    limit: 999999,
                     context: context || {},
                 },
             }).then(function(results) {


### PR DESCRIPTION
Steps to reproduce the problem:

- Have more than 100 products.
- On the "All" group, click "Search more..." until no more records are fetched

Current behavior:

Only 100 records are shown

Expected behavior:

You see more than the 100 records

The problem comes from the call to `name_search` always populating the default limit parameter (100).

@Tecnativa TT38163