### PR TITLE
[15.0][FIX] web_advanced_search: Prevent error in many2one fields

### DIFF
--- a/web_advanced_search/static/src/js/legacy/CustomFilterItem.esm.js
+++ b/web_advanced_search/static/src/js/legacy/CustomFilterItem.esm.js
@@ -76,8 +76,10 @@ patch(CustomFilterItem.prototype, "web_advanced_search.legacy.CustomFilterItem",
      * @param {OwlEvent} ev
      */
     onRelationalChanged(condition, ev) {
-        condition.value = ev.detail.id;
-        condition.displayedValue = ev.detail.display_name;
+        if (ev.detail) {
+            condition.value = ev.detail.id;
+            condition.displayedValue = ev.detail.display_name;
+        }
     },
 });
 

--- a/web_advanced_search/static/src/js/owl/CustomFilterItem.esm.js
+++ b/web_advanced_search/static/src/js/owl/CustomFilterItem.esm.js
@@ -72,8 +72,10 @@ patch(CustomFilterItem.prototype, "web_advanced_search.CustomFilterItem", {
      * @param {OwlEvent} ev
      */
     onRelationalChanged(condition, ev) {
-        condition.value = ev.detail.id;
-        condition.displayedValue = ev.detail.display_name;
+        if (ev.detail) {
+            condition.value = ev.detail.id;
+            condition.displayedValue = ev.detail.display_name;
+        }
     },
 });
 


### PR DESCRIPTION
Prevent error in many2one fields

**Before**
![antes](https://user-images.githubusercontent.com/4117568/189914028-60edbff1-f83b-4b13-ab85-5a3545ace79b.gif)

**After**
![despues](https://user-images.githubusercontent.com/4117568/189914073-78471b6d-3e3d-483f-8e30-a6edc72d1c76.gif)


Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa