### PR TITLE
[15.0][FIX] web_timeline: utc, create and update

### DIFF
--- a/web_timeline/static/src/js/timeline_controller.js
+++ b/web_timeline/static/src/js/timeline_controller.js
@@ -58,7 +58,7 @@ odoo.define("web_timeline.TimelineController", function (require) {
 
             let fields = this.renderer.fieldNames;
             fields = _.uniq(fields.concat(n_group_bys));
-            return $.when(
+            $.when(
                 res,
                 this._rpc({
                     model: this.model.modelName,
@@ -77,6 +77,7 @@ odoo.define("web_timeline.TimelineController", function (require) {
                     )
                 )
             );
+            return res;
         },
 
         /**

--- a/web_timeline/static/src/js/timeline_controller.js
+++ b/web_timeline/static/src/js/timeline_controller.js
@@ -270,12 +270,12 @@ odoo.define("web_timeline.TimelineController", function (require) {
             }
             if (this.date_start) {
                 default_context["default_".concat(this.date_start)] = moment(item.start)
-                    .add(1, "hours")
+                    .utc()
                     .format("YYYY-MM-DD HH:mm:ss");
             }
             if (this.date_stop && item.end) {
                 default_context["default_".concat(this.date_stop)] = moment(item.end)
-                    .add(1, "hours")
+                    .utc()
                     .format("YYYY-MM-DD HH:mm:ss");
             }
             if (item.group > 0) {
@@ -317,8 +317,6 @@ odoo.define("web_timeline.TimelineController", function (require) {
                 var new_event = this.renderer.event_data_transform(records[0]);
                 var items = this.renderer.timeline.itemsData;
                 items.add(new_event);
-                this.renderer.timeline.setItems(items);
-                this.reload();
             });
         },
 


### PR DESCRIPTION
When creating a new record with the timeline view, the dates where not correctly saved as UTC. fixes this oca/project#842

After saving the new record, the timeline view is emptied. I fixed this by removing the renderer and reload.
It seems to work but I'm not sure about this modification.
Any feedback @CarlosRoca13 ?