### PR TITLE
[14.0][IMP] web_disable_export_group: Differenciate between the XLSX export and export all

### DIFF
--- a/web_disable_export_group/README.rst
+++ b/web_disable_export_group/README.rst
@@ -25,11 +25,9 @@ Web Disable Export Group
 
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
-In the standard Odoo the UI option 'Export' that is present in the 'Action' menu
-and the 'Export All' button of any list view is always enabled (for every user).
+The standard export group prevents both options: 'Direct Export (xlsx)' and 'Export All'.
 
-This module makes the option 'Export' and 'Export All' enabled only for the users
-that belong to the Export Data group.
+This module adds a new group for the 'Direct Export (xlsx)' feature, leaving the standard one for only the 'Export All' feature.
 
 Admin user can always use the export option.
 
@@ -41,13 +39,13 @@ Admin user can always use the export option.
 Configuration
 =============
 
-Enable the group "Export Data group" to the users who are allowed to
-make use of the option 'Export'.
+Enable the group "Direct Export" to the users who are allowed to
+make use of the option 'Export xlsx'.
 
 Usage
 =====
 
-Every user without *Export Data* permission won't have the option available.
+Every user without *Direct Export (xlsx)* permission won't have the option available.
 
 Bug Tracker
 ===========
@@ -81,6 +79,7 @@ Contributors
   * David Vidal
   * João Marques
   * Alexandre Díaz
+  * Víctor Martínez
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_disable_export_group/__manifest__.py
+++ b/web_disable_export_group/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Web Disable Export Group",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "license": "AGPL-3",
     "author": "Onestein, " "Tecnativa, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",

--- a/web_disable_export_group/migrations/14.0.1.1.0/post-migration.py
+++ b/web_disable_export_group/migrations/14.0.1.1.0/post-migration.py
@@ -1,0 +1,16 @@
+from openupgradelib import openupgrade
+
+
+def add_new_group_from_group(self, env, group, new_group):
+    groups = env["res.groups"].search([("implied_ids", "=", group.id)])
+    groups.write({"implied_ids": [(4, new_group.id)]})
+    group.users.write({"groups_id": [(4, new_group.id)]})
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    group = env.ref("web_disable_export_group.group_export_data")
+    new_group = env.ref("web_disable_export_group.group_export_xlsx_data")
+    add_new_group_from_group(env, group, new_group)
+    group = env.ref("base.group_allow_export")
+    add_new_group_from_group(env, group, new_group)

--- a/web_disable_export_group/models/ir_http.py
+++ b/web_disable_export_group/models/ir_http.py
@@ -13,8 +13,8 @@ class Http(models.AbstractModel):
         user = request.env.user
         res.update(
             {
-                "group_export_data": user
-                and user.has_group("web_disable_export_group.group_export_data"),
+                "group_xlsx_export_data": user
+                and user.has_group("web_disable_export_group.group_export_xlsx_data"),
             }
         )
         return res

--- a/web_disable_export_group/readme/CONFIGURE.rst
+++ b/web_disable_export_group/readme/CONFIGURE.rst
@@ -1,2 +1,2 @@
-Enable the group "Export Data group" to the users who are allowed to
-make use of the option 'Export'.
+Enable the group "Direct Export" to the users who are allowed to
+make use of the option 'Export xlsx'.

--- a/web_disable_export_group/readme/CONTRIBUTORS.rst
+++ b/web_disable_export_group/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
   * David Vidal
   * João Marques
   * Alexandre Díaz
+  * Víctor Martínez

--- a/web_disable_export_group/readme/DESCRIPTION.rst
+++ b/web_disable_export_group/readme/DESCRIPTION.rst
@@ -1,7 +1,5 @@
-In the standard Odoo the UI option 'Export' that is present in the 'Action' menu
-and the 'Export All' button of any list view is always enabled (for every user).
+The standard export group prevents both options: 'Direct Export (xlsx)' and 'Export All'.
 
-This module makes the option 'Export' and 'Export All' enabled only for the users
-that belong to the Export Data group.
+This module adds a new group for the 'Direct Export (xlsx)' feature, leaving the standard one for only the 'Export All' feature.
 
 Admin user can always use the export option.

--- a/web_disable_export_group/readme/USAGE.rst
+++ b/web_disable_export_group/readme/USAGE.rst
@@ -1,1 +1,1 @@
-Every user without *Export Data* permission won't have the option available.
+Every user without *Direct Export (xlsx)* permission won't have the option available.

--- a/web_disable_export_group/security/groups.xml
+++ b/web_disable_export_group/security/groups.xml
@@ -2,8 +2,10 @@
 <!-- Copyright 2016 Onestein
      License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).-->
 <odoo>
-    <record id="group_export_data" model="res.groups">
-        <field name="name">Export Data</field>
+    <record id="group_export_xlsx_data" model="res.groups">
+        <field name="name">Direct Export (xlsx)</field>
+        <field name="implied_ids" eval="[(4, ref('base.group_allow_export'))]" />
+        <field name="category_id" ref="base.module_category_hidden" />
         <field
             name="users"
             eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"

--- a/web_disable_export_group/static/description/index.html
+++ b/web_disable_export_group/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Web Disable Export Group</title>
 <style type="text/css">
 
@@ -368,10 +368,8 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/web/tree/14.0/web_disable_export_group"><img alt="OCA/web" src="https://img.shields.io/badge/github-OCA%2Fweb-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/web-14-0/web-14-0-web_disable_export_group"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/162/14.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
-<p>In the standard Odoo the UI option ‘Export’ that is present in the ‘Action’ menu
-and the ‘Export All’ button of any list view is always enabled (for every user).</p>
-<p>This module makes the option ‘Export’ and ‘Export All’ enabled only for the users
-that belong to the Export Data group.</p>
+<p>The standard export group prevents both options: ‘Direct Export (xlsx)’ and ‘Export All’.</p>
+<p>This module adds a new group for the ‘Direct Export (xlsx)’ feature, leaving the standard one for only the ‘Export All’ feature.</p>
 <p>Admin user can always use the export option.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
@@ -389,12 +387,12 @@ that belong to the Export Data group.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#id1">Configuration</a></h1>
-<p>Enable the group “Export Data group” to the users who are allowed to
-make use of the option ‘Export’.</p>
+<p>Enable the group “Direct Export” to the users who are allowed to
+make use of the option ‘Export xlsx’.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>
-<p>Every user without <em>Export Data</em> permission won’t have the option available.</p>
+<p>Every user without <em>Direct Export (xlsx)</em> permission won’t have the option available.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
@@ -425,6 +423,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>David Vidal</li>
 <li>João Marques</li>
 <li>Alexandre Díaz</li>
+<li>Víctor Martínez</li>
 </ul>
 </li>
 </ul>

--- a/web_disable_export_group/static/src/js/disable_export_group.js
+++ b/web_disable_export_group/static/src/js/disable_export_group.js
@@ -1,33 +1,15 @@
 /* Copyright 2016 Onestein
    Copyright 2018 Tecnativa - David Vidal
    Copyright 2021 Tecnativa - Alexandre Díaz
+   Copyright 2022 Tecnativa - Víctor Martínez
    License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). */
-odoo.define("web_disable_export_group", function (require) {
+odoo.define("web_disable_export_group.WebDisableExportGroupController", function (
+    require
+) {
     "use strict";
 
-    const core = require("web.core");
-    const Sidebar = require("web.Sidebar");
     const session = require("web.session");
     const AbstractController = require("web.AbstractController");
-    const _t = core._t;
-
-    Sidebar.include({
-        /**
-         * @override
-         */
-        _addItems: function (sectionCode, items) {
-            let _items = items;
-            if (
-                !session.is_superuser &&
-                sectionCode === "other" &&
-                items.length &&
-                !session.group_export_data
-            ) {
-                _items = _.reject(_items, {label: _t("Export")});
-            }
-            this._super(sectionCode, _items);
-        },
-    });
 
     AbstractController.include({
         /**
@@ -37,8 +19,8 @@ odoo.define("web_disable_export_group", function (require) {
             if (
                 !session.is_superuser &&
                 action &&
-                action.startsWith("export_") &&
-                !session.group_export_data
+                action.startsWith("export_xlsx") &&
+                !session.group_xlsx_export_data
             ) {
                 return false;
             }

--- a/web_disable_export_group/static/src/js/web_disable_export_group_tour.js
+++ b/web_disable_export_group/static/src/js/web_disable_export_group_tour.js
@@ -1,16 +1,14 @@
 /* Copyright 2020 Tecnativa - João Marques
+   Copyright 2022 Tecnativa - Víctor Martínez
    License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). */
 
 odoo.define("web_disable_export_group.tour", function (require) {
     "use strict";
 
-    var core = require("web.core");
     var tour = require("web_tour.tour");
 
-    var _t = core._t;
-
     tour.register(
-        "export_tour_admin",
+        "export_tour_xlsx_button_ok",
         {
             test: true,
             url:
@@ -21,25 +19,10 @@ odoo.define("web_disable_export_group.tour", function (require) {
                 content: "Check if 'Export all' button exists",
                 trigger: ".o_list_buttons:has(.o_list_export_xlsx)",
             },
-            {
-                content: "Select all records",
-                trigger: ".custom-control-input:first",
-            },
-            {
-                content: "Open actions",
-                trigger: ".o_dropdown_toggler_btn",
-            },
-            {
-                content: "Check if Export button exists",
-                trigger:
-                    '.o_cp_action_menus ul.o_dropdown_menu a:contains("' +
-                    _t("Export") +
-                    '")',
-            },
         ]
     );
     tour.register(
-        "export_tour_demo",
+        "export_tour_xlsx_button_ko",
         {
             test: true,
             url:
@@ -49,21 +32,6 @@ odoo.define("web_disable_export_group.tour", function (require) {
             {
                 content: "Check if 'Export all' button exists",
                 trigger: ".o_list_buttons:not(:has(.o_list_export_xlsx))",
-            },
-            {
-                content: "Select all records",
-                trigger: ".custom-control-input:first",
-            },
-            {
-                content: "Open actions",
-                trigger: ".o_dropdown_toggler_btn",
-            },
-            {
-                content: "Check if Export button does not exist",
-                trigger:
-                    '.o_cp_action_menus ul.o_dropdown_menu a:first:not(:contains("' +
-                    _t("Export") +
-                    '"))',
             },
         ]
     );

--- a/web_disable_export_group/tests/test_tour.py
+++ b/web_disable_export_group/tests/test_tour.py
@@ -1,32 +1,33 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 # Copyright 2020 Tecnativa - João Marques
+# Copyright 2022 Tecnativa - Víctor Martínez
 import odoo.tests
+from odoo.tests import new_test_user
 
 
 @odoo.tests.tagged("post_install", "-at_install")
 class TestTour(odoo.tests.HttpCase):
     def setUp(self):
         super().setUp()
-        self.env["res.users"].create(
-            {
-                "name": "user_not_export",
-                "login": "user_not_export",
-                "password": "user_not_export",
-                "groups_id": [
-                    (
-                        6,
-                        0,
-                        [
-                            self.env.ref("base.group_user").id,
-                            self.env.ref("base.group_system").id,
-                        ],
-                    )
-                ],
-            }
+        new_test_user(
+            self.env,
+            login="user_not_export",
+            password="user_not_export",
+            groups="base.group_user,base.group_system",
+        )
+        new_test_user(
+            self.env,
+            login="user_export_xlsx",
+            password="user_export_xlsx",
+            groups="base.group_user,base.group_system,%s"
+            % ("web_disable_export_group.group_export_xlsx_data"),
         )
 
     def test_admin(self):
-        self.start_tour("/web", "export_tour_admin", login="admin")
+        self.start_tour("/web", "export_tour_xlsx_button_ok", login="admin")
 
     def test_user_not_export(self):
-        self.start_tour("/web", "export_tour_demo", login="user_not_export")
+        self.start_tour("/web", "export_tour_xlsx_button_ko", login="user_not_export")
+
+    def test_user_export_xlsx(self):
+        self.start_tour("/web", "export_tour_xlsx_button_ok", login="user_export_xlsx")


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/web/pull/2063

With this change, we have now two groups, one for the excel and one for the Export from Actions

Please @chienandalu and @pedrobaeza can you review it?

@Tecnativa