### PR TITLE
[FIX] web_responsive : apply same z-index value for the menu as odoo CE

### DIFF
--- a/web_responsive/static/src/css/web_responsive.scss
+++ b/web_responsive/static/src/css/web_responsive.scss
@@ -12,7 +12,7 @@ $chatter_zone_width: 35%;
     max-height: calc(100vh - #{$o-navbar-height});
     position: fixed;
     width: 100vw;
-    z-index: 100;
+    z-index: 1000;
     // Inline style will override our `top`, so we need !important here
     top: $o-navbar-height !important;
     transform: none !important;


### PR DESCRIPTION
Rational : 
- the odoo menu in the community edition has ``z-index : 1000``. see : https://github.com/odoo/odoo/blob/12.0/addons/web/static/lib/bootstrap/css/bootstrap.css#L2991
- however, the ``web_responsive`` that introduce a new pretty responsive menu has a ``z-index : 100``.

So,
- the value is not consistent
- this value conflict with some implementation. For exemple, if we try to integrate the leaflet.js (https://github.com/OCA/geospatial/pull/310) that use a lot of high z-index.

Thanks for your review.

