### PR TITLE
[15.0][FIX] web_responsive: fix records_draggable attribute

### DIFF
--- a/web_responsive/static/src/legacy/js/kanban_renderer_mobile.js
+++ b/web_responsive/static/src/legacy/js/kanban_renderer_mobile.js
@@ -94,7 +94,9 @@ odoo.define("web_responsive.KanbanRendererMobile", function (require) {
             this._super.apply(this, arguments);
             core.bus.on("UI_CONTEXT:IS_SMALL_CHANGED", this, () => {
                 this.widgets = [];
-                this.columnOptions.recordsDraggable = !config.device.isMobile;
+                this.columnOptions.recordsDraggable =
+                    !config.device.isMobile &&
+                    this.columnOptions.originRecordsDraggable;
                 this._renderView();
             });
         },
@@ -176,7 +178,10 @@ odoo.define("web_responsive.KanbanRendererMobile", function (require) {
          */
         _setState: function () {
             const res = this._super.apply(this, arguments);
-            this.columnOptions.recordsDraggable = !config.device.isMobile;
+            this.columnOptions.originRecordsDraggable =
+                this.columnOptions.recordsDraggable;
+            this.columnOptions.recordsDraggable =
+                !config.device.isMobile && this.columnOptions.recordsDraggable;
             return res;
         },
         /**


### PR DESCRIPTION
Kanban View has an attribute 'records_draggable', means 'whether it should be possible to drag records when kanban is grouped'.
It's support was broken on desktop.
This PR supersedes #2228