### PR TITLE
[13.0][IMP] web_refresher: Remove refresh button from x2Many fields.

### DIFF
--- a/web_refresher/README.rst
+++ b/web_refresher/README.rst
@@ -60,6 +60,7 @@ Contributors
 
   * João Marques
   * Alexandre D. Díaz
+  * Sergio Teruel
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_refresher/readme/CONTRIBUTORS.rst
+++ b/web_refresher/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
 
   * João Marques
   * Alexandre D. Díaz
+  * Sergio Teruel

--- a/web_refresher/static/description/index.html
+++ b/web_refresher/static/description/index.html
@@ -405,6 +405,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>João Marques</li>
 <li>Alexandre D. Díaz</li>
+<li>Sergio Teruel</li>
 </ul>
 </li>
 </ul>

--- a/web_refresher/static/src/js/refresher.js
+++ b/web_refresher/static/src/js/refresher.js
@@ -7,7 +7,6 @@ odoo.define("refresher.Refresher", function(require) {
     const AbstractController = require("web.AbstractController");
     const BasicController = require("web.BasicController");
     const ControlPanelRenderer = require("web.ControlPanelRenderer");
-    const FieldX2Many = require("web.relational_fields").FieldX2Many;
 
     const Refresher = Widget.extend({
         template: "web_refresher.Button",
@@ -61,44 +60,6 @@ odoo.define("refresher.Refresher", function(require) {
                 }
             });
             return this.refresher.appendTo($node);
-        },
-    });
-
-    FieldX2Many.include({
-        /**
-         * @override
-         */
-        _renderControlPanel: function() {
-            if (!this.view) {
-                return this._super.apply(this, arguments);
-            }
-            this.refresher = new Refresher(this);
-            this.refresher.on("pager_refresh", this, () => {
-                if (this.pager) {
-                    this.pager.trigger("pager_changed", {
-                        current_min: this.value.offset + 1,
-                        limit: this.value.limit,
-                        size: this.value.count,
-                    });
-                }
-            });
-            return this._super
-                .apply(this, arguments)
-                .then(() => {
-                    return this.refresher.appendTo($("<div>"));
-                })
-                .then(() => {
-                    this._controlPanel.updateContents(
-                        {
-                            cp_content: {
-                                $refresher: this.refresher.$el,
-                            },
-                        },
-                        {
-                            clear: false,
-                        }
-                    );
-                });
         },
     });
 

--- a/web_refresher/static/src/xml/refresher.xml
+++ b/web_refresher/static/src/xml/refresher.xml
@@ -19,9 +19,4 @@
         </t>
     </t>
 
-    <t t-extend="X2ManyControlPanel">
-        <t t-jquery=".o_x2m_control_panel nav.o_cp_pager" t-operation="before">
-            <nav class="oe_cp_refresher" />
-        </t>
-    </t>
 </template>


### PR DESCRIPTION
cc @Tecnativa

I think that with one refresh button in control panel It's enough.
If we diplay one button for every x2Many field in the view is a lot disturb information.

ping @chienandalu @carlosdauden @malvaprior