### PR TITLE
Prevent domain field evaluation from failing when: (1) the domain is …

### DIFF
--- a/web_domain_field/static/lib/js/pyeval.js
+++ b/web_domain_field/static/lib/js/pyeval.js
@@ -153,8 +153,9 @@ odoo.define('web.domain_field', function (require) {
             if (_.isString(domain)) {
                 // Modified part or the original method
                 if (domain in evaluation_context) {
-                    result_domain.push.apply(
-                        result_domain, $.parseJSON(evaluation_context[domain]));
+                    let domain_json_contents = evaluation_context[domain];
+                    let json_evaled_domain = $.parseJSON(domain_json_contents || "[]");
+                    result_domain.push.apply(result_domain, json_evaled_domain);
                     return;
                 }
                 // End of modifications


### PR DESCRIPTION
I have some code like this:
<pre>
# In Python:
class AccountPaymentOrder(models.Model):
    _inherit = "account.payment.order"
    json_allowed_journals_domain = fields.Char(related="payment_mode_id.json_allowed_journals_domain")
</pre>
<pre>
&lt;!-- In XML: --&gt;
&lt;xpath expr="//field[@name='journal_id']" position="attributes"&gt;
    &lt;attribute name="domain"&gt;json_allowed_journals_domain&lt;/attribute&gt;
&lt;/xpath&gt;
</pre>

And form loading was failing when creating a new record, because the field payment_mode_id was not yet set.

This pull request fixes this:
Prevent domain field evaluation from failing when: (1) the domain is given
by a related field and (2) the path to the target field is not yet
traversable. In this cases, reading the field from javascript code will
yield false. This fix makes the frontend assume a "[]" domain whenever the
field refered to in domain="" attribute contains a false value.
