### PR TITLE
[15.0][FIX] web_m2x_options did not work with widgets

### DIFF
--- a/web_m2x_options/models/ir_config_parameter.py
+++ b/web_m2x_options/models/ir_config_parameter.py
@@ -12,6 +12,7 @@ class IrConfigParameter(models.Model):
             "web_m2x_options.limit",
             "web_m2x_options.search_more",
             "web_m2x_options.m2o_dialog",
+            "web_m2x_options.m2o_dialog_remove_buttons",
             "web_m2x_options.field_limit_entries",
         ]
         values = self.sudo().search_read([["key", "in", opts]], ["key", "value"])

--- a/web_m2x_options/readme/CONTRIBUTORS.rst
+++ b/web_m2x_options/readme/CONTRIBUTORS.rst
@@ -12,3 +12,4 @@
   * Carlos Roca
 * Bhavesh Odedra <bodedra@opensourceintegrators.com>
 * Dhara Solanki <dhara.solanki@initos.com> (http://www.initos.com)
+* Christopher Rogos <crogos@gmail.com>

--- a/web_m2x_options/readme/USAGE.rst
+++ b/web_m2x_options/readme/USAGE.rst
@@ -61,9 +61,14 @@ If you disable one option, you can enable it for particular field by setting "cr
 
   Whether to display the many2one dialog in case of validation error for all fields in the odoo instance.
 
-``web_m2x_options.limit`` *int* (Default: openerp default value is ``7``)
+``web_m2x_options.m2o_dialog_remove_buttons`` *boolean* (Default: default value is ``False``)
 
-  Number of displayed record in drop-down panel for all fields in the odoo instance
+  Whether to display the "Create..." or "Create and Edit..." button on the many2one dialog according to
+  the ``web_m2x_options.create`` and ``web_m2x_options.create_edit`` settings.
+
+``web_m2x_options.limit`` *int* (Default: default value is ``7``)
+
+  Number of displayed record in drop-down panel for all fields in the odoo instance.
 
 ``web_m2x_options.search_more`` *boolean* (Default: default value is ``False``)
 
@@ -71,13 +76,14 @@ If you disable one option, you can enable it for particular field by setting "cr
 
 ``web_m2x_options.field_limit_entries`` *int*
 
-  Number of displayed lines on all One2many fields
+  Number of displayed lines on all One2many fields.
 
 To add these parameters go to Configuration -> Technical -> Parameters -> System Parameters and add new parameters like:
 
 - web_m2x_options.create: False
 - web_m2x_options.create_edit: False
 - web_m2x_options.m2o_dialog: False
+- web_m2x_options.m2o_dialog_remove_buttons: True
 - web_m2x_options.limit: 10
 - web_m2x_options.search_more: True
 - web_m2x_options.field_limit_entries: 5


### PR DESCRIPTION
There was a refactoring of the odoo JS code from v13->v14 which was not taken into account into the migration of the web_m2x_options.

This causes that the widget option did not work properly when web_m2x_options is installed. The red part is triggered by this widget and is missing. 
<field name="task_id" options="{'no_create_edit': True}" widget="task_with_hours"/>
![image](https://user-images.githubusercontent.com/1799080/195817214-cf25ae19-282f-42a3-9b91-1edb901067ec.png)

I've updated the search function from the [odoo/odoo](https://github.com/odoo/odoo/blob/15.0/addons/web/static/src/legacy/js/fields/relational_fields.js#L565) and refactored the implementation.

This was also an issue in the v14 of web_m2x_options so a backport might be useful when this change is merged.