### PR TITLE
[12.0][FIX] web_disable_browser_autocomplete: Qweb include path

### DIFF
--- a/web_disable_browser_autocomplete/__manifest__.py
+++ b/web_disable_browser_autocomplete/__manifest__.py
@@ -11,7 +11,7 @@
     'version': '12.0.1.0.1',
     'depends': ['web'],
     'qweb': [
-        'static/src/web/base.xml',
+        'static/src/xml/base.xml',
     ],
     'installable': True,
 }


### PR DESCRIPTION
The module tries to include qweb template from 'static/src/web', but the file is actually in 'static/src/xml'