### PR TITLE
[14.0] [IMP] ckeditor: Make todoList available

### DIFF
--- a/web_widget_ckeditor/static/src/js/field_ckeditor.js
+++ b/web_widget_ckeditor/static/src/js/field_ckeditor.js
@@ -141,7 +141,7 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
              * @override
              */
             _setValue: function (value, options) {
-                let $obj = $('<div>').html(value)
+                const $obj = $("<div>").html(value);
                 if ($obj.find("ul.todo-list").length) {
                     value = this._todoListCKEditor2Odoo($obj);
                 }
@@ -282,22 +282,30 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
              * @returns {String} the $obj converted to html
              */
             _todoListOdoo2CKEditor: function ($obj) {
-              $obj.find('ul.o_checklist').each(function(index) {
-                $(this).removeClass('o_checklist').addClass('todo-list');
-                $(this).find("li").each(function(index) {
-                  let checked = '';
-                  let text = $(this).children('p').html();
-                  if ($(this).hasClass('o_checked')) {
-                    $(this).removeClass('o_checked');
-                    checked = 'checked="checked"';
-                  };
-                  if(typeof text !== 'undefined') {
-                    $(this).prepend('<label class="todo-list__label" contenteditable="false"><input type="checkbox" tabindex="-1"' + checked + '></label><span class="todo-list__label__description">' + text + '</span>')
-                  }
-                  $(this).children('p').remove();
+                $obj.find("ul.o_checklist").each(function (index) {
+                    $(this).removeClass("o_checklist").addClass("todo-list");
+                    $(this)
+                        .find("li")
+                        .each(function (index) {
+                            let checked = "";
+                            const text = $(this).children("p").html();
+                            if ($(this).hasClass("o_checked")) {
+                                $(this).removeClass("o_checked");
+                                checked = 'checked="checked"';
+                            }
+                            if (typeof text !== "undefined") {
+                                $(this).prepend(
+                                    '<label class="todo-list__label" contenteditable="false"><input type="checkbox" tabindex="-1"' +
+                                        checked +
+                                        '></label><span class="todo-list__label__description">' +
+                                        text +
+                                        "</span>"
+                                );
+                            }
+                            $(this).children("p").remove();
+                        });
                 });
-              });
-              return $obj.html()
+                return $obj.html();
             },
             /**
              * This function converts the TodoList schema from CKEditor to Odoo.
@@ -307,21 +315,30 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
              * @returns {String} the $obj converted to html
              */
             _todoListCKEditor2Odoo: function ($obj) {
-              $obj.find('ul.todo-list').each(function(index) {
-                $(this).removeClass('todo-list').addClass('o_checklist');
-                $(this).find("li").each(function(index) {
-                  let text = $(this).children('.todo-list__label').children('.todo-list__label__description').html();
-                  if ($(this).children('label').find('input[checked="checked"]').length) {
-                    $(this).addClass('o_checked');
-                  };
-                  if(typeof text !== 'undefined') {
-                    $(this).prepend('<p>' + text + '</p>')
-                  }
-                  $(this).children('.todo-list__label').remove();
-                  $(this).children('.todo-list__label__description').remove();
+                $obj.find("ul.todo-list").each(function (index) {
+                    $(this).removeClass("todo-list").addClass("o_checklist");
+                    $(this)
+                        .find("li")
+                        .each(function (index) {
+                            const text = $(this)
+                                .children(".todo-list__label")
+                                .children(".todo-list__label__description")
+                                .html();
+                            if (
+                                $(this)
+                                    .children("label")
+                                    .find('input[checked="checked"]').length
+                            ) {
+                                $(this).addClass("o_checked");
+                            }
+                            if (typeof text !== "undefined") {
+                                $(this).prepend("<p>" + text + "</p>");
+                            }
+                            $(this).children(".todo-list__label").remove();
+                            $(this).children(".todo-list__label__description").remove();
+                        });
                 });
-              });
-              return $obj.html()
+                return $obj.html();
             },
             /**
              * This function is similar to the one found in core's web_editor.FieldHtml.
@@ -332,7 +349,7 @@ odoo.define("web_widget_ckeditor.field_ckeditor", function (require) {
              */
             _textToHtml: function (text) {
                 let value = text || "";
-                let $obj = $('<div>').html(value)
+                const $obj = $("<div>").html(value);
                 if ($obj.find("ul.o_checklist").length) {
                     value = this._todoListOdoo2CKEditor($obj);
                 }

--- a/web_widget_ckeditor/static/src/scss/web_widget_ckeditor.scss
+++ b/web_widget_ckeditor/static/src/scss/web_widget_ckeditor.scss
@@ -6,6 +6,10 @@
 
 .o_field_widget {
     &.oe_form_field_html_ckeditor {
+        :root {
+            --ck-todo-list-checkmark-size: 16px;
+        }
+
         .ck-editor__editable {
             min-height: 330px;
         }
@@ -18,6 +22,65 @@
                     will-change: auto;
                 }
             }
+        }
+
+        .todo-list {
+            list-style: none;
+        }
+        .todo-list li {
+            margin-bottom: 5px;
+        }
+        .todo-list li .todo-list {
+            margin-top: 5px;
+        }
+        .todo-list .todo-list__label > input {
+            -webkit-appearance: none;
+            display: inline-block;
+            position: relative;
+            width: var(--ck-todo-list-checkmark-size);
+            height: var(--ck-todo-list-checkmark-size);
+            vertical-align: middle;
+            border: 0;
+            left: -25px;
+            margin-right: -15px;
+            right: 0;
+            margin-left: 0;
+        }
+        .todo-list .todo-list__label > input::before {
+            display: block;
+            position: absolute;
+            box-sizing: border-box;
+            content: '';
+            width: 100%;
+            height: 100%;
+            border: 1px solid hsl(0, 0%, 20%);
+            border-radius: 2px;
+            transition: 250ms ease-in-out box-shadow, 250ms ease-in-out background, 250ms ease-in-out border;
+        }
+        .todo-list .todo-list__label > input::after {
+            display: block;
+            position: absolute;
+            box-sizing: content-box;
+            pointer-events: none;
+            content: '';
+            left: calc( var(--ck-todo-list-checkmark-size) / 3 );
+            top: calc( var(--ck-todo-list-checkmark-size) / 5.3 );
+            width: calc( var(--ck-todo-list-checkmark-size) / 5.3 );
+            height: calc( var(--ck-todo-list-checkmark-size) / 2.6 );
+            border-style: solid;
+            border-color: transparent;
+            border-width: 0 calc( var(--ck-todo-list-checkmark-size) / 8 ) calc( var(--ck-todo-list-checkmark-size) / 8 ) 0;
+            transform: rotate(45deg);
+        }
+        .todo-list .todo-list__label > input[checked]::before {
+            background: hsl(126, 64%, 41%);
+            border-color: hsl(126, 64%, 41%);
+        }
+        .todo-list .todo-list__label > input[checked]::after {
+            border-color: hsl(0, 0%, 100%);
+        }
+        .todo-list .todo-list__label .todo-list__label__description {
+            vertical-align: middle;
         }
     }
 }

--- a/web_widget_ckeditor/static/src/scss/web_widget_ckeditor.scss
+++ b/web_widget_ckeditor/static/src/scss/web_widget_ckeditor.scss
@@ -50,36 +50,38 @@
             display: block;
             position: absolute;
             box-sizing: border-box;
-            content: '';
+            content: "";
             width: 100%;
             height: 100%;
             border: 1px solid hsl(0, 0%, 20%);
             border-radius: 2px;
-            transition: 250ms ease-in-out box-shadow, 250ms ease-in-out background, 250ms ease-in-out border;
+            transition: 250ms ease-in-out box-shadow, 250ms ease-in-out background,
+                250ms ease-in-out border;
         }
         .todo-list .todo-list__label > input::after {
             display: block;
             position: absolute;
             box-sizing: content-box;
             pointer-events: none;
-            content: '';
-            left: calc( var(--ck-todo-list-checkmark-size) / 3 );
-            top: calc( var(--ck-todo-list-checkmark-size) / 5.3 );
-            width: calc( var(--ck-todo-list-checkmark-size) / 5.3 );
-            height: calc( var(--ck-todo-list-checkmark-size) / 2.6 );
+            content: "";
+            left: calc(var(--ck-todo-list-checkmark-size) / 3);
+            top: calc(var(--ck-todo-list-checkmark-size) / 5.3);
+            width: calc(var(--ck-todo-list-checkmark-size) / 5.3);
+            height: calc(var(--ck-todo-list-checkmark-size) / 2.6);
             border-style: solid;
             border-color: transparent;
-            border-width: 0 calc( var(--ck-todo-list-checkmark-size) / 8 ) calc( var(--ck-todo-list-checkmark-size) / 8 ) 0;
+            border-width: 0 calc(var(--ck-todo-list-checkmark-size) / 8)
+                calc(var(--ck-todo-list-checkmark-size) / 8) 0;
             transform: rotate(45deg);
         }
         .todo-list .todo-list__label > input[checked]::before {
-            background: hsl(126, 64%, 41%);
-            border-color: hsl(126, 64%, 41%);
+            background: hsl(0, 0%, 30%);
+            border-color: hsl(0, 0%, 15%);
         }
         .todo-list .todo-list__label > input[checked]::after {
             border-color: hsl(0, 0%, 100%);
         }
-        .todo-list .todo-list__label .todo-list__label__description {
+        .todo-list .todo-list__label__description {
             vertical-align: middle;
         }
     }


### PR DESCRIPTION
This PR adds a converter for TodoList. 

The default schema for TodoLists from CKEditor is not supported by Odoo, cause <input> elements get stripped away.

My PR adds functions to convert the TODOList schema back and forwards (Odoo <-> CKEditor). By default this PR saves Odoo's schema to the database and converts it back to the CKEditor schema for the frontend. This allows to keep TODOList working, even if someone switches back to Odoo's default editor.

What is not working: With Odoo's editor it was possible to check boxes in ReadOnlyView. This is not implemented by me and also not really needed in my case.