### PR TITLE
[OU] web_disable_export_group: Fix when migration happened on 13.0

### DIFF
--- a/web_disable_export_group/migrations/14.0.1.1.0/pre-migration.py
+++ b/web_disable_export_group/migrations/14.0.1.1.0/pre-migration.py
@@ -3,12 +3,14 @@ from openupgradelib import openupgrade
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.rename_xmlids(
-        env.cr,
-        [
-            (
-                "web_disable_export_group.group_export_data",
-                "web_disable_export_group.group_export_xlsx_data",
-            )
-        ],
-    )
+    # Otherwise, the migration already happened on 13.0
+    if not env.ref("web_disable_export_group.group_export_xlsx_data", False):
+        openupgrade.rename_xmlids(
+            env.cr,
+            [
+                (
+                    "web_disable_export_group.group_export_data",
+                    "web_disable_export_group.group_export_xlsx_data",
+                )
+            ],
+        )


### PR DESCRIPTION
ON 13 the field is created, so this should only happen when migrating from an old version...