### PR TITLE
[15.0][FIX] web_tree_image_tooltip: Set the correct image field in demo data.

### DIFF
--- a/web_tree_image_tooltip/demo/view_res_users.xml
+++ b/web_tree_image_tooltip/demo/view_res_users.xml
@@ -6,8 +6,8 @@
         <field name="arch" type="xml">
             <field name="name" position="before">
                 <field
-                    name="image_small"
-                    options="{'tooltip_image': 'image'}"
+                    name="image_128"
+                    options="{'tooltip_image': 'image_1920'}"
                     widget="image"
                     string="Image"
                 />


### PR DESCRIPTION
Set the correct image field in demo data.

@Tecnativa