### PR TITLE
[14.0][FIX]support_branding: change support_company name

### DIFF
--- a/support_branding/models/res_config_settings.py
+++ b/support_branding/models/res_config_settings.py
@@ -29,7 +29,7 @@ class ResConfigSettings(models.TransientModel):
         param_obj.set_param("support_branding_color", self.support_branding_color)
         return res
 
-    support_company = fields.Char(string="Company Name")
+    support_company = fields.Char(string="Support Company Name")
     support_company_url = fields.Char(string="Company URL")
     support_branding_color = fields.Char(string="Branding color")
     support_email = fields.Char(string="Support email")


### PR DESCRIPTION
I changed the string value of `support_company` because of the following warning

```
WARNING devel odoo.addons.base.models.ir_model: Two fields (support_company, company_name) of res.config.settings() have the same label: Company Name.
```