### PR TITLE
[FIX] web_timeline group_bys default array if undefined

### DIFF
--- a/web_timeline/static/src/js/timeline_controller.js
+++ b/web_timeline/static/src/js/timeline_controller.js
@@ -49,7 +49,7 @@ odoo.define("web_timeline.TimelineController", function (require) {
             this.last_domains = domains;
             this.last_contexts = contexts;
             // Select the group by
-            let n_group_bys = group_bys;
+            let n_group_bys = group_bys || [];
             if (!n_group_bys.length && this.renderer.arch.attrs.default_group_by) {
                 n_group_bys = this.renderer.arch.attrs.default_group_by.split(",");
             }


### PR DESCRIPTION
So there is a bug when you open a timeline record then go back to the timeline view, the **n_group_bys** is undefined and pops up an error. So I added a default definition of empty array if the timeline's **n_group_bys** is undefined. @pedrobaeza @thomaspaulb 