### PR TITLE
[FIX] drag_drop element cannot be seen, if check for undefined value

### DIFF
--- a/web_drop_target/static/src/js/web_drop_target.js
+++ b/web_drop_target/static/src/js/web_drop_target.js
@@ -151,18 +151,9 @@ odoo.define("web_drop_target", function (require) {
          * @private
          * @param {MouseEvent} ev
          */
-        _onBodyFileDragover: function (ev) {
+        _onBodyFileDragover: function(ev) {
             ev.preventDefault();
-            const actionManager = this.findAncestor(function (ancestor) {
-                return ancestor instanceof ActionManager;
-            });
-            const controller = actionManager.currentDialogController;
-            if (
-                _.isEmpty(this._get_drop_items(ev)) &&
-                this._checkDragOver() &&
-                (controller === undefined ||
-                    (controller && controller.jsID === this.controllerID))
-            ) {
+            if (_.isEmpty(this._get_drop_items(ev)) && this._checkDragOver()) {
                 const drop_zone_offset = this.$drop_zone.offset();
                 const overlay_css = {
                     top: drop_zone_offset.top,
@@ -173,8 +164,11 @@ odoo.define("web_drop_target", function (require) {
                 if (!this._get_record_id()) {
                     overlay_css.background = "#FF000020";
                 }
-                this._drop_overlay.css(overlay_css);
-                this._drop_overlay.removeClass("d-none");
+                if (this._drop_overlay) {
+                    this._drop_overlay.css(overlay_css);
+                    this._drop_overlay.removeClass("d-none");
+                }
+
             }
         },
 
@@ -186,9 +180,10 @@ odoo.define("web_drop_target", function (require) {
          * @private
          * @param {MouseEvent} ev
          */
-        _onBodyFileDrop: function (ev) {
+        _onBodyFileDrop: function(ev) {
             ev.preventDefault();
-            this._drop_overlay.addClass("d-none");
+            if (this._drop_overlay)
+                this._drop_overlay.addClass("d-none");
         },
 
         /**

--- a/web_drop_target/static/src/js/web_drop_target.js
+++ b/web_drop_target/static/src/js/web_drop_target.js
@@ -5,7 +5,6 @@
 
 odoo.define("web_drop_target", function (require) {
     "use strict";
-    const ActionManager = require("web.ActionManager");
     const FormController = require("web.FormController");
     const core = require("web.core");
     const qweb = core.qweb;
@@ -151,7 +150,7 @@ odoo.define("web_drop_target", function (require) {
          * @private
          * @param {MouseEvent} ev
          */
-        _onBodyFileDragover: function(ev) {
+        _onBodyFileDragover: function (ev) {
             ev.preventDefault();
             if (_.isEmpty(this._get_drop_items(ev)) && this._checkDragOver()) {
                 const drop_zone_offset = this.$drop_zone.offset();
@@ -168,7 +167,6 @@ odoo.define("web_drop_target", function (require) {
                     this._drop_overlay.css(overlay_css);
                     this._drop_overlay.removeClass("d-none");
                 }
-
             }
         },
 
@@ -180,10 +178,9 @@ odoo.define("web_drop_target", function (require) {
          * @private
          * @param {MouseEvent} ev
          */
-        _onBodyFileDrop: function(ev) {
+        _onBodyFileDrop: function (ev) {
             ev.preventDefault();
-            if (this._drop_overlay)
-                this._drop_overlay.addClass("d-none");
+            if (this._drop_overlay) this._drop_overlay.addClass("d-none");
         },
 
         /**


### PR DESCRIPTION
There was a merge fix [PR](https://github.com/OCA/web/pull/2299) it lead to an issue where the drag drop panel could not be accessed any more. I did a fix here things are back to normal, I couldn't regenerate the controller issue, in case anyone finds it let me know what you did to get it, but for now the module works well unless anything pops up. @tarteo @pedrobaeza another bug which I found and hopefully fixed.