### PR TITLE
[FIX] web_environment_ribbon: Adding the class="hidden" causes conflicts.

### DIFF
--- a/web_environment_ribbon/static/src/js/ribbon.js
+++ b/web_environment_ribbon/static/src/js/ribbon.js
@@ -34,7 +34,7 @@ odoo.define("web_environment_ribbon.ribbon", function (require) {
     }
 
     core.bus.on("web_client_ready", null, function () {
-        var ribbon = $('<div class="test-ribbon hidden"/>');
+        var ribbon = $('<div class="test-ribbon"/>');
         $("body").append(ribbon);
         ribbon.hide();
         // Get ribbon data from backend


### PR DESCRIPTION
Adding the class="hidden" to the ribbon can cause conflicts with other modules that define the same CSS class. Furthermore, it is unnecessary here, as we call `ribbon.hide()` just a few lines below.

In our case, the class "hidden" caused the jQuery `ribbon.show()` method not to reveal the ribbon even though the name is set in the system parameters. 

I have tested the fix and can confirm that removing the `hidden` class does not affect the functionality at all. Even with this fix, the ribbon is **not** visible with `self.env["ir.config_parameter"].sudo().get_param("ribbon.name") in ['', 'False']`.