### PR TITLE
[15.0][FIX] web_responsive: only change width of main control panel

### DIFF
--- a/web_responsive/static/src/components/control_panel/control_panel.scss
+++ b/web_responsive/static/src/components/control_panel/control_panel.scss
@@ -19,12 +19,12 @@
     }
     // For FULL HD devices
     @media (min-width: 1900px) {
-        .o_cp_top_left,
-        .o_cp_bottom_left {
+        .o_action_manager & .o_cp_top_left,
+        .o_action_manager & .o_cp_bottom_left {
             width: 60%;
         }
-        .o_cp_top_right,
-        .o_cp_bottom_right {
+        .o_action_manager & .o_cp_top_right,
+        .o_action_manager & .o_cp_bottom_right {
             width: 40%;
         }
     }


### PR DESCRIPTION
The Search More panel is incorrectly displayed due to the reduced screen so only change width on the main screen.

Fixes #2395