### PR TITLE
[FIX] web_m2x_options: M2Dialog not working properly

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -38,13 +38,13 @@ odoo.define("web_m2x_options.web_m2x_options", function (require) {
                         text: _t("Create"),
                         classes: "btn-primary",
                         click: function () {
-                            if (this.$("input").val()) {
+                            if (this.value) {
                                 this.trigger_up("quick_create", {
-                                    value: this.$("input").val(),
+                                    value: this.value,
                                 });
                                 this.close(true);
                             } else {
-                                this.$("input").focus();
+                                parent.$("input").focus();
                             }
                         },
                     },
@@ -55,7 +55,7 @@ odoo.define("web_m2x_options.web_m2x_options", function (require) {
                         click: function () {
                             this.trigger_up("search_create_popup", {
                                 view_type: "form",
-                                value: this.$("input").val(),
+                                value: this.value,
                             });
                         },
                     },


### PR DESCRIPTION
When opening the M2Dialog, the value was not propagated,

As you can see in the example, the value is `MY LOT NAME` but it is not inherited.
![Peek 2023-02-16 12-39](https://user-images.githubusercontent.com/112381711/219355646-ce316e7e-183a-4adf-aab0-100e66d3a8bf.gif)

This change fixes the bug
