### PR TITLE
[14.0][IMP] web_ir_actions_act_view_reload: add missing model

### DIFF
--- a/web_ir_actions_act_view_reload/__init__.py
+++ b/web_ir_actions_act_view_reload/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/web_ir_actions_act_view_reload/models/__init__.py
+++ b/web_ir_actions_act_view_reload/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_act_view_reload

--- a/web_ir_actions_act_view_reload/models/ir_actions_act_view_reload.py
+++ b/web_ir_actions_act_view_reload/models/ir_actions_act_view_reload.py
@@ -1,0 +1,7 @@
+from odoo import models
+
+
+class IrActionsActViewReload(models.Model):
+    _name = "ir.actions.act_view_reload"
+    _inherit = "ir.actions.actions"
+    _description = "View Reload"


### PR DESCRIPTION
When adding the type on an action, an error was raised. With this change, it should work again.

Ported the change from 15.0, not cherry-picked, as other changes were not necessary

@etobella 