### PR TITLE
[14.0][FIX] web_widget_open_tab: Use `isDebug()` to render the template properly

### DIFF
--- a/web_widget_open_tab/static/src/js/widget.js
+++ b/web_widget_open_tab/static/src/js/widget.js
@@ -43,7 +43,7 @@ odoo.define("web_widget_open_tab.FieldOpenTab", function (require) {
                 delay: {show: 1000, hide: 0},
                 title: function () {
                     return qweb.render("WidgetButton.tooltip", {
-                        debug: config.debug,
+                        debug: config.isDebug(),
                         state: self.record,
                         node: {
                             attrs: {


### PR DESCRIPTION
Since odoo 13.0, the debug state is got from this function instead of `require('web.config').debug`