### PR TITLE
[14.0][FIX] fix white-space display in markdown widget

### DIFF
--- a/web_widget_text_markdown/static/src/css/web_widget_text_markdown.css
+++ b/web_widget_text_markdown/static/src/css/web_widget_text_markdown.css
@@ -5,3 +5,7 @@
     padding: 1em 10px 0.1em 10px;
     quotes: "\201C""\201D""\2018""\2019";
 }
+
+.o_field_text.o_field_text_markdown {
+    white-space: inherit;
+}


### PR DESCRIPTION
add css rule to override the default white-space declaration for text fields (pre-wrap) to ensure the html generated from markdown is correctly displayed.