### PR TITLE
[FIX][12.0] web_tree_dynamic_colored_field : return first color that match with valid expression.

### DIFF
--- a/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
+++ b/web_tree_dynamic_colored_field/static/src/js/web_tree_dynamic_colored_field.js
@@ -96,6 +96,7 @@ odoo.define('web_tree_dynamic_colored_field', function (require) {
                         expression = pair[1];
                     if (py.evaluate(expression, ctx).toJSON()) {
                         $td.css(cssAttribute, color);
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
trivial patch.

For the time being, if there are many key / value (color / expression) all the colors corresponding to valid expressions will be set. So the last color will be put. 

**Without that patch** : ``{'bg_color': 'red: True; green: True;'}`` will return 'green'
**With that patch** : ``{'bg_color': 'red: True; green: True;'}`` will return 'red'

CC : @amh-mw as you migrated the module in V15 recently here https://github.com/OCA/web/pull/2145
CC : @damdam-s : original author