### PR TITLE
[15.0][UPD] web_ir_actions_act_view_reload: Added ACL to avoid Odoo warning

### DIFF
--- a/web_ir_actions_act_view_reload/__manifest__.py
+++ b/web_ir_actions_act_view_reload/__manifest__.py
@@ -18,4 +18,7 @@
             "web_ir_actions_act_view_reload/static/src/**/*.esm.js",
         ],
     },
+    "data": [
+        "security/ir.model.access.csv",
+    ],
 }

--- a/web_ir_actions_act_view_reload/security/ir.model.access.csv
+++ b/web_ir_actions_act_view_reload/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_ir_actions_act_view_reload_system","ir_actions_act_view_reload_system","web_ir_actions_act_view_reload.model_ir_actions_act_view_reload","base.group_system",1,1,1,1


### PR DESCRIPTION
Added ir.model.access.csv with an access rule to avoid Odoo's warning when models does not have an ACL