### PR TITLE
[14.0][FIX] web_ir_action_act_*: add/fix access rights

### DIFF
--- a/web_ir_actions_act_multi/security/ir.model.access.csv
+++ b/web_ir_actions_act_multi/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-crud_ir_actions_act_multi,access_ir_actions_act_multi,model_ir_actions_act_multi,,1,1,1,1
+crud_ir_actions_act_multi,access_ir_actions_act_multi,model_ir_actions_act_multi,base.group_system,1,1,1,1

--- a/web_ir_actions_act_view_reload/__manifest__.py
+++ b/web_ir_actions_act_view_reload/__manifest__.py
@@ -12,6 +12,9 @@
     "author": "Modoolar, CorporateHub, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",
     "depends": ["web"],
-    "data": ["views/web_ir_actions_act_view_reload.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/web_ir_actions_act_view_reload.xml",
+    ],
     "installable": True,
 }

--- a/web_ir_actions_act_view_reload/security/ir.model.access.csv
+++ b/web_ir_actions_act_view_reload/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+crud_ir_actions_act_view_reload,access_ir_actions_act_wiew_reload,model_ir_actions_act_view_reload,base.group_system,1,1,1,1

--- a/web_ir_actions_act_window_message/security/ir.model.access.csv
+++ b/web_ir_actions_act_window_message/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-crud_ir_actions_act_window_message,access_ir_actions_act_window_message,model_ir_actions_act_window_message,,1,1,1,1
+crud_ir_actions_act_window_message,access_ir_actions_act_window_message,model_ir_actions_act_window_message,base.group_system,1,1,1,1


### PR DESCRIPTION
Squashes the warning

```
odoo.modules.loading: The model ir.actions.act_view_reload has no access rules, consider adding one. E.g. access_ir_actions_act_view_reload,access_ir_actions_act_view_reload,model_ir_actions_act_view_reload,base.group_user,1,0,0,0
```