### PR TITLE
[FIX] NOBUMP. web_dashboard_tile : reduce duration to display tiles of a category

### DIFF
--- a/web_dashboard_tile/__manifest__.py
+++ b/web_dashboard_tile/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Overview Dashboard (Tiles)",
     "summary": "Add Overview Dashboards with Tiles",
-    "version": "12.0.1.0.2",
+    "version": "12.0.2.0.0",
     "depends": ["web", "board", "mail", "web_widget_color"],
     "author": "initOS GmbH & Co. KG, "
     "GRAP, "

--- a/web_dashboard_tile/migrations/12.0.2.0.0/post-migration.py
+++ b/web_dashboard_tile/migrations/12.0.2.0.0/post-migration.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2023-Today: GTRAP (<http://www.grap.coop/>)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+import odoo
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    with odoo.api.Environment.manage():
+        env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+
+        for category in env["tile.category"].search([]):
+            _logger.info(
+                "Rewrite domain and context for the action"
+                " related to the tile category %s" % category.name
+            )
+            vals = category._prepare_action()
+            category.action_id.write({
+                "domain": vals["domain"],
+                "context": vals["context"],
+            })

--- a/web_dashboard_tile/migrations/post-migration.py
+++ b/web_dashboard_tile/migrations/post-migration.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2023-Today: GRAP (<http://www.grap.coop/>)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
+from openupgradelib import openupgrade
+
+logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    cr = env.cr
+
+    if openupgrade.table_exists(cr, "pos_config") and openupgrade.column_exists(
+        cr, "pos_config", "minimum_wallet_amount"
+    ):
+        cr.execute(
+            """
+            SELECT aj.id, min(pc.minimum_wallet_amount)
+            FROM account_journal aj
+            INNER JOIN pos_config_journal_rel ajpc_rel
+                ON ajpc_rel.journal_id = aj.id
+            INNER JOIN pos_config pc
+                ON pc.id = ajpc_rel.pos_config_id
+            WHERE aj.is_customer_wallet_journal group by aj.id;
+        """
+        )
+        for (journal_id, minimum_wallet_amount) in cr.fetchall():
+            if minimum_wallet_amount:
+                journal = env["account.journal"].browse(journal_id)
+                logger.info(
+                    "Initialize minimum_wallet_amount to %s for journal %s (company %s)"
+                    % (minimum_wallet_amount, journal.name, journal.company_id.name)
+                )
+                journal.minimum_wallet_amount = minimum_wallet_amount

--- a/web_dashboard_tile/models/tile_category.py
+++ b/web_dashboard_tile/models/tile_category.py
@@ -40,13 +40,16 @@ class TileCategory(models.Model):
 
     def _prepare_action(self):
         self.ensure_one()
+        # Do not write domain [('hidden', '=', False)]
+        # to avoid to call _compute_data on all tiles
+        # see tile_tile.search()
         return {
             'name': self.name,
             'res_model': 'tile.tile',
             'type': 'ir.actions.act_window',
             'view_mode': 'kanban',
+            'context': "{'no_hidden_tiles': True}",
             'domain': """[
-                ('hidden', '=', False),
                 '|', ('user_id', '=', False), ('user_id', '=', uid),
                 ('category_id', '=', {self.id})
             ]""".format(self=self),

--- a/web_dashboard_tile/models/tile_tile.py
+++ b/web_dashboard_tile/models/tile_tile.py
@@ -185,6 +185,13 @@ class TileTile(models.Model):
 
     error = fields.Char(string="Error Details", compute="_compute_data")
 
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        res = super().search(args, offset=offset, limit=limit, order=order, count=count)
+        if self.env.context.get("no_hidden_tiles", False):
+            # late research on the hidden field.
+            return res.filtered(lambda x: not x.hidden)
+        return res
+
     # Compute Section
     @api.depends("primary_format", "secondary_format", "model_id", "domain")
     def _compute_data(self):


### PR DESCRIPTION
Rational : 
previous improvment introduced a regression due to the domain [('hidden', '=', False)] because it call the _compute_data for all the tiles, even if we want to display the tiles of a single category.

Note : this PR includes a migration script. please use nobump when calling ``ocabot merge``