### PR TITLE
[15.0] [FIX] `web_advanced_search`: Exception raised with "Search more..."

### DIFF
--- a/web_advanced_search/static/src/js/RecordPicker.esm.js
+++ b/web_advanced_search/static/src/js/RecordPicker.esm.js
@@ -17,7 +17,7 @@ export const FakeMany2oneFieldWidget = FieldMany2One.extend(FieldManagerMixin, {
         this.componentAdapter = parent;
         const options = this.componentAdapter.props.attrs;
         // Create a dummy record with only a dummy m2o field to search on
-        const model = new BasicModel("dummy");
+        const model = new BasicModel(this.componentAdapter);
         const params = {
             fieldNames: ["dummy"],
             modelName: "dummy",
@@ -63,9 +63,11 @@ export const FakeMany2oneFieldWidget = FieldMany2One.extend(FieldManagerMixin, {
      * @override
      */
     _confirmChange: function (id, fields, event) {
-        this.componentAdapter.trigger("change", event.data.changes[fields[0]]);
+        const res = FieldManagerMixin._confirmChange.apply(this, arguments);
         this.dataPointID = id;
-        return this.reset(this._get_record(this.model), event);
+        this.reset(this._get_record(this.model), event);
+        this.componentAdapter.trigger("change", this.value.data);
+        return res;
     },
     /**
      * Stop propagation of the autocompleteselect event.


### PR DESCRIPTION

https://user-images.githubusercontent.com/1914185/232817651-5c3f45e6-6263-430e-9afb-9ec41ed24953.mp4


**Steps to reproduce:**

1. Go to Contacts (for example).
2. Filters > Add Custom Filter.
3. Select "Company" field.
4. Select "is equal to" operator.
5. Click on "Search more..." button.
6. Select a record.


**Result:**

An exception is raised

```
UncaughtPromiseError > TypeError
Uncaught Promise > parent._trigger_up is not a function
```

**Expected:**

It should open the search more dialog, and let the user select a record.