### PR TITLE
[16.0] [IMP] web theme classic

### DIFF
--- a/web_theme_classic/static/src/scss/web_theme_classic.scss
+++ b/web_theme_classic/static/src/scss/web_theme_classic.scss
@@ -90,3 +90,13 @@ div.o_searchview_facet[role="img"] {
 i.o_searchview_icon[role="img"] {
     padding-right: 2px;
 }
+
+/***********************************************************
+        Tree View : Handle style for required fields
+************************************************************/
+.o_list_renderer
+    .o_data_row.o_selected_row
+    > .o_data_cell.o_required_modifier:not(.o_readonly_modifier) {
+    /* Disable border bottom as the field has now a background */
+    border-bottom: 0px solid;
+}

--- a/web_theme_classic/static/src/scss/web_theme_classic.scss
+++ b/web_theme_classic/static/src/scss/web_theme_classic.scss
@@ -51,7 +51,7 @@ $button-border-color: #dee2e6;
         Form View : Handle Background for required fields
 ************************************************************/
 
-.o_required_modifier {
+.o_required_modifier:not(.o_readonly_modifier) {
     .o_input {
         /* Add background for all editable and required fields */
         background-color: $input-background-color-required !important;
@@ -63,7 +63,7 @@ $button-border-color: #dee2e6;
     }
 }
 
-.o_required_modifier.o_field_selection {
+.o_required_modifier.o_field_selection:not(.o_readonly_modifier) {
     /* Specific case for field selection */
     background-color: $input-background-color-required !important;
 }


### PR DESCRIPTION
Two simple patches : 
-  Do not display required color on readonly fields
- Do not set border-bottom to required field as the field has now a background-color

### Before

![image](https://user-images.githubusercontent.com/3407482/232826327-45edba83-0153-487e-9545-9cf66eebd9e1.png)


### After

![image](https://user-images.githubusercontent.com/3407482/232826079-ebf0a0ce-201e-4afb-9a30-eb37792dc5de.png)


CC : @pierrickbrun