### PR TITLE
[15.0][FIX] web_pivot_computed_measure: Error when using filter created with favorites

### DIFF
--- a/web_pivot_computed_measure/static/src/pivot/pivot_view.esm.js
+++ b/web_pivot_computed_measure/static/src/pivot/pivot_view.esm.js
@@ -1,0 +1,20 @@
+/** @odoo-module **/
+/* Copyright 2022 Tecnativa - Carlos Roca
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html) */
+
+import {PivotView} from "@web/views/pivot/pivot_view";
+import {patch} from "web.utils";
+
+patch(PivotView.prototype, "web_pivot_computed_measure.PivotView", {
+    /**
+     * Add computed_measures to context key to avoid loosing info when saving the
+     * filter to favorites.
+     *
+     * @override
+     */
+    getContext() {
+        var res = this._super(...arguments);
+        res.pivot_computed_measures = this.model._computed_measures;
+        return res;
+    },
+});


### PR DESCRIPTION
Before this changes, when trying to select a user filter that includes a computed measurement, an error was thrown as it did not know where to retrieve the previously computed measurement from.

With the applied changes we are saving the computed measurements in the context. This way we can retrieve the filter when loading it.

cc @Tecnativa TT43005

ping @sergio-teruel @chienandalu 