### PR TITLE
[15.0][IMP] web_time_range_menu_custom: Dates include today but other granularities not

### DIFF
--- a/web_time_range_menu_custom/static/src/js/dates.esm.js
+++ b/web_time_range_menu_custom/static/src/js/dates.esm.js
@@ -137,13 +137,25 @@ patch(dates, "patch dates", {
             setParam.month = dates.QUARTERS[setParam.quarter].coveredMonths[0];
             delete setParam.quarter;
         }
-        const plusParamReferenceMoment = referenceMoment.plus(plusParam || {});
         const date = referenceMoment.set(setParam).plus(plusParam || {});
         // Compute domain
-        const leftDate = date.startOf(granularity);
+        var leftDate = date.startOf(granularity);
         var rightDate = date.endOf(granularity);
-        if (custom_period.is_custom_period) {
-            rightDate = plusParamReferenceMoment;
+        if (
+            custom_period.is_custom_period &&
+            parseInt(custom_period.last_period) !== 0
+        ) {
+            if (granularity === "day") {
+                const plusParamReferenceMoment = referenceMoment.plus(plusParam || {});
+                leftDate = leftDate.plus({days: 1});
+                rightDate = plusParamReferenceMoment;
+            } else {
+                var customPlusParam = {};
+                customPlusParam[granularity + "s"] = parseInt(
+                    custom_period.last_period
+                );
+                rightDate = leftDate.plus(customPlusParam);
+            }
         }
         let leftBound;
         let rightBound;


### PR DESCRIPTION
Before this changes, when a custom range filter was added, it included dates from the beginning of the period indicated to the present day.

By applying these changes, this will only happen for granularity "Day" and in the other cases only the indicated period will be displayed.

Example as of 11 May: 
    Last 7 days -> 5th of May - 11th of May
    Last 2 months -> 1st of March - 30th of April

cc @Tecnativa TT43091

ping @carlosdauden @sergio-teruel 