### PR TITLE
[16.0][FIX] web_domain_field: if you have a domain saved in a binary variable, parsing that text will fail.

### DIFF
--- a/web_domain_field/readme/DESCRIPTION.rst
+++ b/web_domain_field/readme/DESCRIPTION.rst
@@ -1,3 +1,8 @@
+.. warning::
+    This module is deprecated.
+    If you want to use this functionality you can assign a unserialised
+    domain to a fields.Binary, `example <https://github.com/OCA/OCB/blob/16.0/addons/account/models/account_tax.py#L1308>`_
+
 This technical addon allows developers to specify a field domain in a view
 using the value of another field in that view, rather than as a static
 XML attribute.

--- a/web_domain_field/static/lib/js/pyeval.js
+++ b/web_domain_field/static/lib/js/pyeval.js
@@ -153,9 +153,17 @@ odoo.define('web.domain_field', function (require) {
             if (_.isString(domain)) {
                 // Modified part or the original method
                 if (domain in evaluation_context) {
-                    result_domain.push.apply(
-                        result_domain, $.parseJSON(evaluation_context[domain]));
-                    return;
+                    var fail_parse_domain = false;
+                    try {
+                        var domain_parse = $.parseJSON(evaluation_context[domain]);
+                        console.warn("`web_domain_field is deprecated. If you want to use this functionality you can assign a unserialised domain to a fields.Binary");
+                    } catch (e) {
+                        fail_parse_domain = true;
+                    }
+                    if (!fail_parse_domain) {
+                        result_domain.push.apply(result_domain, domain_parse);
+                        return;
+                    }
                 }
                 // End of modifications
 


### PR DESCRIPTION
If you have a domain saved in a binary variable, parsing that text will fail.

https://github.com/OCA/web/assets/6359121/a6cb04e2-acbe-4a80-99f8-eb5a14e51678

You can see the example of this field https://github.com/OCA/OCB/blob/16.0/addons/account/models/account_tax.py#L1308
