### PR TITLE
[16.0] [FIX] web_advanced_search - Prevent closure dropdown

### DIFF
--- a/web_advanced_search/static/src/js/RecordPicker.esm.js
+++ b/web_advanced_search/static/src/js/RecordPicker.esm.js
@@ -15,12 +15,16 @@ patch(Dropdown.prototype, "dropdown", {
     onWindowClicked(ev) {
         // This patch is created to prevent the closing of the Filter menu
         // when a selection is made in the RecordPicker
-        if (
-            $(ev.target.closest("ul.dropdown-menu")).attr("id") !== undefined &&
-            $(ev.target.closest("ul.dropdown-menu")).attr("id") ===
-                $("body > ul.dropdown-menu").attr("id")
-        ) {
-            return;
+        if ($(ev.target.closest("ul.dropdown-menu")).attr("id") !== undefined) {
+            const dropdown = $("body > ul.dropdown-menu");
+            for (let i = 0; i < dropdown.length; i++) {
+                if (
+                    $(ev.target.closest("ul.dropdown-menu")).attr("id") ===
+                    $(dropdown[i]).attr("id")
+                ) {
+                    return;
+                }
+            }
         }
         this._super(ev);
     },


### PR DESCRIPTION
An error selecting many2one fields in the Custom filter.

When select to add a field "is equal to" and adding an extra condition like the first one, the filter disappears!