### PR TITLE
[15.0][FIX] web_responsive: Wrap text when display_name is too long

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -459,3 +459,8 @@ html .o_web_client .o_action_manager .o_action {
         padding-right: 0;
     }
 }
+
+// Many2one li items with wrap
+ul.ui-autocomplete .dropdown-item.ui-menu-item-wrapper {
+    white-space: initial;
+}


### PR DESCRIPTION
cc @Tecnativa TT43540

Before this patch:
![image](https://github.com/OCA/web/assets/35952655/601905cc-e9d8-4539-97a7-86a4d9a51874)

After this patch:
![image](https://github.com/OCA/web/assets/35952655/aa8e5879-c939-40d9-9d65-1956c9545691)


ping @pedrobaeza @chienandalu 