### PR TITLE
[16.0][IMP] web_responsive: Remove z and x hotkeys

### DIFF
--- a/web_responsive/static/src/components/hotkey/hotkey.xml
+++ b/web_responsive/static/src/components/hotkey/hotkey.xml
@@ -24,16 +24,4 @@
             >'shift+' + (sectionsVisibleCount + 1 % 10).toString()</attribute>
         </xpath>
     </t>
-    <t t-inherit="web.Pager" t-inherit-mode="extension" owl="1">
-        <xpath expr="//button[hasclass('o_pager_previous')]" position="attributes">
-            <attribute
-                name="t-att-accesskey"
-            >props.withAccessKey ? 'z' : false</attribute>
-        </xpath>
-        <xpath expr="//button[hasclass('o_pager_next')]" position="attributes">
-            <attribute
-                name="t-att-accesskey"
-            >props.withAccessKey ? 'x' : false</attribute>
-        </xpath>
-    </t>
 </templates>


### PR DESCRIPTION
cc @Tecnativa TT43583

remove customized hotkeys for Previous and Next

Reported on Issue https://github.com/OCA/web/issues/2504

ping @pedrobaeza @Tardo @yajo @liebana @mohamedhagag