### PR TITLE
[15.0][IMP] web_widget_open_tab

### DIFF
--- a/web_widget_open_tab/README.rst
+++ b/web_widget_open_tab/README.rst
@@ -48,6 +48,10 @@ Edit the tree view and add the widget as the first field, usually, we should use
 You can open the record in a new tab when clicking with the mouse wheel on the external link icon.
 On a usual click the record will be opened without changes (keeping the breadcrumbs).
 
+You can also add open-tab field in tree views by selecting "Add Open Tab Field" field in
+the ir.model record. When you do this, the open-tab field is added right after the name
+field in the tree if the field exists, otherwise at the beginning of the tree.
+
 Bug Tracker
 ===========
 
@@ -71,6 +75,9 @@ Contributors
 
 * Enric Tobella <etobella@creublanca.es>
 * Raf Ven <raf.ven@dynapps.be>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Aung Ko Ko Lin
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_widget_open_tab/__init__.py
+++ b/web_widget_open_tab/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/web_widget_open_tab/__manifest__.py
+++ b/web_widget_open_tab/__manifest__.py
@@ -11,6 +11,9 @@
     "website": "https://github.com/OCA/web",
     "depends": ["web"],
     "demo": ["demo/res_users_view.xml"],
+    "data": [
+        "views/ir_model_views.xml",
+    ],
     "assets": {
         "web.assets_backend": ["web_widget_open_tab/static/src/js/widget.js"],
     },

--- a/web_widget_open_tab/models/__init__.py
+++ b/web_widget_open_tab/models/__init__.py
@@ -1,0 +1,2 @@
+from . import ir_model
+from . import ir_ui_view

--- a/web_widget_open_tab/models/ir_model.py
+++ b/web_widget_open_tab/models/ir_model.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class IrModel(models.Model):
+    _inherit = "ir.model"
+
+    add_open_tab_field = fields.Boolean(help="Adds open-tab field in list views.")

--- a/web_widget_open_tab/models/ir_ui_view.py
+++ b/web_widget_open_tab/models/ir_ui_view.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+
+from odoo import api, models
+
+
+class Base(models.AbstractModel):
+    _inherit = "base"
+
+    @api.model
+    def fields_view_get(
+        self, view_id=None, view_type="form", toolbar=False, submenu=False
+    ):
+        res = super(Base, self).fields_view_get(
+            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
+        )
+        arch = etree.fromstring(res["arch"])
+        model = self.env["ir.model"]._get(self._name)
+        if view_type == "tree" and model.add_open_tab_field:
+            id_elem = """<field name="id" widget="open_tab" nolabel="1"/>"""
+            id_elem = etree.fromstring(id_elem)
+            tree = arch.xpath("//tree")[0]
+            name_field = tree.xpath('./field[@name="name"]')
+            if name_field:
+                tree = arch.xpath("//tree")[0]
+                tree.insert(name_field[0].getparent().index(name_field[0]) + 1, id_elem)
+            else:
+                tree.insert(0, id_elem)
+        res["arch"] = etree.tostring(arch)
+        return res

--- a/web_widget_open_tab/models/ir_ui_view.py
+++ b/web_widget_open_tab/models/ir_ui_view.py
@@ -10,6 +10,12 @@ class Base(models.AbstractModel):
     _inherit = "base"
 
     @api.model
+    def _get_name_field(self, tree):
+        if tree.xpath('./field[@name="display_name"]'):
+            return tree.xpath('./field[@name="display_name"]')
+        return tree.xpath('./field[@name="name"]')
+
+    @api.model
     def fields_view_get(
         self, view_id=None, view_type="form", toolbar=False, submenu=False
     ):
@@ -22,7 +28,7 @@ class Base(models.AbstractModel):
             id_elem = """<field name="id" widget="open_tab" nolabel="1"/>"""
             id_elem = etree.fromstring(id_elem)
             tree = arch.xpath("//tree")[0]
-            name_field = tree.xpath('./field[@name="name"]')
+            name_field = self._get_name_field(tree)
             if name_field:
                 tree = arch.xpath("//tree")[0]
                 tree.insert(name_field[0].getparent().index(name_field[0]) + 1, id_elem)

--- a/web_widget_open_tab/readme/CONTRIBUTORS.rst
+++ b/web_widget_open_tab/readme/CONTRIBUTORS.rst
@@ -1,2 +1,5 @@
 * Enric Tobella <etobella@creublanca.es>
 * Raf Ven <raf.ven@dynapps.be>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Aung Ko Ko Lin

--- a/web_widget_open_tab/readme/USAGE.rst
+++ b/web_widget_open_tab/readme/USAGE.rst
@@ -5,3 +5,7 @@ Edit the tree view and add the widget as the first field, usually, we should use
 
 You can open the record in a new tab when clicking with the mouse wheel on the external link icon.
 On a usual click the record will be opened without changes (keeping the breadcrumbs).
+
+You can also add open-tab field in tree views by selecting "Add Open Tab Field" field in
+the ir.model record. When you do this, the open-tab field is added right after the name
+field in the tree if the field exists, otherwise at the beginning of the tree.

--- a/web_widget_open_tab/static/description/index.html
+++ b/web_widget_open_tab/static/description/index.html
@@ -394,6 +394,9 @@ When clicking on the line (but not on the button), the record is opened in the s
 &lt;field name=”id” widget=”open_tab”/&gt;</blockquote>
 <p>You can open the record in a new tab when clicking with the mouse wheel on the external link icon.
 On a usual click the record will be opened without changes (keeping the breadcrumbs).</p>
+<p>You can also add open-tab field in tree views by selecting “Add Open Tab Field” field in
+the ir.model record. When you do this, the open-tab field is added right after the name
+field in the tree if the field exists, otherwise at the beginning of the tree.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
@@ -416,6 +419,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Enric Tobella &lt;<a class="reference external" href="mailto:etobella&#64;creublanca.es">etobella&#64;creublanca.es</a>&gt;</li>
 <li>Raf Ven &lt;<a class="reference external" href="mailto:raf.ven&#64;dynapps.be">raf.ven&#64;dynapps.be</a>&gt;</li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/web_widget_open_tab/views/ir_model_views.xml
+++ b/web_widget_open_tab/views/ir_model_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="ir_model_view" model="ir.ui.view">
+        <field name="name">ir.model.view.form</field>
+        <field name="model">ir.model</field>
+        <field name="inherit_id" ref="base.view_model_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='transient']" position="after">
+                <field name="add_open_tab_field" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR adds open-tab field in tree views by selecting "Add Open Tab Field" field in the ir.model record. When you do this, the open-tab field is added right after the name field in the tree if the field exists, otherwise at the beginning of the tree.
Back port of https://github.com/OCA/web/pull/2572
@qrtl