### PR TITLE
[16.0][FIX] web_timeline: css and styles not charged when rendering t…

### DIFF
--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -227,7 +227,11 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 this.qweb.add_template(tmpl);
             }
 
-            this.timeline = new vis.Timeline(this.$timeline.get(0));
+            this.timeline = new vis.Timeline(
+                this.$timeline.get(0),
+                {},
+                {xss: {disabled: true}}
+            );
             this.timeline.setOptions(this.options);
             if (this.mode && this["on_scale_" + this.mode + "_clicked"]) {
                 this["on_scale_" + this.mode + "_clicked"]();


### PR DESCRIPTION
On library version update a new feature was added at Timeline creation level to allow modifying the xss. By keeping it active the css classes are not showed

As the view is on backend, has no sense to keep it active. So we deactivate the feature to allow show the timeline correctly.

TT43238