### PR TITLE
Add name_get() implementation for ir.model.fields

### DIFF
--- a/web_m2x_options_manager/models/ir_model.py
+++ b/web_m2x_options_manager/models/ir_model.py
@@ -50,3 +50,17 @@ class IrModelFields(models.Model):
         if limit and limit > 0:
             new_fids = new_fids[:limit]
         return self.browse(new_fids).sudo().name_get()
+
+    def name_get(self):
+        res = []
+        if self.env.context.get("display_technical_name"):
+            for field in self:
+                res.append(
+                    (
+                        field.id,
+                        "%s (%s), model: (%s)"
+                        % (field.field_description, field.name, field.model),
+                    )
+                )
+            return res
+        return super(IrModelFields, self).name_get()

--- a/web_m2x_options_manager/views/ir_model.xml
+++ b/web_m2x_options_manager/views/ir_model.xml
@@ -15,13 +15,13 @@
                     <field
                         name="m2x_create_edit_option_ids"
                         nolabel="1"
-                        context="{'default_model_name': model}"
+                        context="{'default_model_name': model, 'display_technical_name': True}"
                     >
                         <tree string="Fields Description" editable="bottom">
                             <field name="model_name" invisible="1" />
                             <field
                                 name="field_id"
-                                context="{'search_by_technical_name': True, 'display_technical_name': True}"
+                                context="{'search_by_technical_name': True}"
                                 domain="[('ttype', 'in', ('many2many', 'many2one')), ('model_id.model', '=', model_name)]"
                                 options="{'create': False, 'create_edit': False}"
                             />


### PR DESCRIPTION
This commit will allow to show technical field name of a `field_id` on `m2x_create_edit_option_ids` field. The key "display_technical_name" was in `field_id` context but it wasn't actually used to display name correctly.

I took the liberty to move the key up on the one2many field `m2x_create_edit_option_id`, as it allows to retrieve the key in python.

After this commit the _rec_name of `field_id` is formatted as: "Field Label (Technical Field Name), model: Model Name" if key "display_technical_name" is detected on context.