### PR TITLE
[UPD] web_dialog_size: reduce rpc call to get config

### DIFF
--- a/web_dialog_size/models/__init__.py
+++ b/web_dialog_size/models/__init__.py
@@ -1,1 +1,2 @@
 from . import ir_config_parameter
+from . import ir_http

--- a/web_dialog_size/models/ir_http.py
+++ b/web_dialog_size/models/ir_http.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class Http(models.AbstractModel):
+    _inherit = "ir.http"
+
+    def session_info(self):
+        IrConfigSudo = self.env["ir.config_parameter"].sudo()
+        session_info = super().session_info()
+        session_info.update(IrConfigSudo.get_web_dialog_size_config())
+        return session_info

--- a/web_dialog_size/static/src/js/web_dialog_draggable.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_draggable.esm.js
@@ -1,10 +1,10 @@
 /** @odoo-module **/
 
-import {patch} from "@web/core/utils/patch";
+const {Component} = owl;
 import {Dialog} from "@web/core/dialog/dialog";
+import {patch} from "@web/core/utils/patch";
 const {useExternalListener} = owl.hooks;
 import {useListener} from "web.custom_hooks";
-const {Component} = owl;
 
 export class DialogDraggable extends Component {
     setup() {

--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -1,27 +1,18 @@
 /** @odoo-module **/
 
+/* global require*/
+var session = require("web.session");
 import {ActionDialog} from "@web/webclient/actions/action_dialog";
-import {patch} from "@web/core/utils/patch";
-import rpc from "web.rpc";
 const {Component} = owl;
-const {onMounted} = owl.hooks;
+import {patch} from "@web/core/utils/patch";
 
 export class ExpandButton extends Component {
     setup() {
-        this.last_size = this.props.getsize();
-        this.config = rpc.query({
-            model: "ir.config_parameter",
-            method: "get_web_dialog_size_config",
-        });
-
-        onMounted(() => {
-            var self = this;
-            this.config.then(function (r) {
-                if (r.default_maximize && stop) {
-                    self.dialog_button_extend();
-                }
-            });
-        });
+        if (session.default_maximize) {
+            this.last_size = "modal-lg";
+        } else {
+            this.last_size = this.props.getsize();
+        }
     }
 
     dialog_button_extend() {
@@ -40,6 +31,11 @@ patch(ActionDialog.prototype, "web_dialog_size.ActionDialog", {
         this._super(...arguments);
         this.setSize = this.setSize.bind(this);
         this.getSize = this.getSize.bind(this);
+
+        if (session.default_maximize) {
+            this.last_size = "modal-lg";
+            this.size = "dialog_full_screen";
+        }
     },
 
     setSize(size) {

--- a/web_dialog_size/static/src/js/web_dialog_size.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.js
@@ -1,13 +1,7 @@
 odoo.define("web_dialog_size.web_dialog_size", function (require) {
     "use strict";
 
-    var rpc = require("web.rpc");
     var Dialog = require("web.Dialog");
-
-    var config = rpc.query({
-        model: "ir.config_parameter",
-        method: "get_web_dialog_size_config",
-    });
 
     Dialog.include({
         willStart: function () {
@@ -19,13 +13,6 @@ odoo.define("web_dialog_size.web_dialog_size", function (require) {
                 self.$modal
                     .find(".dialog_button_restore")
                     .on("click", self.proxy("_restore"));
-                return config.then(function (r) {
-                    if (r.default_maximize) {
-                        self._extending();
-                    } else {
-                        self._restore();
-                    }
-                });
             });
         },
 


### PR DESCRIPTION
After installing web_dialog_size and setup its parameter, there's a slight delay where we can see the modal at its normal size and then after a rpc to ir.config_parameter:get_web_dialog_size_config() the modal is maximized.

This commit is to set a session value then use it to set initial dialog size upfront without delay.