### PR TITLE
[15.0][FIX] web_responsive: attachment_viewer is displayed under clock of employees view

### DIFF
--- a/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
+++ b/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
@@ -12,7 +12,7 @@
         }
         .o_AttachmentViewer {
             // On-top of navbar
-            z-index: 10;
+            z-index: 100;
             position: absolute;
             right: 0;
             top: 0;


### PR DESCRIPTION
Before this change, when an attachment was displayed on the screen, the employee's clocks were being shown above the attachment viewer.
![image](https://github.com/OCA/web/assets/35952655/ee1b92bc-5aae-4b75-a74f-fa8af28f0f84)

After making this change, everything is now displayed normally.
![image](https://github.com/OCA/web/assets/35952655/678f5cdc-98ac-4434-ae88-985c18a4d5a1)

cc @Tecnativa TT44101

ping @pedrobaeza @pilarvargas-tecnativa 