### PR TITLE
[14.0][IMP] web_ir_actions_act_window_message: ctx to avoid reloading

### DIFF
--- a/web_ir_actions_act_window_message/README.rst
+++ b/web_ir_actions_act_window_message/README.rst
@@ -80,6 +80,9 @@ Depend on this module and return
 
 You are responsible for translating the messages.
 
+A special context `avoid_message_view_reload` can be passed through the message dict to avoid
+reloading the main view after closing the message view.
+
 Known issues / Roadmap
 ======================
 

--- a/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
+++ b/web_ir_actions_act_window_message/static/src/js/web_ir_actions_act_window_message.js
@@ -90,11 +90,13 @@ odoo.define("web.web_ir_actions_act_window_message", function (require) {
                                 if (_.isObject(result)) {
                                     self.do_action(result);
                                 }
-                                // Always refresh the view after the action
+                                // Refresh the view after the action
                                 // ex: action updates a status
-                                var controller = self.getCurrentController();
-                                if (controller && controller.widget) {
-                                    controller.widget.reload();
+                                if (!action.context.avoid_message_view_reload) {
+                                    var controller = self.getCurrentController();
+                                    if (controller && controller.widget) {
+                                        controller.widget.reload();
+                                    }
                                 }
                             });
                         } else {


### PR DESCRIPTION
Accept a context to stop the main view from reloading after the message view is closed. I found out that this causes an error when the message view is shown inside enterprise's barcode app