### PR TITLE
[16.0][FIX]: web_widget_x2many_2d_matrix: Editable boolean

### DIFF
--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -35,6 +35,7 @@
             "x2many_2d_matrix_field.xml",
             "web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/"
             "x2many_2d_matrix_field.scss",
+            "web_widget_x2many_2d_matrix/static/src/views/fields/boolean/boolean_field.esm.js",
         ],
     },
 }

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -144,6 +144,9 @@ export class X2Many2DMatrixRenderer extends Component {
             record = this.matrix[y][x].records[0];
             value = this.matrix[y][x].value;
         }
+        if (this.list.fields[this.matrixFields.value].type === "boolean") {
+            record.bypass_readonly = true;
+        }
         value =
             !this._canAggregate() && record
                 ? record.data[this.matrixFields.value]

--- a/web_widget_x2many_2d_matrix/static/src/views/fields/boolean/boolean_field.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/views/fields/boolean/boolean_field.esm.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import {patch} from "@web/core/utils/patch";
+import {BooleanField} from "@web/views/fields/boolean/boolean_field";
+
+patch(BooleanField.prototype, "web_widget_x2many_2d_matrix", {
+    get isReadonly() {
+        if (this.props.record.bypass_readonly) {
+            return false;
+        }
+        return this._super(...arguments);
+    },
+});


### PR DESCRIPTION
#### Problem:

- When using the `web_widget_x2many_2d_matrix` module to create a nice matrix view with a `boolean` field as the value, said field is stuck in "readonly" mode. I believe this is due to 16.0 changes to always "edit" mode not propagating properly to this custom Component and some limitations it causes with Boolean fields specifically

####  PR

- The proposed change is probably not the most performant and there is likely a more elegant way of adapting it with more knowledge of the framework but I couldn't find it, I don't think this change would really cause any issues
