### PR TITLE
[15.0][FIX] web_responsive: increase z-index of attachment_viewer

### DIFF
--- a/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
+++ b/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
@@ -12,7 +12,7 @@
         }
         .o_AttachmentViewer {
             // On-top of navbar
-            z-index: 100;
+            z-index: 1000;
             position: absolute;
             right: 0;
             top: 0;


### PR DESCRIPTION
Before this change, when the attachment_viewer was opened from the chat, it was displayed in front of the chat and could obscure part of the image.
![image](https://github.com/OCA/web/assets/35952655/0a09c1c8-aa20-4ded-89e8-01694925def1)

After this change, this is no longer the case, as the attachment_viewer is displayed in front of the chat.
![image](https://github.com/OCA/web/assets/35952655/374db06d-cabd-4baa-8565-dea8b8701cb7)

cc @Tecnativa TT44471

ping @pedrobaeza @pilarvargas-tecnativa 