### PR TITLE
[16.0][FIX] requirements.txt: use bokeh 2.4.3 for Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # generated from manifests external_dependencies
-bokeh==3.1.1
+bokeh==2.4.3; python_version == '3.7'
+bokeh==3.1.1; python_version > '3.7'
 plotly==5.13.1

--- a/web_widget_bokeh_chart/__manifest__.py
+++ b/web_widget_bokeh_chart/__manifest__.py
@@ -12,7 +12,12 @@
     "website": "https://github.com/OCA/web",
     "depends": ["web"],
     "data": [],
-    "external_dependencies": {"python": ["bokeh==3.1.1"]},
+    "external_dependencies": {
+        "python": [
+            "bokeh==2.4.3; python_version == '3.7'",
+            "bokeh==3.1.1; python_version > '3.7'",
+        ]
+    },
     "auto_install": False,
     "license": "LGPL-3",
     "assets": {


### PR DESCRIPTION
boken 3.* require installed on Python 3.8 or higher

Noting, that I did not check how [web_widget_bokeh_chart](https://github.com/OCA/web/tree/16.0/web_widget_bokeh_chart) works with new pinned version. The only thing I am doing is fixing my private CI/CD that is based on minimal usable version for odoo 16.0, which is 3.7.