### PR TITLE
[16.0][IMP] web_widget_open_tab

### DIFF
--- a/web_widget_open_tab/README.rst
+++ b/web_widget_open_tab/README.rst
@@ -48,6 +48,10 @@ Edit the tree view and add the widget as the first field, usually, we should use
 You can open the record in a new tab when clicking with the mouse wheel on the external link icon.
 On a usual click the record will be opened without changes (keeping the breadcrumbs).
 
+You can also add open-tab field in tree views by selecting "Add Open Tab Field" field in
+the ir.model record. When you do this, the open-tab field is added right after the name
+field in the tree if the field exists, otherwise at the beginning of the tree.
+
 Known issues / Roadmap
 ======================
 
@@ -77,6 +81,9 @@ Contributors
 * Enric Tobella <etobella@creublanca.es>
 * Raf Ven <raf.ven@dynapps.be>
 * Dhara Solanki <dhara.solanki@initos.com>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Aung Ko Ko Lin
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_widget_open_tab/__init__.py
+++ b/web_widget_open_tab/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/web_widget_open_tab/__manifest__.py
+++ b/web_widget_open_tab/__manifest__.py
@@ -11,6 +11,9 @@
     "website": "https://github.com/OCA/web",
     "depends": ["web"],
     "demo": ["demo/res_users_view.xml"],
+    "data": [
+        "views/ir_model_views.xml",
+    ],
     "assets": {
         "web.assets_backend": [
             "web_widget_open_tab/static/src/xml/open_tab_widget.xml",

--- a/web_widget_open_tab/i18n/ja.po
+++ b/web_widget_open_tab/i18n/ja.po
@@ -1,0 +1,50 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* web_widget_open_tab
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-05-27 08:24+0000\n"
+"PO-Revision-Date: 2023-05-27 08:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: web_widget_open_tab
+#: model:ir.model.fields,field_description:web_widget_open_tab.field_ir_model__add_open_tab_field
+msgid "Add Open Tab Field"
+msgstr "別タブ表示ボタン追加"
+
+#. module: web_widget_open_tab
+#: model:ir.model.fields,help:web_widget_open_tab.field_ir_model__add_open_tab_field
+msgid "Adds open-tab field in list views."
+msgstr "リストビューに別タブ表示ボタンを追加。"
+
+#. module: web_widget_open_tab
+#: model:ir.model,name:web_widget_open_tab.model_base
+msgid "Base"
+msgstr "ベース"
+
+#. module: web_widget_open_tab
+#. odoo-javascript
+#: code:addons/web_widget_open_tab/static/src/js/open_tab_widget.esm.js:0
+#, python-format
+msgid "Click to open on new tab"
+msgstr "クリックして別タブを開く"
+
+#. module: web_widget_open_tab
+#: model:ir.model,name:web_widget_open_tab.model_ir_model
+msgid "Models"
+msgstr "モデル"
+
+#. module: web_widget_open_tab
+#. odoo-javascript
+#: code:addons/web_widget_open_tab/static/src/js/open_tab_widget.esm.js:0
+#, python-format
+msgid "Open Tab"
+msgstr "別タブを開く"

--- a/web_widget_open_tab/models/__init__.py
+++ b/web_widget_open_tab/models/__init__.py
@@ -1,0 +1,2 @@
+from . import ir_model
+from . import ir_ui_view

--- a/web_widget_open_tab/models/ir_model.py
+++ b/web_widget_open_tab/models/ir_model.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class IrModel(models.Model):
+    _inherit = "ir.model"
+
+    add_open_tab_field = fields.Boolean(help="Adds open-tab field in list views.")

--- a/web_widget_open_tab/models/ir_ui_view.py
+++ b/web_widget_open_tab/models/ir_ui_view.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+
+from odoo import api, models
+
+
+class Base(models.AbstractModel):
+    _inherit = "base"
+
+    @api.model
+    def _get_view(self, view_id=None, view_type="form", **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+        model = self.env["ir.model"]._get(self._name)
+        if view_type == "tree" and model.add_open_tab_field:
+            id_elem = """<field name="id" widget="open_tab" nolabel="1"/>"""
+            id_elem = etree.fromstring(id_elem)
+            tree = arch.xpath("//tree")[0]
+            name_field = tree.xpath('./field[@name="name"]')
+            if name_field:
+                tree.insert(name_field[0].getparent().index(name_field[0]) + 1, id_elem)
+            else:
+                tree.insert(0, id_elem)
+        return arch, view

--- a/web_widget_open_tab/readme/CONTRIBUTORS.rst
+++ b/web_widget_open_tab/readme/CONTRIBUTORS.rst
@@ -1,3 +1,6 @@
 * Enric Tobella <etobella@creublanca.es>
 * Raf Ven <raf.ven@dynapps.be>
 * Dhara Solanki <dhara.solanki@initos.com>
+* `Quartile <https://www.quartile.co>`__:
+
+  * Aung Ko Ko Lin

--- a/web_widget_open_tab/readme/USAGE.rst
+++ b/web_widget_open_tab/readme/USAGE.rst
@@ -5,3 +5,7 @@ Edit the tree view and add the widget as the first field, usually, we should use
 
 You can open the record in a new tab when clicking with the mouse wheel on the external link icon.
 On a usual click the record will be opened without changes (keeping the breadcrumbs).
+
+You can also add open-tab field in tree views by selecting "Add Open Tab Field" field in
+the ir.model record. When you do this, the open-tab field is added right after the name
+field in the tree if the field exists, otherwise at the beginning of the tree.

--- a/web_widget_open_tab/static/description/index.html
+++ b/web_widget_open_tab/static/description/index.html
@@ -395,6 +395,9 @@ When clicking on the line (but not on the button), the record is opened in the s
 &lt;field name=”id” widget=”open_tab”/&gt;</blockquote>
 <p>You can open the record in a new tab when clicking with the mouse wheel on the external link icon.
 On a usual click the record will be opened without changes (keeping the breadcrumbs).</p>
+<p>You can also add open-tab field in tree views by selecting “Add Open Tab Field” field in
+the ir.model record. When you do this, the open-tab field is added right after the name
+field in the tree if the field exists, otherwise at the beginning of the tree.</p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
@@ -424,6 +427,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Enric Tobella &lt;<a class="reference external" href="mailto:etobella&#64;creublanca.es">etobella&#64;creublanca.es</a>&gt;</li>
 <li>Raf Ven &lt;<a class="reference external" href="mailto:raf.ven&#64;dynapps.be">raf.ven&#64;dynapps.be</a>&gt;</li>
 <li>Dhara Solanki &lt;<a class="reference external" href="mailto:dhara.solanki&#64;initos.com">dhara.solanki&#64;initos.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
+<li>Aung Ko Ko Lin</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/web_widget_open_tab/views/ir_model_views.xml
+++ b/web_widget_open_tab/views/ir_model_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="ir_model_view" model="ir.ui.view">
+        <field name="name">ir.model.view.form</field>
+        <field name="model">ir.model</field>
+        <field name="inherit_id" ref="base.view_model_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='transient']" position="after">
+                <field name="add_open_tab_field" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR enhances to add open-tab field in tree views by selecting "Add Open Tab Field" field in the ir.model record. When you do this, the open-tab field is added right after the name field in the tree if the field exists, otherwise at the beginning of the tree for the respective model.

@qrtl