### PR TITLE
[FIX] web_widget_bokeh_chart : bad image path in description, break readme file

### DIFF
--- a/web_widget_bokeh_chart/readme/DESCRIPTION.rst
+++ b/web_widget_bokeh_chart/readme/DESCRIPTION.rst
@@ -1,6 +1,6 @@
 This module add the possibility to insert Bokeh charts into Odoo standard views.
 
-.. image:: /web_widget_bokeh_chart/static/description/example.png
+.. image:: ../static/description/example.png
    :alt: Bokeh Chart inserted into an Odoo view
    :width: 600 px
 


### PR DESCRIPTION
Trivial.

the image is not visible here https://github.com/OCA/web/blob/16.0/web_widget_bokeh_chart/README.rst

with that patch, it is.