### PR TITLE
[15.0][FIX] web_search_with_and

### DIFF
--- a/web_search_with_and/static/src/js/search_bar.js
+++ b/web_search_with_and/static/src/js/search_bar.js
@@ -27,8 +27,8 @@ odoo.define("web_search_with_and/static/src/js/search_bar.js", function (require
                     filterId: source.filterId,
                     value:
                         "value" in source
-                            ? source.value.trim()
-                            : this._parseWithSource(labelValue, source).trim(),
+                            ? source.value
+                            : this._parseWithSource(labelValue.trim(), source),
                     label: labelValue.trim(),
                     operator: source.filterOperator || source.operator,
                     isShiftKey: this.isShiftKey,


### PR DESCRIPTION
When we search by the id of any record and not a string, it gives an error on the line: ? source.value.trim().
It is because the value of source.value is an integer. To fix it, we do the trim() operation just if source.value is an string.

Update: I haven't explained myself well. What i tried to say is when we search by a suggested value:
![image](https://github.com/OCA/web/assets/98804703/465154a1-029c-49a0-9e6b-2f70f0eab87a)

When we select "My Company", source.value is an integer, and this why we cannot trim. It is just this case, when we search for "my com", for example, we search by a string and we can trim.