### PR TITLE
[12.0][FIX] web_translate_dialog dataset context not always filled

### DIFF
--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -51,7 +51,7 @@ var TranslateDialog = Dialog.extend({
         this.languages = null;
         this.languages_loaded = $.Deferred();
         this.lang_data = new data.DataSetSearch(
-            this, 'res.lang', parent.searchView.dataset.get_context(),
+            this, 'res.lang', parent.context,
             [['translatable', '=', '1']]
         );
         this.lang_data.set_sort(['tr_sequence asc','id asc']);


### PR DESCRIPTION
dataset context not always filled by the searchView.dataset but the context of the parent is always present and contain the context.