### PR TITLE
[FIX] web_chatter_position: Fixes bug where incompatible apps crash

### DIFF
--- a/web_chatter_position/__manifest__.py
+++ b/web_chatter_position/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Chatter Position",
     "summary": "Add an option to change the chatter position",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "author": "Hynsys Technologies, Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",
     "license": "LGPL-3",

--- a/web_chatter_position/static/src/js/web_chatter_position.esm.js
+++ b/web_chatter_position/static/src/js/web_chatter_position.esm.js
@@ -126,6 +126,10 @@ patch(FormCompiler.prototype, "web_chatter_position", {
                 chatterContainerHookXml.setAttribute("t-if", false);
             } else {
                 const formSheetBgXml = res.querySelector(".o_form_sheet_bg");
+                const parentXml = formSheetBgXml && formSheetBgXml.parentNode;
+                if (!parentXml) {
+                    return res; // Miss-config: a sheet-bg is required for the rest
+                }
                 const sheetBgChatterContainerHookXml =
                     chatterContainerHookXml.cloneNode(true);
                 sheetBgChatterContainerHookXml.classList.add("o-isInFormSheetBg");


### PR DESCRIPTION
In some (new) apps, the query selector `querySelector('.o_form_sheet_bg')` in `web_chatter_position` will not return anything. This causes a crash when you try to open the app in question.

You can replicate this by installing both the new 'Knowledge' app, as well as `web_chatter_position`, and trying to open the former when the current user's preferences have been set to chatter position 'bottom'.

Odoo avoids this problem by exiting early without a chatter if there no `sheet-bg`. This PR implements the exact same solution. See the Odoo source [here](https://github.com/odoo/odoo/blob/16.0/addons/mail/static/src/views/form/form_compiler.js#L171).
