### PR TITLE
[16.0][FIX] web_timeline: Add record -> popup form

### DIFF
--- a/web_timeline/static/src/js/timeline_controller.esm.js
+++ b/web_timeline/static/src/js/timeline_controller.esm.js
@@ -290,7 +290,7 @@ export default AbstractController.extend({
         this.Dialog = Component.env.services.dialog.add(
             FormViewDialog,
             {
-                resId: null,
+                resId: false,
                 context: _.extend(default_context, this.context),
                 onRecordSaved: (record) => this.create_completed([record.res_id]),
                 resModel: this.model.modelName,


### PR DESCRIPTION
`resId: null` caused an error when creating a record from timeline view: resId is not a number or boolean.
`resId: false` fixed the error.