### PR TITLE
[16.0][FIX] web_company_color: Changing just one color fixed

### DIFF
--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -16,6 +16,7 @@ class ResCompany(models.Model):
 
     SCSS_TEMPLATE = """
         .o_main_navbar {
+          background: %(color_navbar_bg)s !important;
           background-color: %(color_navbar_bg)s !important;
           color: %(color_navbar_text)s !important;
 
@@ -113,10 +114,7 @@ class ResCompany(models.Model):
         values.update(
             {
                 "color_navbar_bg": (values.get("color_navbar_bg") or "$o-brand-odoo"),
-                "color_navbar_bg_hover": (
-                    values.get("color_navbar_bg_hover")
-                    or "$o-navbar-inverse-link-hover-bg"
-                ),
+                "color_navbar_bg_hover": (values.get("color_navbar_bg_hover")),
                 "color_navbar_text": (values.get("color_navbar_text") or "#FFF"),
             }
         )


### PR DESCRIPTION
Before it didn't work if just a color was set because it couldn't find "color_navbar_bg_hover". Moreover, in odoo enterprise the navbar background color only worked for the main app menu, now it works for both main app menu and the navbar of the apps. 