### PR TITLE
[16.0][FIX] web_timeline: date_delay = date_stop - date_start

### DIFF
--- a/web_timeline/static/src/js/timeline_controller.esm.js
+++ b/web_timeline/static/src/js/timeline_controller.esm.js
@@ -282,6 +282,10 @@ export default AbstractController.extend({
                 .utc()
                 .format("YYYY-MM-DD HH:mm:ss");
         }
+        if (this.date_delay && this.date_start && this.date_stop && item.end) {
+            default_context["default_".concat(this.date_delay)] =
+                (moment(item.end) - moment(item.start)) / 3600000;
+        }
         if (item.group > 0) {
             default_context["default_".concat(this.renderer.last_group_bys[0])] =
                 item.group;


### PR DESCRIPTION
Adding / Creating a new record, `date_delay` was hard-coded to always be 1.
Now it computes correctly, if both date_start and date_stop exists.