### PR TITLE
[15.0][FIX] web_advanced_search: recover support for m2m custom filter

### DIFF
--- a/web_advanced_search/static/src/js/RecordPicker.esm.js
+++ b/web_advanced_search/static/src/js/RecordPicker.esm.js
@@ -10,6 +10,7 @@ const {Component} = owl;
 const {xml} = owl.tags;
 
 export const FakeMany2oneFieldWidget = FieldMany2One.extend(FieldManagerMixin, {
+    supportedFieldTypes: ["many2many", "many2one", "one2many"],
     /**
      * @override
      */

--- a/web_advanced_search/static/src/js/legacy/CustomFilterItem.esm.js
+++ b/web_advanced_search/static/src/js/legacy/CustomFilterItem.esm.js
@@ -22,6 +22,8 @@ patch(CustomFilterItem.prototype, "web_advanced_search.legacy.CustomFilterItem",
     async willStart() {
         this.OPERATORS.relational = this.OPERATORS.char;
         this.FIELD_TYPES.many2one = "relational";
+        this.FIELD_TYPES.many2many = "relational";
+        this.FIELD_TYPES.one2many = "relational";
         return this._super(...arguments);
     },
     /**

--- a/web_advanced_search/static/src/xml/CustomFilterItem.xml
+++ b/web_advanced_search/static/src/xml/CustomFilterItem.xml
@@ -8,7 +8,7 @@
     <t t-inherit="web.CustomFilterItem" t-inherit-mode="extension" owl="1">
         <xpath expr="//select[@t-elif]" position="after">
             <t
-                t-elif="fieldType === 'many2one' and ['=', '!='].includes(selectedOperator.symbol)"
+                t-elif="['many2one', 'many2many', 'one2many'].includes(fieldType) and ['=', '!='].includes(selectedOperator.symbol)"
             >
                 <RecordPicker
                     model="fields[condition.field].relation"


### PR DESCRIPTION

![Peek 01-09-2023 12-20](https://github.com/OCA/web/assets/5040182/7a3359c9-2324-4f3f-a80d-edf4b25004ca)


edit 1: Following the same technique I added o2m support as well. Maybe not that useful but a cheap change anyway
edit 2: Now rendering the text of the filtered tag correctly

cc @Tecnativa TT44862

please check @CarlosRoca13 @pedrobaeza 