### PR TITLE
[10.0][FIX] web_responsive: Filter properly menus on AppDrawer search

### DIFF
--- a/web_responsive/__init__.py
+++ b/web_responsive/__init__.py
@@ -1,1 +1,2 @@
 # -*- coding: utf-8 -*-
+from . import models

--- a/web_responsive/models/__init__.py
+++ b/web_responsive/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import ir_ui_menu

--- a/web_responsive/models/ir_ui_menu.py
+++ b/web_responsive/models/ir_ui_menu.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from odoo import api, models
+
+
+class IrUiMenu(models.Model):
+    _inherit = 'ir.ui.menu'
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        """The filtering that is done on the menus by upstream doesn't take into account
+        the visibility of their ancestors to decide if the menu is visible or not, which
+        is needed for the AppDrawer menu search.
+        """
+        menus = super(IrUiMenu, self).search(
+            args, offset=offset, limit=limit, order=order, count=count
+        )
+        if menus and not count and self.env.context.get("responsive_search"):
+            accesible_menus = self.env["ir.ui.menu"]
+            full_menus = self.with_context(responsive_search=False).search([])
+            for menu in menus:
+                add = True
+                parent_menu = menu.parent_id
+                while parent_menu:
+                    if parent_menu not in full_menus:
+                        add = False
+                        break
+                    parent_menu = parent_menu.parent_id
+                if add:
+                    accesible_menus += menu
+            menus = accesible_menus
+        return menus

--- a/web_responsive/static/src/js/web_responsive.js
+++ b/web_responsive/static/src/js/web_responsive.js
@@ -314,6 +314,7 @@ odoo.define('web_responsive', function(require) {
             this.$searchInput = $('#appDrawerSearchInput').focus();
             var Menus = new DataModel('ir.ui.menu');
             Menus.query(['action', 'display_name', 'id'])
+                .context({"responsive_search": true})
                 .filter([['name', 'ilike', this.$searchInput.val()],
                          ['action', '!=', false]
                          ])


### PR DESCRIPTION
Disclaimer: On a project we have recovered bounced from other partner, and meanwhile we migrate it to latest versions, we have found this problem, that we fix and put it back into the community for those that are sticky to this version.

The filtering that is done on the menus by upstream doesn't take into account the visibility of their ancestors to decide if the menu is visible or not, which is needed for the AppDrawer menu search.

@Tecnativa TT45078