### PR TITLE
[16.0][IMP] web_responsive: To follow the app menu icon in Odoo 16

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.xml
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.xml
@@ -37,7 +37,7 @@
                 data-hotkey="a"
                 t-on-click.stop="() => this.setOpenState(!state.open,true)"
             >
-                <i class="fa fa-th-large" />
+                <i class="oi oi-apps" />
             </button>
             <div t-if="state.open" class="dropdown-menu-custom">
                 <t t-slot="default" />


### PR DESCRIPTION
Hello,

I've made the changes to follow the app menu icon for Odoo 16. The code has been updated accordingly.

[current icon](https://www.awesomescreenshot.com/image/43133750?key=06fb8d19642188cb572753c51cc8f348)
[updated icon](https://www.awesomescreenshot.com/image/43133756?key=71be3fb303ccd9e06f3837d02d0da04e)

As you can see, the app menu icon now aligns with the design in Odoo 16. I believe these changes enhance the user experience and consistency.

Please let me know if there are any further adjustments.

Thank you for your review!