### PR TITLE
[16.0][IMP] web_responsive: Fixed full-screen apps menu

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.scss
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.scss
@@ -10,7 +10,7 @@
     position: fixed;
     margin: 0;
     width: 100vw;
-    z-index: 200;
+    z-index: 1000;
     left: 0 !important;
 }
 


### PR DESCRIPTION
Hello,

I've made the changes to fix full-screen app menu issue when exiting sale order form, sale order lines remain visible on app menu screen.

To reproduce, open the sale order form, and the odoo bubbles are still visible on the sale order line.

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2I2dGN6bjRuMXhsY3QyaDg5cWx6bzVoeTE5MXJra3h4MDVkaDV5YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/GmXpeklyBRjp5DOkoH/giphy.gif)

Please let me know if there are any further adjustments.

Thank you for your review!