### PR TITLE
[14.0][FIX] web_field_required_invisible_manager: regenerate rest. field

### DIFF
--- a/web_field_required_invisible_manager/models/custom_field_restriction.py
+++ b/web_field_required_invisible_manager/models/custom_field_restriction.py
@@ -49,9 +49,9 @@ class CustomFieldRestriction(models.Model):
     field_invisible = fields.Boolean()
     field_readonly = fields.Boolean()
     # generated technical fields used in form attrs:
-    visibility_field_id = fields.Many2one("ir.model.fields", ondelete="cascade")
-    readonly_field_id = fields.Many2one("ir.model.fields", ondelete="cascade")
-    required_field_id = fields.Many2one("ir.model.fields", ondelete="cascade")
+    visibility_field_id = fields.Many2one("ir.model.fields")
+    readonly_field_id = fields.Many2one("ir.model.fields")
+    required_field_id = fields.Many2one("ir.model.fields")
 
     @api.onchange("field_id")
     def onchange_field_id(self):
@@ -83,6 +83,20 @@ class CustomFieldRestriction(models.Model):
         elif rec.required_model_id and rec.required:
             rec.create_restriction_field("required")
         return rec
+
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get("field_id"):
+            if self.visibility_field_id:
+                self.visibility_field_id.unlink()
+                self.create_restriction_field("visibility")
+            elif self.readonly_field_id:
+                self.readonly_field_id.unlink()
+                self.create_restriction_field("readonly")
+            elif self.required_field_id:
+                self.required_field_id.unlink()
+                self.create_restriction_field("required")
+        return res
 
     def create_restriction_field(self, f_type):
         field_name = self.get_field_name(f_type)

--- a/web_field_required_invisible_manager/tests/test_web_field_required_invisible_manager.py
+++ b/web_field_required_invisible_manager/tests/test_web_field_required_invisible_manager.py
@@ -73,11 +73,6 @@ class TestFieldRequiredIvisibleManager(common.SavepointCase):
         self.assertTrue(self.invisible_rec_id.visibility_field_id)
         self.assertTrue(self.required_rec_id.required_field_id)
         self.assertTrue(self.readonly_rec_id.readonly_field_id)
-        # onchange_field_id()
-        self.assertFalse(self.invisible_title_rec_id.required)
-        self.invisible_title_rec_id.field_id = self.partner_title_name_field_id
-        self.invisible_title_rec_id.onchange_field_id()
-        self.assertTrue(self.invisible_title_rec_id.required)
         # _compute_model_name()
         self.invisible_rec_id._compute_model_name()
         self.assertEqual(self.invisible_rec_id.model_name, "res.partner")
@@ -125,13 +120,13 @@ class TestFieldRequiredIvisibleManager(common.SavepointCase):
         self.deco_addict.invalidate_cache()
         self.deco_addict.read(["x_computed_res_partner_name_visibility"])
         self.assertTrue(self.deco_addict.x_computed_res_partner_name_visibility)
-        # unlink
-        field_name = self.invisible_title_rec_id.get_field_name("visibility")
-        self.invisible_title_rec_id.unlink()
-        field_id = self.env["ir.model.fields"].search([("name", "=", field_name)])
-        self.assertFalse(field_id)
         # default get
         self.env["res.partner"].default_get(["name"])
         self.env["res.partner"].default_get(["city"])
         self.env["res.partner.title"].default_get(["name"])
         self.env["res.partner.title"].default_get(["shortcut"])
+        # onchange_field_id()
+        self.assertFalse(self.invisible_title_rec_id.required)
+        self.invisible_title_rec_id.field_id = self.partner_title_name_field_id
+        self.invisible_title_rec_id.onchange_field_id()
+        self.assertTrue(self.invisible_title_rec_id.required)


### PR DESCRIPTION
When you change a field of the existing restriction record need to delete old visibility_field_id,  readonly_field_id, required_field_id and create a new one with correct name.