### PR TITLE
[14.0][FIX] web_field_required_invisible_manager: restrict fields dependency

### DIFF
--- a/web_field_required_invisible_manager/readme/ROADMAP.rst
+++ b/web_field_required_invisible_manager/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+When one model inherits another (e.g. res.users inherits res.partner) and new custom
+field is created, then same field is created for inheriting model as well, which should
+be avoided or at least duplicated field should be also manual, but created as base.

--- a/web_field_required_invisible_manager/tests/test_web_field_required_invisible_manager.py
+++ b/web_field_required_invisible_manager/tests/test_web_field_required_invisible_manager.py
@@ -130,3 +130,5 @@ class TestFieldRequiredIvisibleManager(common.SavepointCase):
         self.invisible_title_rec_id.field_id = self.partner_title_name_field_id
         self.invisible_title_rec_id.onchange_field_id()
         self.assertTrue(self.invisible_title_rec_id.required)
+        # unlink
+        self.invisible_rec_id.unlink()


### PR DESCRIPTION
- Add dependency to compute of restriction fields (fields from domain)
- Search only for manual state  fields
- Unlink created fields

TODO
When one model inherits another (e.g. res.users inherits res.partner) and new custom field is created, then same field is created for inheriting model as well, which should be avoided or at least duplicated field should be also manual, but created as base. I could not catch it in the create method. 