### PR TITLE
[16][FIX] web_remember_tree_column_width : Column resizing with list_button column

### DIFF
--- a/web_remember_tree_column_width/static/src/js/list_renderer.esm.js
+++ b/web_remember_tree_column_width/static/src/js/list_renderer.esm.js
@@ -11,10 +11,15 @@ patch(ListRenderer.prototype, "web_remember_tree_column_width.ListRenderer", {
     computeColumnWidthsFromContent() {
         const columnWidths = this._super.apply(this, arguments);
         const table = this.tableRef.el;
-        const thElements = [...table.querySelectorAll("thead th:not(.o_list_button)")];
+        const thElements = [...table.querySelectorAll("thead th")];
         thElements.forEach((el, elIndex) => {
             const fieldName = $(el).data("name");
-            if (this.props.list.resModel && fieldName && browser.localStorage) {
+            if (
+                !el.classList.contains("o_list_button") &&
+                this.props.list.resModel &&
+                fieldName &&
+                browser.localStorage
+            ) {
                 const storedWidth = browser.localStorage.getItem(
                     `odoo.columnWidth.${this.props.list.resModel}.${fieldName}`
                 );


### PR DESCRIPTION
Fix an error when retrieving column sizes for lists containing one or more list_button columns.
This error occurs when a list_button column is placed between other columns in the list. This type of column is excluded from the querySelector string used to retrieve column headers, which can cause the index to shift and the column size to change when the list is displayed.
