### PR TITLE
[15.0][FIX] web_advanced_search: search more filters

### DIFF
--- a/web_advanced_search/static/src/js/owl/dropdown.esm.js
+++ b/web_advanced_search/static/src/js/owl/dropdown.esm.js
@@ -1,0 +1,20 @@
+/** @odoo-module **/
+
+import {Dropdown} from "@web/core/dropdown/dropdown";
+import {patch} from "web.utils";
+
+patch(Dropdown.prototype, "web.Dropdown", {
+    /**
+     * Our many2one widget in the filter menus has a dropdown that propagates some
+     * custom events through the bus to the search more pop-up. This is not replicable
+     * in core but we can simply cut it here
+     * @override
+     */
+    onDropdownStateChanged(args) {
+        const direct_siblings = args.emitter.el.parentElement === this.el.parentElement;
+        if (!direct_siblings && args.emitter.myActiveEl !== this.myActiveEl) {
+            return;
+        }
+        return this._super(...arguments);
+    },
+});


### PR DESCRIPTION
Fix advanced filters in the popup window

To investigate: try to do a `bus.off` over our fake many2one component for that custom event

cc @Tecnativa TT44025