### PR TITLE
[14.0][FIX] web_widget_domain_editor_dialog: keep context

### DIFF
--- a/web_widget_domain_editor_dialog/static/src/js/basic_fields.js
+++ b/web_widget_domain_editor_dialog/static/src/js/basic_fields.js
@@ -26,6 +26,10 @@ odoo.define("web_widget_domain_editor_dialog.basic_fields", function (require) {
                 readonly: false,
                 disable_multiple_selection: false,
                 no_create: true,
+                context: this.record.getContext({
+                    fieldName: this.name,
+                    viewType: this.viewType,
+                }),
                 on_selected: function (selected_ids) {
                     _this.inDomainEditor = true;
                     _this.domainSelector


### PR DESCRIPTION
fw of https://github.com/OCA/web/pull/2641

The dialog needs to keep the context so translations and other things work as expected.

cc @Tecnativa TT45543

please review @CarlosRoca13 @pedrobaeza 
