### PR TITLE
[FIX][16.0] web_chatter_position: special case of sided chatter pos in mass mailing module

### DIFF
--- a/web_chatter_position/static/src/js/web_chatter_position.esm.js
+++ b/web_chatter_position/static/src/js/web_chatter_position.esm.js
@@ -113,6 +113,10 @@ patch(FormCompiler.prototype, "web_chatter_position", {
             // For "sided", we have to remote the bottom chatter
             // (except if there is an attachment viewer, as we have to force bottom)
         } else if (odoo.web_chatter_position === "sided") {
+            const formSheetBgXml = res.querySelector(".o_form_sheet_bg");
+            if (!formSheetBgXml) {
+                return res;
+            }
             chatterContainerHookXml.setAttribute("t-if", false);
             // For "bottom", we keep the chatter in the form sheet
             // (the one used for the attachment viewer case)


### PR DESCRIPTION
- Because the chatter in mass mailing form view lie under a notebook tab, if user choose sided chatter, it will disappear
Video before the fix:

https://github.com/OCA/web/assets/56789189/219c1bcb-c596-42f1-bfff-3a92317dd0f6



Video after the fix:

https://github.com/OCA/web/assets/56789189/6804c1b5-3f6b-413b-8567-457e2b3def0c

