### PR TITLE
[16.0][FIX] web_calendar_slot_duration: custom event length

### DIFF
--- a/web_calendar_slot_duration/static/src/js/calendar_model.esm.js
+++ b/web_calendar_slot_duration/static/src/js/calendar_model.esm.js
@@ -9,6 +9,7 @@ import {patch} from "@web/core/utils/patch";
 patch(CalendarModel.prototype, "WebCalendarSlotDurationCalendarModel", {
     buildRawRecord(partialRecord, options = {}) {
         if (
+            !partialRecord.end &&
             this.env.searchModel.context.calendar_slot_duration &&
             !partialRecord.isAllDay
         ) {


### PR DESCRIPTION
When we specify the date in the calendar event we should not force the duration.

cc @Tecnativa TT45649

please review @pedrobaeza @CarlosRoca13 @CRogos