### PR TITLE
[16.0][FIX] web_responsive: overlapping issue

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.scss
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.scss
@@ -10,7 +10,7 @@
     position: fixed;
     margin: 0;
     width: 100vw;
-    z-index: 10000;
+    z-index: 1000;
     left: 0 !important;
 }
 

--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -393,3 +393,7 @@ body:not(.o_statusbar_buttons) {
         background-color: lighten($o-brand-primary, 40%);
     }
 }
+
+.o_searchview_autocomplete {
+    z-index: 999;
+}


### PR DESCRIPTION
Hi there,

Based on the report by @gpothier here https://github.com/OCA/web/commit/5de47a859287bbd71cd0532a739a0f943d6384ad#commitcomment-131721969, it seems that my commit in PR #2654 is causing the User menu to disappear when the Apps menu is shown. I've made the necessary changes to both revert the problematic commit and introduce specific changes to address this issue.

Please let me know if there are any further adjustments.

Thank you for your review!