### PR TITLE
[16.0][FIX] web_dark_mode: Add fields to field lists

### DIFF
--- a/web_dark_mode/models/res_users.py
+++ b/web_dark_mode/models/res_users.py
@@ -10,3 +10,17 @@ class ResUsers(models.Model):
 
     dark_mode = fields.Boolean()
     dark_mode_device_dependent = fields.Boolean("Device Dependent Dark Mode")
+
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + [
+            "dark_mode_device_dependent",
+            "dark_mode",
+        ]
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + [
+            "dark_mode_device_dependent",
+            "dark_mode",
+        ]


### PR DESCRIPTION
**Exception:**
- Access denied error because a non-admin user doesn't have access to their own HR fields

**Reproduction:**
- Database with hr and web_dark_mode
- Create new regular user (non-admin) with an employee linked
- Log in as the user and go to your own profile (top right corner > Profile/Preferences)

