### PR TITLE
[16.0] web_m2x_options: impossible to open a mass mailing

### DIFF
--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -284,7 +284,7 @@ try {
             "@mass_mailing/js/mailing_m2o_filter"
         );
         if (installed_mass_mailing) {
-            var FieldMany2OneMailingFilter = await odoo.runtimeImport(
+            const {FieldMany2OneMailingFilter} = await odoo.runtimeImport(
                 "@mass_mailing/js/mailing_m2o_filter"
             );
             FieldMany2OneMailingFilter.props = {


### PR DESCRIPTION
When you try to open a mass.mailing

```
JS Issue:
OwlError: Invalid props for component 'FieldMany2OneMailingFilter': unknown key 'searchMore', unknown key 'nodeOptions'
    at Object.validateProps (https://odoo.simplyfeu.com/web/assets/1913698-b61fd5b/web.assets_common.min.js:1698:67)
    at Field.template (eval at compile (https://odoo.simplyfeu.com/web/assets/1913698-b61fd5b/web.assets_common.min.js:2057:374), <anonymous>:17:13)
    at Fiber._render (https://odoo.simplyfeu.com/web/assets/1913698-b61fd5b/web.assets_common.min.js:1496:96)
    at Fiber.render (https://odoo.simplyfeu.com/web/assets/1913698-b61fd5b/web.assets_common.min.js:1495:6)
    at ComponentNode.initiateRender (https://odoo.simplyfeu.com/web/assets/1913698-b61fd5b/web.assets_common.min.js:1563:47)
```