### PR TITLE
[14.0][IMP] web_notify

### DIFF
--- a/web_notify/models/res_users.py
+++ b/web_notify/models/res_users.py
@@ -56,7 +56,7 @@ class ResUsers(models.Model):
         self, type_message=DEFAULT, message=DEFAULT_MESSAGE, title=None, sticky=False
     ):
         # pylint: disable=protected-access
-        if not self.env.user._is_admin() and any(
+        if not (self.env.user._is_admin() or self.env.su) and any(
             user.id != self.env.uid for user in self
         ):
             raise exceptions.UserError(


### PR DESCRIPTION
When trying to use the notify function that comes from a normal user with sudo flag enabled, it wasn't letting the user access it. Adding the su flag to the check should allow sudo users using this feature.

@ForgeFlow