### PR TITLE
[14.0][FIX] web_notify_channel_message

### DIFF
--- a/web_notify_channel_message/models/__init__.py
+++ b/web_notify_channel_message/models/__init__.py
@@ -1,1 +1,2 @@
 from . import mail_channel
+from . import res_users

--- a/web_notify_channel_message/models/mail_channel.py
+++ b/web_notify_channel_message/models/mail_channel.py
@@ -1,5 +1,4 @@
-# pylint: disable=missing-docstring
-# Copyright 2016 ACSONE SA/NV
+# Copyright 2023 ForgeFlow
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, models
@@ -15,7 +14,7 @@ class MailChannel(models.Model):
             for user in users:
                 if user in message.author_id.user_ids:
                     continue
-                user.notify_info(
+                user.with_context(_notify_channel_message=True).notify_info(
                     message=_("You have a new message in channel %s") % self.name
                 )
         return message

--- a/web_notify_channel_message/models/res_users.py
+++ b/web_notify_channel_message/models/res_users.py
@@ -1,0 +1,31 @@
+from odoo import models
+
+from odoo.addons.web_notify.models.res_users import DEFAULT, DEFAULT_MESSAGE
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _notify_channel(
+        self,
+        type_message=DEFAULT,
+        message=DEFAULT_MESSAGE,
+        title=None,
+        sticky=False,
+        params=None,
+    ):
+        if self.env.context.get("_notify_channel_message", False):
+            return super(ResUsers, self.sudo())._notify_channel(
+                type_message=type_message,
+                message=message,
+                title=title,
+                sticky=sticky,
+                params=params,
+            )
+        return super(ResUsers, self)._notify_channel(
+            type_message=type_message,
+            message=message,
+            title=title,
+            sticky=sticky,
+            params=params,
+        )

--- a/web_notify_channel_message/tests/__init__.py
+++ b/web_notify_channel_message/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_notify_channel_message

--- a/web_notify_channel_message/tests/test_notify_channel_message.py
+++ b/web_notify_channel_message/tests/test_notify_channel_message.py
@@ -1,0 +1,72 @@
+# Copyright 2023 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import api
+from odoo.tests import common
+
+
+class TestWebNotifyChannelMessage(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestWebNotifyChannelMessage, cls).setUpClass()
+        cls.env.user = cls.env.ref("base.user_admin")
+        cls.other_user = cls.env.ref("base.user_demo")
+        cls.env = api.Environment(cls.cr, cls.env.user.id, {})
+        cls.env.user.tz = False  # Make sure there's no timezone in user
+        cls.user_internal = cls.env["res.users"].create(
+            {
+                "name": "Test Internal User",
+                "login": "internal_user",
+                "password": "internal_user",
+                "email": "mark.brown23@example.com",
+            }
+        )
+        cls.channel = cls.env["mail.channel"].create(
+            {
+                "name": "Test channel",
+                "channel_partner_ids": [
+                    (4, cls.env.user.partner_id.id),
+                    (4, cls.user_internal.partner_id.id),
+                ],
+            }
+        )
+
+    def test_01_post_message_admin(self):
+        initial_message = (
+            self.env["mail.channel"]
+            .search([("name", "=", "Test channel")], limit=1)
+            .message_ids
+        )
+        self.assertEqual(len(initial_message), 0)
+        self.channel.message_post(
+            author_id=self.env.user.partner_id.id,
+            body="Hello",
+            message_type="notification",
+            subtype_xmlid="mail.mt_comment",
+        )
+        message = (
+            self.env["mail.channel"]
+            .search([("name", "=", "Test channel")], limit=1)
+            .message_ids[0]
+        )
+        self.assertEqual(len(message), 1)
+
+    def test_02_post_message_non_admin(self):
+        initial_message = (
+            self.env["mail.channel"]
+            .search([("name", "=", "Test channel")], limit=1)
+            .message_ids
+        )
+        self.assertEqual(len(initial_message), 0)
+        self.channel.with_user(self.other_user).message_post(
+            author_id=self.other_user.partner_id.id,
+            body="Hello",
+            message_type="notification",
+            subtype_xmlid="mail.mt_comment",
+        )
+        message = (
+            self.env["mail.channel"]
+            .search([("name", "=", "Test channel")], limit=1)
+            .message_ids[0]
+        )
+        self.assertEqual(len(message), 1)


### PR DESCRIPTION
If other user than the admin is trying to send a message to a channel it will show an error message. Sending it as sudo solves the problem and makes sense that in this case you will always want to send the notification.

@ForgeFlow