### PR TITLE
[16.0][FIX] web_notify_channel_message

### DIFF
--- a/web_notify_channel_message/models/__init__.py
+++ b/web_notify_channel_message/models/__init__.py
@@ -1,1 +1,2 @@
 from . import mail_channel
+from . import res_users

--- a/web_notify_channel_message/models/mail_channel.py
+++ b/web_notify_channel_message/models/mail_channel.py
@@ -14,7 +14,7 @@ class MailChannel(models.Model):
             for user in users:
                 if user in message.author_id.user_ids:
                     continue
-                user.notify_info(
+                user.with_context(_notify_channel_message=True).notify_info(
                     message=_("You have a new message in channel %s") % self.name
                 )
 

--- a/web_notify_channel_message/models/res_users.py
+++ b/web_notify_channel_message/models/res_users.py
@@ -1,0 +1,40 @@
+from odoo import models
+
+from odoo.addons.web_notify.models.res_users import DEFAULT, DEFAULT_MESSAGE
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _notify_channel(
+        self,
+        type_message=DEFAULT,
+        message=DEFAULT_MESSAGE,
+        title=None,
+        sticky=False,
+        target=None,
+        action=None,
+        params=None,
+        sound=None,
+    ):
+        if self.env.context.get("_notify_channel_message", False):
+            return super(ResUsers, self.sudo())._notify_channel(
+                type_message=type_message,
+                message=message,
+                title=title,
+                sticky=sticky,
+                target=target,
+                action=action,
+                params=params,
+                sound=sound,
+            )
+        return super(ResUsers, self)._notify_channel(
+            type_message=type_message,
+            message=message,
+            title=title,
+            sticky=sticky,
+            target=target,
+            action=action,
+            params=params,
+            sound=sound,
+        )

--- a/web_notify_channel_message/tests/test_notify_channel_message.py
+++ b/web_notify_channel_message/tests/test_notify_channel_message.py
@@ -10,6 +10,7 @@ class TestWebNotifyChannelMessage(common.TransactionCase):
     def setUpClass(cls):
         super(TestWebNotifyChannelMessage, cls).setUpClass()
         cls.env.user = cls.env.ref("base.user_admin")
+        cls.other_user = cls.env.ref("base.user_demo")
         cls.env = api.Environment(cls.cr, cls.env.user.id, {})
         cls.env.user.tz = False  # Make sure there's no timezone in user
         cls.user_internal = cls.env["res.users"].create(
@@ -30,7 +31,7 @@ class TestWebNotifyChannelMessage(common.TransactionCase):
             }
         )
 
-    def test_01_post_message(self):
+    def test_01_post_message_admin(self):
         initial_message = (
             self.env["mail.channel"]
             .search([("name", "=", "Test channel")], limit=1)
@@ -39,6 +40,26 @@ class TestWebNotifyChannelMessage(common.TransactionCase):
         self.assertEqual(len(initial_message), 0)
         self.channel.message_post(
             author_id=self.env.user.partner_id.id,
+            body="Hello",
+            message_type="notification",
+            subtype_xmlid="mail.mt_comment",
+        )
+        message = (
+            self.env["mail.channel"]
+            .search([("name", "=", "Test channel")], limit=1)
+            .message_ids[0]
+        )
+        self.assertEqual(len(message), 1)
+
+    def test_02_post_message_non_admin(self):
+        initial_message = (
+            self.env["mail.channel"]
+            .search([("name", "=", "Test channel")], limit=1)
+            .message_ids
+        )
+        self.assertEqual(len(initial_message), 0)
+        self.channel.with_user(self.other_user).message_post(
+            author_id=self.other_user.partner_id.id,
             body="Hello",
             message_type="notification",
             subtype_xmlid="mail.mt_comment",


### PR DESCRIPTION
If other user than the admin is trying to send a message to a channel it will show an error message. Sending it as sudo solves the problem and makes sense that in this case you will always want to send the notification.

Depends on #2676 

Forward port of #2674 

@ForgeFlow