### PR TITLE
[FIX] web_responsive: Missing key in search panel filter component OWL

### DIFF
--- a/web_responsive/static/src/components/search_panel/search_panel.esm.js
+++ b/web_responsive/static/src/components/search_panel/search_panel.esm.js
@@ -43,6 +43,7 @@ patch(SearchPanel.prototype, "web_responsive.SearchPanelMobile", {
             }
             if (filterValues.length) {
                 selection.push({
+                    id: filter.id,
                     values: filterValues,
                     icon: filter.icon,
                     color: filter.color,

--- a/web_responsive/static/src/components/search_panel/search_panel.xml
+++ b/web_responsive/static/src/components/search_panel/search_panel.xml
@@ -12,7 +12,12 @@
                 <div class="d-flex flex-wrap align-items-center">
                     <i class="fa fa-fw fa-filter mr-1" />
                     <t t-set="filters" t-value="getActiveSummary()" />
-                    <span t-foreach="filters" t-as="filter" class="mx-1">
+                    <span
+                        t-foreach="filters"
+                        t-as="filter"
+                        t-key="filter.id"
+                        class="mx-1"
+                    >
                         <i
                             t-if="filter.icon"
                             t-attf-class="fa {{ filter.icon }} mr-2"


### PR DESCRIPTION
Fixes #2653

Owl requires the presence of a t-key directive in [t-foreach](https://github.com/odoo/owl/blob/master/doc/reference/templates.md#loops) to be able to properly reconcile renderings.

The owl template in `web_responsive/static/src/components/search_panel/search_panel.xml` missed the t-key directive. Hence the crash.

This commit introduces this `t-key` and ensures that it is unique.