### PR TITLE
[FIX][16.0] web_responsive: broken delete message confirm dialog UI

### DIFF
--- a/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
+++ b/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
@@ -6,7 +6,7 @@
 .o_web_client .o_DialogManager_dialog {
     /* Show sided viewer on large screens */
     @media (min-width: 1533px) {
-        &:not(:has(.o_AttachmentDeleteConfirm)) {
+        &:has(.o_AttachmentViewer) {
             position: static;
         }
         .o_AttachmentViewer_main {


### PR DESCRIPTION
The error will mostly occur with Chrome and Chromium core browsers. Firefox doesn't error because it doesn't support `:has` pseudo class :D

Before:
![Screenshot from 2023-11-24 11-54-31](https://github.com/OCA/web/assets/66666640/abac4921-bccc-4708-944f-8df48109d211)


After:
![Screenshot from 2023-11-24 11-53-54](https://github.com/OCA/web/assets/66666640/e302fe8c-57e9-4894-a173-9374dbb9fd64)


