### PR TITLE
[16.0][FIX] web_responsive mail_post_access flag works

### DIFF
--- a/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -100,7 +100,7 @@
                                 'btn-odoo': !chatterTopbar.chatter.composerView,
                                 'btn-light': chatterTopbar.chatter.composerView and chatterTopbar.chatter.composerView.composer.isLog,
                             }"
-                            t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
+                            t-att-disabled="!chatterTopbar.chatter.canPostMessage"
                             data-hotkey="m"
                             t-on-click="chatterTopbar.chatter.onClickSendMessage"
                         >


### PR DESCRIPTION
in a threaded model there is a _mail_post_access flag for possibility to post messages in read only objects.

This path fixes the possibility to do it with web_responsive addon