### PR TITLE
[IMP] web_widget_numeric_step: display always on mobile

### DIFF
--- a/web_widget_numeric_step/static/src/js/numeric_step.esm.js
+++ b/web_widget_numeric_step/static/src/js/numeric_step.esm.js
@@ -11,11 +11,11 @@ export class NumericStep extends FloatField {
     }
     _onFocusInput(ev) {
         const $el = $(ev.target).parent().find(".widget_numeric_step_btn");
-        $el.removeClass("d-none");
+        $el.removeClass("d-lg-none");
     }
     _onFocusOutInput(ev) {
         const $el = $(ev.target).find(".widget_numeric_step_btn");
-        $el.addClass("d-none");
+        $el.addClass("d-lg-none");
     }
     _onStepClick(ev) {
         const $el = $(ev.target).parent().parent().find("input");

--- a/web_widget_numeric_step/static/src/xml/numeric_step.xml
+++ b/web_widget_numeric_step/static/src/xml/numeric_step.xml
@@ -11,7 +11,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             t-on-mouseleave="_onFocusOutInput"
             t-on-mouseenter="_onFocusInput"
         >
-            <div class="input-group-prepend d-none widget_numeric_step_btn">
+            <div class="input-group-prepend d-lg-none widget_numeric_step_btn">
                 <button
                     class="fa fa-minus btn btn-default btn_numeric_step"
                     aria-label="Minus"
@@ -27,11 +27,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 t-att-placeholder="props.placeholder"
                 t-att-type="props.inputType"
                 class="o_input input_numeric_step"
+                inputmode="decimal"
                 t-att-step="props.step"
                 t-on-keydown="_onKeyDown"
                 t-on-wheel="_onWheel"
             />
-            <div class="input-group-append d-none widget_numeric_step_btn">
+            <div class="input-group-append d-lg-none widget_numeric_step_btn">
                 <button
                     class="fa fa-plus btn btn-default btn_numeric_step"
                     aria-label="Plus"


### PR DESCRIPTION
Mobile screens benefit most from this module's enhanced usability.

However, since the events used for displaying/hiding the +/- buttons depend on mouse, at the end you'll never see these buttons on mobile screens.

Thus, here's a new approach: smaller screens *always* display the buttons.
![imagen](https://github.com/OCA/web/assets/973709/5b581fa7-939d-4b3b-8cb9-6107d90c087c)


@moduon MT-4396