### PR TITLE
[FIX] web_widget_numeric_step: disable buttons on readonly fields

### DIFF
--- a/web_widget_numeric_step/static/src/xml/numeric_step.xml
+++ b/web_widget_numeric_step/static/src/xml/numeric_step.xml
@@ -18,6 +18,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     title="Minus"
                     type="button"
                     data-mode="minus"
+                    t-att-disabled="props.readonly"
                     t-on-click="_onStepClick"
                 />
             </div>
@@ -39,6 +40,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     title="Plus"
                     type="button"
                     data-mode="plus"
+                    t-att-disabled="props.readonly"
                     t-on-click="_onStepClick"
                 />
             </div>


### PR DESCRIPTION
Before this patch, if a field was readonly, the user could still use the +/- buttons to alter its value. Not good!

@moduon MT-4396