### PR TITLE
[16.0][FIX] web_responsive: Show Attachment Preview By Default In Form view

### DIFF
--- a/web_responsive/__init__.py
+++ b/web_responsive/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -19,10 +19,9 @@
     "development_status": "Production/Stable",
     "maintainers": ["Yajo", "Tardo", "SplashS"],
     "excludes": ["web_enterprise"],
-    "data": ["views/web.xml"],
+    "data": ["views/web.xml", "views/res_users.xml"],
     "assets": {
         "web.assets_backend": [
-            "/web_responsive/static/src/views/form/form_controller.esm.js",
             "/web_responsive/static/src/legacy/scss/web_responsive.scss",
             "/web_responsive/static/src/legacy/js/web_responsive.js",
             "/web_responsive/static/src/components/ui_context.esm.js",
@@ -44,6 +43,7 @@
             "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.esm.js",
             "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.xml",
             "/web_responsive/static/src/views/form/form_controller.scss",
+            "/web_responsive/static/src/views/form/form_controller.esm.js",
         ],
         "web.assets_tests": [
             "/web_responsive/static/tests/test_patch.js",

--- a/web_responsive/models/__init__.py
+++ b/web_responsive/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_users

--- a/web_responsive/models/res_users.py
+++ b/web_responsive/models/res_users.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Onestein - Anjeel Haria
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    allow_attachment_preview = fields.Selection(
+        [
+            ("yes", "Yes"),
+            ("no", "No"),
+        ],
+        default="no",
+        help="Allows attachments to be previewed in form view by default",
+    )
+
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS + ["allow_attachment_preview"]
+
+    @property
+    def SELF_WRITEABLE_FIELDS(self):
+        return super().SELF_WRITEABLE_FIELDS + ["allow_attachment_preview"]

--- a/web_responsive/readme/DESCRIPTION.rst
+++ b/web_responsive/readme/DESCRIPTION.rst
@@ -22,6 +22,8 @@ This module adds responsiveness to web backend.
 
   .. image:: ../static/img/listview.gif
 
+* Configurable attachment preview from user preferences.
+
 
 **Features for mobile**:
 * View type picker dropdown displays comfortably

--- a/web_responsive/readme/USAGE.rst
+++ b/web_responsive/readme/USAGE.rst
@@ -3,3 +3,6 @@ The following keyboard shortcuts are implemented:
 * Navigate app search results - Arrow keys
 * Choose app result - ``Enter``
 * ``Esc`` to close app drawer
+
+There's a **Allow Attachment Preview** option in **User Preferences**, where you can
+choose between ``yes`` and ``no``. If specified as yes, the preview would be loaded for attachments wherever added else the preview would not be loaded

--- a/web_responsive/static/src/views/form/form_controller.esm.js
+++ b/web_responsive/static/src/views/form/form_controller.esm.js
@@ -9,6 +9,7 @@ import {FormController} from "@web/views/form/form_controller";
 patch(FormController.prototype, "web_responsive.FormController", {
     setup() {
         this._super();
-        this.hasAttachmentViewerInArch = false;
+        this.hasAttachmentViewerInArch =
+            this.hasAttachmentViewerInArch && odoo.allow_attachment_preview == "yes";
     },
 });

--- a/web_responsive/views/res_users.xml
+++ b/web_responsive/views/res_users.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_users_form_simple_modif" model="ir.ui.view">
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form_simple_modif" />
+        <field name="arch" type="xml">
+            <field name="email" position="after">
+                <field name="allow_attachment_preview" widget="radio" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/web_responsive/views/web.xml
+++ b/web_responsive/views/web.xml
@@ -18,4 +18,14 @@
             />
         </xpath>
     </template>
+
+     <template id="webclient_bootstrap" inherit_id="web.webclient_bootstrap">
+        <t t-set="head_web" position="inside">
+            <script type="text/javascript">
+                odoo.allow_attachment_preview = "<t
+                    t-out="request.env.user.allow_attachment_preview"
+                />";
+            </script>
+        </t>
+    </template>
 </odoo>


### PR DESCRIPTION
This commit would allow the attachment previews to load by default wherever applicable like for Invoices.
Check the following screenshot for invoices before this change:
![Before Change](https://github.com/OCA/web/assets/88703470/7488bcf3-d098-48c2-a652-b427064dbd1c)
Check the following screenshot for invoices after this change is merged:
![After Change](https://github.com/OCA/web/assets/88703470/fd54e069-ce19-4010-9f40-806fb21566f7)
