### PR TITLE
[15.0][IMP] web_notify html format

### DIFF
--- a/web_notify/models/res_users.py
+++ b/web_notify/models/res_users.py
@@ -42,34 +42,59 @@ class ResUsers(models.Model):
     notify_default_channel_name = fields.Char(compute="_compute_channel_names")
 
     def notify_success(
-        self, message="Default message", title=None, sticky=False, target=None
+        self,
+        message="Default message",
+        title=None,
+        sticky=False,
+        target=None,
+        html=False,
     ):
         title = title or _("Success")
-        self._notify_channel(SUCCESS, message, title, sticky, target)
+        self._notify_channel(SUCCESS, message, title, sticky, target, html)
 
     def notify_danger(
-        self, message="Default message", title=None, sticky=False, target=None
+        self,
+        message="Default message",
+        title=None,
+        sticky=False,
+        target=None,
+        html=False,
     ):
         title = title or _("Danger")
-        self._notify_channel(DANGER, message, title, sticky, target)
+        self._notify_channel(DANGER, message, title, sticky, target, html)
 
     def notify_warning(
-        self, message="Default message", title=None, sticky=False, target=None
+        self,
+        message="Default message",
+        title=None,
+        sticky=False,
+        target=None,
+        html=False,
     ):
         title = title or _("Warning")
-        self._notify_channel(WARNING, message, title, sticky, target)
+        self._notify_channel(WARNING, message, title, sticky, target, html)
 
     def notify_info(
-        self, message="Default message", title=None, sticky=False, target=None
+        self,
+        message="Default message",
+        title=None,
+        sticky=False,
+        target=None,
+        html=False,
     ):
         title = title or _("Information")
-        self._notify_channel(INFO, message, title, sticky, target)
+        self._notify_channel(INFO, message, title, sticky, target, html)
 
     def notify_default(
-        self, message="Default message", title=None, sticky=False, target=None
+        self,
+        message="Default message",
+        title=None,
+        sticky=False,
+        target=None,
+        html=False,
     ):
         title = title or _("Default")
-        self._notify_channel(DEFAULT, message, title, sticky, target)
+        self._notify_channel(DEFAULT, message, title, sticky, target, html)
 
     def _notify_channel(
         self,
@@ -78,6 +103,7 @@ class ResUsers(models.Model):
         title=None,
         sticky=False,
         target=None,
+        html=False,
     ):
         if not (self.env.user._is_admin() or self.env.su) and any(
             user.id != self.env.uid for user in self
@@ -92,6 +118,7 @@ class ResUsers(models.Model):
             "message": message,
             "title": title,
             "sticky": sticky,
+            "html": html,
         }
 
         notifications = [[partner, "web.notify", [bus_message]] for partner in target]

--- a/web_notify/static/src/js/services/notification_services.esm.js
+++ b/web_notify/static/src/js/services/notification_services.esm.js
@@ -24,6 +24,7 @@ export const webNotificationService = {
                         type: notif.type,
                         sticky: notif.sticky,
                         className: notif.className,
+                        messageIsHtml: notif.html,
                     });
                 });
             });

--- a/web_notify/tests/test_res_users.py
+++ b/web_notify/tests/test_res_users.py
@@ -14,7 +14,12 @@ class TestResUsers(common.TransactionCase):
         bus_bus = self.env["bus.bus"]
         domain = [("channel", "=", self.env.user.notify_success_channel_name)]
         existing = bus_bus.search(domain)
-        test_msg = {"message": "message", "title": "title", "sticky": True}
+        test_msg = {
+            "message": "message",
+            "title": "title",
+            "sticky": True,
+            "html": False,
+        }
         self.env.user.notify_success(**test_msg)
         news = bus_bus.search(domain) - existing
         self.assertEqual(1, len(news))
@@ -26,7 +31,12 @@ class TestResUsers(common.TransactionCase):
         bus_bus = self.env["bus.bus"]
         domain = [("channel", "=", self.env.user.notify_danger_channel_name)]
         existing = bus_bus.search(domain)
-        test_msg = {"message": "message", "title": "title", "sticky": True}
+        test_msg = {
+            "message": "message",
+            "title": "title",
+            "sticky": True,
+            "html": False,
+        }
         self.env.user.notify_danger(**test_msg)
         news = bus_bus.search(domain) - existing
         self.assertEqual(1, len(news))
@@ -38,7 +48,12 @@ class TestResUsers(common.TransactionCase):
         bus_bus = self.env["bus.bus"]
         domain = [("channel", "=", self.env.user.notify_warning_channel_name)]
         existing = bus_bus.search(domain)
-        test_msg = {"message": "message", "title": "title", "sticky": True}
+        test_msg = {
+            "message": "message",
+            "title": "title",
+            "sticky": True,
+            "html": False,
+        }
         self.env.user.notify_warning(**test_msg)
         news = bus_bus.search(domain) - existing
         self.assertEqual(1, len(news))
@@ -50,7 +65,12 @@ class TestResUsers(common.TransactionCase):
         bus_bus = self.env["bus.bus"]
         domain = [("channel", "=", self.env.user.notify_info_channel_name)]
         existing = bus_bus.search(domain)
-        test_msg = {"message": "message", "title": "title", "sticky": True}
+        test_msg = {
+            "message": "message",
+            "title": "title",
+            "sticky": True,
+            "html": False,
+        }
         self.env.user.notify_info(**test_msg)
         news = bus_bus.search(domain) - existing
         self.assertEqual(1, len(news))
@@ -62,7 +82,12 @@ class TestResUsers(common.TransactionCase):
         bus_bus = self.env["bus.bus"]
         domain = [("channel", "=", self.env.user.notify_default_channel_name)]
         existing = bus_bus.search(domain)
-        test_msg = {"message": "message", "title": "title", "sticky": True}
+        test_msg = {
+            "message": "message",
+            "title": "title",
+            "sticky": True,
+            "html": False,
+        }
         self.env.user.notify_default(**test_msg)
         news = bus_bus.search(domain) - existing
         self.assertEqual(1, len(news))


### PR DESCRIPTION
In v12 the message was rendered as HTML
This restore that as an option