### PR TITLE
[FIX] web_widget_numeric_step: no input focus on touch screens

### DIFF
--- a/web_widget_numeric_step/static/src/numeric_step.esm.js
+++ b/web_widget_numeric_step/static/src/numeric_step.esm.js
@@ -4,6 +4,7 @@ import {registry} from "@web/core/registry";
 import {standardFieldProps} from "@web/views/fields/standard_field_props";
 import {_lt} from "@web/core/l10n/translation";
 import {FloatField} from "@web/views/fields/float/float_field";
+import {hasTouch} from "@web/core/browser/feature_detection";
 
 export class NumericStep extends FloatField {
     setup() {
@@ -11,7 +12,9 @@ export class NumericStep extends FloatField {
     }
     _onStepClick(ev) {
         const $el = $(ev.target).parent().parent().find("input");
-        $el.focus();
+        if (!hasTouch()) {
+            $el.focus();
+        }
         const mode = $(ev.target).data("mode");
         this._doStep(mode);
     }


### PR DESCRIPTION
If you're using a tablet and click on the ➕ or ➖ buttons created by this module, the result was that the numeric input related to that button got focused.

On tablets, that means that the on-screen keyboard pops up. This usually triggers a layout recalculation and becomes clunky. Besides, it's useless, because if you wanted to use the keyboard, you'd have clicked on the input by yourself, and not in one of those buttons.

After this change, when using a touch screen, if you click on the +/- buttons, you won't auto-focus on the input. Thus, the keyboard won't show up.

@moduon MT-4472