### PR TITLE
[16.0][FIX] web_widget_x2many_2d_matrix: cells with no data error

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -133,16 +133,22 @@ export class X2Many2DMatrixRenderer extends Component {
     getValueFieldProps(column, row) {
         const x = this.columns.findIndex((c) => c.value === column);
         const y = this.rows.findIndex((r) => r.value === row);
-        const props = this.list.activeFields[this.matrixFields.value].props;
-        const propsFromAttrs =
-            this.list.activeFields[this.matrixFields.value].propsFromAttrs;
-        const record = this.matrix[y][x].records[0];
-        let value = this.matrix[y][x].value;
-        if (!this._canAggregate()) {
-            value = record.data[this.matrixFields.value];
+        const {props, propsFromAttrs} = this.list.activeFields[this.matrixFields.value];
+        let record = null;
+        let value = null;
+        if (
+            this.matrix[y] &&
+            this.matrix[y][x] &&
+            (record = this.matrix[y][x].records[0])
+        ) {
+            record = this.matrix[y][x].records[0];
+            value = this.matrix[y][x].value;
         }
-
-        return {
+        value =
+            !this._canAggregate() && record
+                ? record.data[this.matrixFields.value]
+                : value;
+        const result = {
             ...props,
             ...propsFromAttrs,
             value: value,
@@ -151,6 +157,10 @@ export class X2Many2DMatrixRenderer extends Component {
             record: record,
             name: this.matrixFields.value,
         };
+        if (value === null) {
+            result.readonly = true;
+        }
+        return result;
     }
 }
 


### PR DESCRIPTION
The code was modified to properly handle missing data related to a row/column set, allowing the matrix to generate blank spaces instead of causing Owl errors.
[Issue](https://github.com/OCA/web/issues/2651)