### PR TITLE
[16.0][FIX] web_timeline: Wrap fields_get arg into a list

### DIFF
--- a/web_timeline/readme/CONTRIBUTORS.rst
+++ b/web_timeline/readme/CONTRIBUTORS.rst
@@ -10,6 +10,12 @@
   * Pedro M. Baeza
   * Alexandre Díaz
   * César A. Sánchez
+
 * `Onestein <https://www.onestein.nl>`_:
-    * Dennis Sluijk <d.sluijk@onestein.nl>
-    * Anjeel Haria
+
+  * Dennis Sluijk <d.sluijk@onestein.nl>
+  * Anjeel Haria
+
+* `XCG Consulting <https://xcg-consulting.fr>`_:
+
+  * Houzéfa Abbasbhay

--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -399,7 +399,7 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                             await this._rpc({
                                 model: this.modelName,
                                 method: "fields_get",
-                                args: [grouped_field],
+                                args: [[grouped_field]],
                                 context: this.getSession().user_context,
                             }).then(async (fields) => {
                                 if (fields[grouped_field].type === "many2many") {


### PR DESCRIPTION
By contract the first argument of the `fields_get` method is supposed to be a list. Before this fix, `web_timeline` would call `fields_get` with a string instead of a list.

Fortunately in case only 1 field is being grouped, this worked as Odoo does an `x in y` comparison [in its `fields_get` implementation](https://github.com/odoo/odoo/blob/16.0/odoo/models.py#L2852), which does pass in a simple `"project_id" in "project_id"` case.

But that call remains invalid and can break when `fields_get` has been tweaked by other modules.

Here is Odoo code that does this right (with `[[` instead of just `[`): https://github.com/odoo/odoo/blob/16.0/addons/website/static/src/js/editor/snippets.options.js#L53

I checked this with [OCA's `project_timeline`](https://github.com/OCA/project/tree/16.0/project_timeline) module:
![Screenshot at 2024-01-08 18-15-15](https://github.com/OCA/web/assets/6347423/b7f7f657-0984-4dc5-b9dd-91904aa040d5)
