### PR TITLE
[FIX] web_widget_numeric_step: restore tab navigation

### DIFF
--- a/web_widget_numeric_step/static/src/numeric_step.xml
+++ b/web_widget_numeric_step/static/src/numeric_step.xml
@@ -11,6 +11,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <button
                     class="fa fa-minus btn btn-default btn_numeric_step"
                     aria-label="Minus"
+                    tabindex="-1"
                     title="Minus"
                     type="button"
                     data-mode="minus"
@@ -33,6 +34,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <button
                     class="fa fa-plus btn btn-default btn_numeric_step"
                     aria-label="Plus"
+                    tabindex="-1"
                     title="Plus"
                     type="button"
                     data-mode="plus"


### PR DESCRIPTION
Before this patch, when navigating inputs hitting <kbd>TAB</kbd>, you were stopped before any numeric step input.

Now, you can navigate as usual and use Odoo without a 🐁.

@moduon MT-4657