### PR TITLE
[16.0][IMP] web_remember_tree_column_width: adjust SCSS selector

### DIFF
--- a/web_remember_tree_column_width/static/src/scss/main.scss
+++ b/web_remember_tree_column_width/static/src/scss/main.scss
@@ -1,4 +1,4 @@
-th.o_column_sortable {
+div.o_list_renderer > table.o_list_table th:not(.o_list_controller) {
     max-width: none !important;
     min-width: 0 !important;
 }


### PR DESCRIPTION
This PR fixes the issue https://github.com/OCA/web/issues/2717

Technical note:
- Previously, only columns with the class o_column_sortable had the custom SCSS applied to them. As a result, columns like HTML were not sortable and didn't benefit from the custom SCSS.
- This pull request made changes to the SCSS selector to include all table columns in the list view. However, the record selector (the first checkbox column) and column optional (the last column) that have the class o_list_controller were excluded.

