### PR TITLE
[FIX] web_widget_numeric_step: list view column min width

### DIFF
--- a/web_widget_numeric_step/static/src/numeric_step.scss
+++ b/web_widget_numeric_step/static/src/numeric_step.scss
@@ -12,3 +12,11 @@
         visibility: visible;
     }
 }
+
+.o_numeric_step_cell {
+    // Default for old browsers
+    min-width: 15 * $btn-padding-x;
+    // Value hardcoded in `FIXED_FIELD_COLUMN_WIDTHS.float` + width of 2
+    // FontAwesome icons + 2 buttons * 2 horizontal paddings
+    min-width: calc(92px + 2ex + 4 * #{$btn-padding-x});
+}


### PR DESCRIPTION
Default width is too narrow for these fields in list views, which makes it uncomfortable to use in desktops.

For example, a sale order after installing `sale_numeric_step`:

| Before | After |
| --- | --- |
| ![imagen](https://github.com/OCA/web/assets/973709/3436ba98-b336-42c3-a7fc-fdb892f21737) | ![imagen](https://github.com/OCA/web/assets/973709/c566cd35-2586-4ead-b8eb-0dcc9ee9b57f) |

@moduon MT-4472