### PR TITLE
[16.0][FIX] web_responsive: fix z-index on toolbar to prevent being on background in modals

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -372,7 +372,7 @@ html .o_web_client .o_action_manager .o_action {
 
 body:not(.o_statusbar_buttons) {
     .oe-toolbar {
-        z-index: 0 !important;
+        z-index: 0;
     }
 }
 


### PR DESCRIPTION
Prevent the tools bar which is appearing when selecting text to be behind the modal (e.g when sending quote by mail).