### PR TITLE
[12.0] web_widget_image_url: add html class to img as standard the standard widget

### DIFF
--- a/web_widget_image_url/static/src/xml/web_widget_image_url.xml
+++ b/web_widget_image_url/static/src/xml/web_widget_image_url.xml
@@ -6,7 +6,7 @@
 <templates xml:space="preserve">
     <t t-name="FieldImageURL">
         <span class="oe_form_field oe_form_field_image" t-att-style="widget.attrs.style">
-            <img t-att-src="widget.url()"
+            <img class="img img-fluid" t-att-src="widget.url()"
             t-att-style="(!widget.readonly ? 'border: 0' : 'border: 1')"
             t-att-name="widget.name"
             t-att-width="widget.attrs.img_width || widget.attrs.width"


### PR DESCRIPTION
Add html class to the widget in order to behave the same as FieldBinaryWidget-img.
This allows to respect the colspan rules and contains large images
without breaking the view.

Same as:
https://github.com/odoo/odoo/blob/12.0/addons/web/static/src/xml/base.xml#L953C9-L953C31

Before:
![Screenshot from 2024-02-08 16-57-40](https://github.com/OCA/web/assets/4158438/c69f174f-2e02-458c-a2a9-0831b4eae3b2)

After:
![Screenshot from 2024-02-08 16-58-29](https://github.com/OCA/web/assets/4158438/0bd2811a-b118-4b5c-8eda-cc236bcab826)
