### PR TITLE
[16.0] web_refresher: add ability to auto-refresh and make it configurable from view action

### DIFF
--- a/web_refresher/static/src/js/refresher.esm.js
+++ b/web_refresher/static/src/js/refresher.esm.js
@@ -3,26 +3,48 @@
  * Copyright 2022 Tecnativa - Carlos Roca
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
-const {Component} = owl;
-import {useService} from "@web/core/utils/hooks";
+import { Component, onMounted, onWillUnmount } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
 
 export class Refresher extends Component {
     setup() {
         super.setup();
-        this.action = useService("action");
+        this.actionService = useService("action");
+
+        onWillUnmount(this._cancelRefresh);
+
+        onMounted(async () => {
+
+            //console.debug("MOUNTED", this);
+
+            const action    = await this.actionService.loadAction(this.env.config.actionId);
+            const checkBox  = this.__owl__.bdom.el.querySelector('input#web_refresher_automatic');
+
+            //console.debug("MOUNTED LOADED", action, checkBox);
+
+            if (checkBox && action && action.context && action.context.web_refresher_autorefresh) {
+                this._refreshInterval = Number(action.context.web_refresher_autorefresh) || 30;
+                checkBox.checked = true;
+                this._scheduleRefresh(this);
+            }
+
+            this._checkBox = checkBox;
+            this._refreshInterval = this._refreshInterval || 30;
+        });
     }
+
     async _doRefresh() {
-        const viewAction = this.action.currentController.action;
+        const viewAction = this.actionService.currentController.action;
         // Allow refresh reports
         if (["ir.actions.report", "ir.actions.client"].includes(viewAction.type)) {
             const options = {};
             if (this.env.config.breadcrumbs.length > 1) {
                 const breadcrumb = this.env.config.breadcrumbs.slice(-1);
-                await this.action.restore(breadcrumb.jsId);
+                await this.actionService.restore(breadcrumb.jsId);
             } else {
                 options.clearBreadcrumbs = true;
             }
-            return this.action.doAction(viewAction, options);
+            return this.actionService.doAction(viewAction, options);
         }
         // Note: here we use the pager props, see xml
         const {limit, offset} = this.props;
@@ -30,6 +52,33 @@ export class Refresher extends Component {
             return;
         }
         return this.props.onUpdate({offset, limit});
+    }
+
+    _scheduleRefresh(component) {
+        component.__currentTimer = setTimeout(component._autoRefresh, component._refreshInterval*1000, "unused", component);
+    }
+
+    _cancelRefresh() {
+        //console.log("_cancelRefresh", this);
+        if (this.__currentTimer) {
+            clearTimeout(this.__currentTimer);
+        }
+    }
+
+    _autoRefresh(__unused, component) {
+        // when called via setTimeout we have the component as second parameter. otherwise we're 'this'
+        //TODO: use bind()?
+        component = component || this;
+
+        if (component.__owl__.status != 1) {
+            console.warn("web_refresher component no longer active");
+            return;
+        }
+
+        if (component._checkBox && component._checkBox.checked) {
+            component._doRefresh();
+            component._scheduleRefresh(component);
+        }
     }
 }
 

--- a/web_refresher/static/src/js/refresher.esm.js
+++ b/web_refresher/static/src/js/refresher.esm.js
@@ -15,21 +15,23 @@ export class Refresher extends Component {
 
         onMounted(async () => {
 
-            //console.debug("MOUNTED", this);
+            if (this.env && this.env.config && this.env.config.actionId) {
+                console.debug("MOUNTED", this);
 
-            const action    = await this.actionService.loadAction(this.env.config.actionId);
-            const checkBox  = this.__owl__.bdom.el.querySelector('input#web_refresher_automatic');
+                const action    = await this.actionService.loadAction(this.env.config.actionId);
+                const checkBox  = this.__owl__.bdom.el.querySelector('input#web_refresher_automatic');
 
-            //console.debug("MOUNTED LOADED", action, checkBox);
+                console.debug("MOUNTED LOADED", action, checkBox);
 
-            if (checkBox && action && action.context && action.context.web_refresher_autorefresh) {
-                this._refreshInterval = Number(action.context.web_refresher_autorefresh) || 30;
-                checkBox.checked = true;
-                this._scheduleRefresh(this);
+                if (checkBox && action && action.context && action.context.web_refresher_autorefresh) {
+                    this._refreshInterval = Number(action.context.web_refresher_autorefresh) || 30;
+                    checkBox.checked = true;
+                    this._scheduleRefresh(this);
+                }
+
+                this._checkBox = checkBox;
+                this._refreshInterval = this._refreshInterval || 30;
             }
-
-            this._checkBox = checkBox;
-            this._refreshInterval = this._refreshInterval || 30;
         });
     }
 
@@ -59,7 +61,7 @@ export class Refresher extends Component {
     }
 
     _cancelRefresh() {
-        //console.log("_cancelRefresh", this);
+        console.log("_cancelRefresh", this);
         if (this.__currentTimer) {
             clearTimeout(this.__currentTimer);
         }

--- a/web_refresher/static/src/xml/refresher.xml
+++ b/web_refresher/static/src/xml/refresher.xml
@@ -12,6 +12,12 @@
                     title="Refresh"
                     tabindex="-1"
                 />
+                <input
+                    type="checkbox"
+                    t-on-click="_autoRefresh"
+                    id="web_refresher_automatic"
+                    class="btn"
+                />
             </span>
         </nav>
     </t>


### PR DESCRIPTION
Hi there, this is a proposal for merging the auto-refresh feature as we use it.
It reads the view action in onMounted() to be configurable from the view.

If this is not the proper way to implement it, we're happy to enhance it :) 