### PR TITLE
[16.0][FIX] web_responsive: chatter with _mail_post_access read

### DIFF
--- a/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -100,7 +100,7 @@
                                 'btn-odoo': !chatterTopbar.chatter.composerView,
                                 'btn-light': chatterTopbar.chatter.composerView and chatterTopbar.chatter.composerView.composer.isLog,
                             }"
-                            t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
+                            t-att-disabled="!chatterTopbar.chatter.canPostMessage"
                             data-hotkey="m"
                             t-on-click="chatterTopbar.chatter.onClickSendMessage"
                         >
@@ -113,7 +113,7 @@
                                 'o-active btn-odoo': chatterTopbar.chatter.composerView and chatterTopbar.chatter.composerView.composer.isLog,
                                 'btn-light': chatterTopbar.chatter.composerView and !chatterTopbar.chatter.composerView.composer.isLog or !chatterTopbar.chatter.composerView,
                             }"
-                            t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
+                            t-att-disabled="!chatterTopbar.chatter.canPostMessage"
                             t-on-click="chatterTopbar.chatter.onClickLogNote"
                             data-hotkey="shift+m"
                         >
@@ -130,7 +130,7 @@
                             <button
                                 class="o_ChatterTopbar_button o_ChatterTopbar_buttonScheduleActivity btn btn-light text-nowrap"
                                 type="button"
-                                t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
+                                t-att-disabled="!chatterTopbar.chatter.canPostMessage"
                                 t-on-click="chatterTopbar.chatter.onClickScheduleActivity"
                                 data-hotkey="shift+a"
                             >


### PR DESCRIPTION
Currently when you have _mail_post_access = 'read' which gives a user with read only access on the record the right to send message/note/activity the chatter still show the buttons as readonly.

This is a know bug in odoo that was partially fixed here:
https://github.com/odoo/odoo/commit/d2b8612cf7d9c118a12a1f0407bbc893f07e4b56

This PR, in addition to already merged Odoo fix for the Message button, also fixes access to Note and Activity as discussed in pending odoo PR https://github.com/odoo/odoo/pull/135589