### PR TITLE
[14.0] [FIX] web_widget_text_markdown: fix white spaces

### DIFF
--- a/web_widget_text_markdown/static/src/js/web_widget_text_markdown.js
+++ b/web_widget_text_markdown/static/src/js/web_widget_text_markdown.js
@@ -15,10 +15,7 @@ odoo.define("web_widget_text_markdown.FieldTextMarkDown", function (require) {
     var CUST_LIBS_PATH = "/web_widget_text_markdown/static/src/css/";
 
     var FieldTextMarkDown = basic_fields.FieldText.extend({
-        className: [
-            basic_fields.FieldText.prototype.className,
-            "o_field_text_markdown",
-        ].join(" "),
+        className: "o_field_text_markdown",
         jsLibs: [
             LIBS_PATH + "bootstrap-markdown.js",
             LIBS_PATH + "showdown.js",


### PR DESCRIPTION
Before this PR the visualization of the widget looked with more white spaces than needed:
![immagine](https://github.com/OCA/web/assets/42804718/9c27bf39-5245-4907-bf59-7f2bc3cc0ea5)

With these changes it removes the class `o_field_text` to make it look right:
![immagine](https://github.com/OCA/web/assets/42804718/0c349b52-a7e9-4afb-bddd-4b77a2ac8b72)
