### PR TITLE
[15.0][IMP] web_drop_target: Avoid errors for undefined elements

### DIFF
--- a/web_drop_target/static/src/js/web_drop_target.js
+++ b/web_drop_target/static/src/js/web_drop_target.js
@@ -155,7 +155,7 @@ odoo.define("web_drop_target", function (require) {
             const abstractAction = this.findAncestor(function (ancestor) {
                 return ancestor instanceof AbstractAction;
             });
-            const controller = abstractAction.currentDialogController;
+            const controller = abstractAction && abstractAction.currentDialogController;
             if (
                 _.isEmpty(this._get_drop_items(ev)) &&
                 this._checkDragOver() &&
@@ -186,7 +186,9 @@ odoo.define("web_drop_target", function (require) {
          */
         _onBodyFileDrop: function (ev) {
             ev.preventDefault();
-            this._drop_overlay.addClass("d-none");
+            if (this._drop_overlay) {
+                this._drop_overlay.addClass("d-none");
+            }
         },
 
         /**


### PR DESCRIPTION
cc @Tecnativa TT48179

This changes are done to avoid errors in dms_field. This error is
found using this other PR: https://github.com/OCA/dms/pull/310

The steps to reproduce the error are:
1. Create a directory or a file without using drag and drop
2. Drag and drop a file into a folder and you will see the error

ping @victoralmau @chienandalu 