### PR TITLE
[14.0][UPD] web_pwa_oca: Init Action + minor refactor

### DIFF
--- a/web_pwa_oca/README.rst
+++ b/web_pwa_oca/README.rst
@@ -37,7 +37,7 @@ If you're building a web app today, you're already on the path towards building 
 
 + Developers Info.
 
-The service worker is contructed using 'Odoo Class' to have the same class inheritance behaviour that in the 'user pages'. Be noticed
+The service worker is constructed using 'Odoo Class' to have the same class inheritance behaviour that in the 'user pages'. Be noticed
 that 'Odoo Bootstrap' is not supported so, you can't use 'require' here.
 
 All service worker content can be found in 'static/src/js/worker'. The management between 'user pages' and service worker is done in

--- a/web_pwa_oca/controllers/main.py
+++ b/web_pwa_oca/controllers/main.py
@@ -6,46 +6,14 @@ import json
 
 from odoo.http import Controller, request, route
 
+from ..models.res_config_settings import PWA_ICON_SIZES
+
 
 class PWA(Controller):
-    def _get_pwa_scripts(self):
-        """Scripts to be imported in the service worker (Order is important)"""
-        return [
-            "/web/static/lib/underscore/underscore.js",
-            "/web_pwa_oca/static/src/js/worker/jquery-sw-compat.js",
-            "/web/static/src/js/promise_extension.js",
-            "/web/static/src/js/boot.js",
-            "/web/static/src/js/core/class.js",
-            "/web_pwa_oca/static/src/js/worker/pwa.js",
-        ]
-
-    @route("/service-worker.js", type="http", auth="public")
-    def render_service_worker(self):
-        """Route to register the service worker in the 'main' scope ('/')"""
-        return request.render(
-            "web_pwa_oca.service_worker",
-            {
-                "pwa_scripts": self._get_pwa_scripts(),
-                "pwa_params": self._get_pwa_params(),
-            },
-            headers=[("Content-Type", "text/javascript;charset=utf-8")],
-        )
-
-    def _get_pwa_params(self):
-        """Get javascript PWA class initialzation params"""
-        return {}
-
     def _get_pwa_manifest_icons(self, pwa_icon):
         icons = []
         if not pwa_icon:
-            for size in [
-                (128, 128),
-                (144, 144),
-                (152, 152),
-                (192, 192),
-                (256, 256),
-                (512, 512),
-            ]:
+            for size in PWA_ICON_SIZES:
                 icons.append(
                     {
                         "src": "/web_pwa_oca/static/img/icons/icon-%sx%s.png"
@@ -75,12 +43,14 @@ class PWA(Controller):
                     {"src": icon.url, "sizes": icon_size_name, "type": icon.mimetype}
                 )
         else:
+            icon_sizes = " ".join(
+                map(
+                    lambda size: "{}x{}".format(size[0], size[1]),
+                    PWA_ICON_SIZES,
+                )
+            )
             icons = [
-                {
-                    "src": pwa_icon.url,
-                    "sizes": "128x128 144x144 152x152 192x192 256x256 512x512",
-                    "type": pwa_icon.mimetype,
-                }
+                {"src": pwa_icon.url, "sizes": icon_sizes, "type": pwa_icon.mimetype}
             ]
         return icons
 

--- a/web_pwa_oca/controllers/service_worker.py
+++ b/web_pwa_oca/controllers/service_worker.py
@@ -48,26 +48,52 @@ class ServiceWorker(PWA):
 
     def _get_js_pwa_init(self):
         return """
-            const oca_pwa = new PWA({});
+            let promise_start = Promise.resolve();
+            if (typeof self.oca_pwa === "undefined") {{
+                self.oca_pwa = new PWA({});
+                promise_start = self.oca_pwa.start();
+                if (self.serviceWorker.state === "activated") {{
+                    promise_start = promise_start.then(
+                        () => self.oca_pwa.activateWorker(true));
+                }}
+            }}
         """.format(
             self._get_pwa_params()
         )
 
     def _get_js_pwa_core_event_install_impl(self):
         return """
-            evt.waitUntil(oca_pwa.installWorker());
-            self.skipWaiting();
+            evt.waitUntil(promise_start.then(() => self.oca_pwa.installWorker()));
         """
 
     def _get_js_pwa_core_event_activate_impl(self):
         return """
             console.log('[ServiceWorker] Activating...');
-            evt.waitUntil(oca_pwa.activateWorker());
-            self.clients.claim();
+            evt.waitUntil(promise_start.then(() => self.oca_pwa.activateWorker()));
         """
 
     def _get_js_pwa_core_event_fetch_impl(self):
-        return ""
+        return """
+        if (evt.request.url.startsWith(self.registration.scope)) {
+            evt.respondWith(promise_start.then(
+                () => self.oca_pwa.processRequest(evt.request)));
+        }
+        """
+
+    def _get_pwa_scripts(self):
+        """Scripts to be imported in the service worker (Order is important)"""
+        return [
+            "/web/static/lib/underscore/underscore.js",
+            "/web_pwa_oca/static/src/js/worker/jquery-sw-compat.js",
+            "/web/static/src/js/promise_extension.js",
+            "/web/static/src/js/boot.js",
+            "/web/static/src/js/core/class.js",
+            "/web_pwa_oca/static/src/js/worker/pwa.js",
+        ]
+
+    def _get_pwa_params(self):
+        """Get javascript PWA class initialzation params"""
+        return {}
 
     @route("/service-worker.js", type="http", auth="public")
     def render_service_worker(self):

--- a/web_pwa_oca/models/res_config_settings.py
+++ b/web_pwa_oca/models/res_config_settings.py
@@ -9,6 +9,12 @@ from PIL import Image
 from odoo import _, api, exceptions, fields, models
 from odoo.tools.mimetypes import guess_mimetype
 
+DEFAULT_ICON_SIZE = 512
+PWA_ICON_SIZES = (
+    (512, 512),
+    (192, 192),
+)
+
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
@@ -24,6 +30,12 @@ class ResConfigSettings(models.TransientModel):
     pwa_icon = fields.Binary("Icon", readonly=False)
     pwa_background_color = fields.Char("Background Color")
     pwa_theme_color = fields.Char("Theme Color")
+    pwa_action_id = fields.Many2one(
+        "ir.actions.actions",
+        string="Home Action",
+        help="If specified, this action will be opened at pwa opened, in addition "
+        "to the standard menu.",
+    )
 
     @api.model
     def get_values(self):
@@ -49,7 +61,19 @@ class ResConfigSettings(models.TransientModel):
         res["pwa_theme_color"] = config_parameter_obj_sudo.get_param(
             "pwa.manifest.theme_color", default="#2E69B5"
         )
+        action_id = config_parameter_obj_sudo.get_param(
+            "pwa.config.action_id", default=False
+        )
+        res["pwa_action_id"] = action_id and int(action_id)
         return res
+
+    @api.model
+    def get_pwa_home_action(self):
+        return (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("pwa.config.action_id", default=False)
+        )
 
     def _unpack_icon(self, icon):
         # Wrap decoded_icon in BytesIO object
@@ -106,11 +130,17 @@ class ResConfigSettings(models.TransientModel):
         config_parameter_obj_sudo.set_param(
             "pwa.manifest.theme_color", self.pwa_theme_color
         )
+        config_parameter_obj_sudo.set_param(
+            "pwa.config.action_id", self.pwa_action_id.id
+        )
         # Retrieve previous value for pwa_icon from ir_attachment
         pwa_icon_ir_attachments = (
             self.env["ir.attachment"]
             .sudo()
             .search([("url", "like", self._pwa_icon_url_base)])
+        )
+        config_parameter_obj_sudo.set_param(
+            "pwa.manifest.custom_icon", True if self.pwa_icon else False
         )
         # Delete or ignore if no icon provided
         if not self.pwa_icon:
@@ -141,19 +171,20 @@ class ResConfigSettings(models.TransientModel):
         self._write_icon_to_attachment(pwa_icon_extension, pwa_icon_mimetype)
         # write multiple sizes if not SVG
         if pwa_icon_extension != ".svg":
-            # Fail if provided PNG is smaller than 512x512
-            if self._unpack_icon(self.pwa_icon).size < (512, 512):
+            # Fail if provided PNG is smaller than DEFAULT_ICON_SIZE
+            if self._unpack_icon(self.pwa_icon).size < (
+                DEFAULT_ICON_SIZE,
+                DEFAULT_ICON_SIZE,
+            ):
                 raise exceptions.UserError(
-                    _("You can only upload PNG files bigger than 512x512")
+                    _(
+                        "You can only upload PNG files bigger "
+                        + "than {icon_size}x{icon_size}".format(
+                            icon_size=DEFAULT_ICON_SIZE
+                        )
+                    )
                 )
-            for size in [
-                (128, 128),
-                (144, 144),
-                (152, 152),
-                (192, 192),
-                (256, 256),
-                (512, 512),
-            ]:
+            for size in PWA_ICON_SIZES:
                 self._write_icon_to_attachment(
                     pwa_icon_extension, pwa_icon_mimetype, size=size
                 )

--- a/web_pwa_oca/readme/DESCRIPTION.rst
+++ b/web_pwa_oca/readme/DESCRIPTION.rst
@@ -7,7 +7,7 @@ If you're building a web app today, you're already on the path towards building 
 
 + Developers Info.
 
-The service worker is contructed using 'Odoo Class' to have the same class inheritance behaviour that in the 'user pages'. Be noticed
+The service worker is constructed using 'Odoo Class' to have the same class inheritance behaviour that in the 'user pages'. Be noticed
 that 'Odoo Bootstrap' is not supported so, you can't use 'require' here.
 
 All service worker content can be found in 'static/src/js/worker'. The management between 'user pages' and service worker is done in

--- a/web_pwa_oca/static/description/index.html
+++ b/web_pwa_oca/static/description/index.html
@@ -377,7 +377,7 @@ If you’re building a web app today, you’re already on the path towards build
 <ul class="simple">
 <li>Developers Info.</li>
 </ul>
-<p>The service worker is contructed using ‘Odoo Class’ to have the same class inheritance behaviour that in the ‘user pages’. Be noticed
+<p>The service worker is constructed using ‘Odoo Class’ to have the same class inheritance behaviour that in the ‘user pages’. Be noticed
 that ‘Odoo Bootstrap’ is not supported so, you can’t use ‘require’ here.</p>
 <p>All service worker content can be found in ‘static/src/js/worker’. The management between ‘user pages’ and service worker is done in
 ‘pwa_manager.js’.</p>

--- a/web_pwa_oca/static/src/js/app_menus.js
+++ b/web_pwa_oca/static/src/js/app_menus.js
@@ -1,0 +1,42 @@
+/* Copyright 2021 Tecnativa - Alexandre D. Díaz
+ * License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). */
+odoo.define("web_pwa_oca.AppsMenu", function (require) {
+    "use strict";
+
+    const AppsMenu = require("web.AppsMenu");
+    require("web_pwa_oca.webclient");
+    const WebClientObj = require("web.web_client");
+
+    AppsMenu.include({
+        /**
+         * @override
+         */
+        openFirstApp: function () {
+            const is_standalone = WebClientObj.pwa_manager.isPWAStandalone();
+            if (is_standalone) {
+                const _sup = this._super;
+                WebClientObj.menu_dp
+                    .add(
+                        this._rpc({
+                            model: "res.config.settings",
+                            method: "get_pwa_home_action",
+                        })
+                    )
+                    .then((action_id) => {
+                        if (action_id) {
+                            return this.do_action(action_id).then(() => {
+                                WebClientObj.menu.change_menu_section(
+                                    WebClientObj.menu.action_id_to_primary_menu_id(
+                                        action_id
+                                    )
+                                );
+                            });
+                        }
+                        return _sup.apply(this, arguments);
+                    });
+            } else {
+                return this._super(this, arguments);
+            }
+        },
+    });
+});

--- a/web_pwa_oca/static/src/js/pwa_manager.js
+++ b/web_pwa_oca/static/src/js/pwa_manager.js
@@ -5,9 +5,25 @@ odoo.define("web_pwa_oca.PWAManager", function (require) {
     "use strict";
 
     var core = require("web.core");
+    var config = require("web.config");
     var Widget = require("web.Widget");
 
     var _t = core._t;
+
+    /**
+     * @returns {Boolean}
+     */
+    function isPWAStandalone() {
+        return (
+            window.navigator.standalone ||
+            document.referrer.includes("android-app://") ||
+            window.matchMedia("(display-mode: standalone)").matches
+        );
+    }
+
+    if (isPWAStandalone()) {
+        config.device.isMobile = true;
+    }
 
     var PWAManager = Widget.extend({
         /**
@@ -15,16 +31,18 @@ odoo.define("web_pwa_oca.PWAManager", function (require) {
          */
         init: function () {
             this._super.apply(this, arguments);
-            if (!("serviceWorker" in navigator)) {
+            this._isServiceWorkerSupported = "serviceWorker" in navigator;
+            if (!this._isServiceWorkerSupported) {
                 console.error(
                     _t(
                         "Service workers are not supported! Maybe you are not using HTTPS or you work in private mode."
                     )
                 );
-            }
-            if ("serviceWorker" in navigator) {
+            } else {
                 this._service_worker = navigator.serviceWorker;
-                this.registerServiceWorker("/service-worker.js");
+                this.registerServiceWorker("/service-worker.js", {
+                    updateViaCache: "none",
+                });
             }
         },
 
@@ -32,13 +50,20 @@ odoo.define("web_pwa_oca.PWAManager", function (require) {
          * @param {String} sw_script
          * @returns {Promise}
          */
-        registerServiceWorker: function (sw_script) {
+        registerServiceWorker: function (sw_script, options) {
             return this._service_worker
-                .register(sw_script)
-                .then(this._onRegisterServiceWorker)
+                .register(sw_script, options)
+                .then(this._onRegisterServiceWorker.bind(this))
                 .catch(function (error) {
                     console.log(_t("[ServiceWorker] Registration failed: "), error);
                 });
+        },
+
+        /**
+         * @returns {Boolean}
+         */
+        isPWAStandalone: function () {
+            return isPWAStandalone();
         },
 
         /**
@@ -48,7 +73,7 @@ odoo.define("web_pwa_oca.PWAManager", function (require) {
          * @param {ServiceWorkerRegistration} registration
          */
         _onRegisterServiceWorker: function (registration) {
-            console.log(_t("[ServiceWorker] Registered:"), registration);
+            console.log(_t("[ServiceWorker] Registered: "), registration);
         },
     });
 

--- a/web_pwa_oca/static/src/js/webclient.js
+++ b/web_pwa_oca/static/src/js/webclient.js
@@ -13,7 +13,8 @@ odoo.define("web_pwa_oca.webclient", function (require) {
          */
         show_application: function () {
             this.pwa_manager = new PWAManager(this);
-            return this._super.apply(this, arguments);
+            const def = this.pwa_manager.start();
+            return Promise.all([this._super.apply(this, arguments), def]);
         },
     });
 });

--- a/web_pwa_oca/static/src/js/worker/pwa.js
+++ b/web_pwa_oca/static/src/js/worker/pwa.js
@@ -22,6 +22,14 @@ odoo.define("web_pwa_oca.PWA", function (require) {
         /**
          * @returns {Promise}
          */
+        start: function () {
+            // To be overridden
+            return Promise.resolve();
+        },
+
+        /**
+         * @returns {Promise}
+         */
         installWorker: function () {
             // To be overridden
             return Promise.resolve();
@@ -30,9 +38,18 @@ odoo.define("web_pwa_oca.PWA", function (require) {
         /**
          * @returns {Promise}
          */
-        activateWorker: function () {
+        /* eslint-disable no-unused-vars */
+        activateWorker: function (forced) {
             // To be overridden
             return Promise.resolve();
+        },
+
+        /**
+         * @returns {Promise}
+         */
+        processRequest: function (request) {
+            // To be overridden
+            return fetch(request);
         },
     });
 

--- a/web_pwa_oca/templates/assets.xml
+++ b/web_pwa_oca/templates/assets.xml
@@ -15,11 +15,32 @@
                 t-set="pwa_name"
                 t-value="request.env['ir.config_parameter'].sudo().get_param('pwa.manifest.name')"
             />
-            <meta name="apple-mobile-web-app-title" t-att-content="pwa_name" />
-            <link
-                rel="apple-touch-icon"
-                href="/web_pwa_oca/static/img/icons/icon-152x152.png"
+            <t
+                t-set="pwa_custom_icon"
+                t-value="request.env['ir.config_parameter'].sudo().get_param('pwa.manifest.custom_icon')"
             />
+            <t t-if="pwa_custom_icon">
+                <!-- This icon must be 180x180 -->
+                <link rel="apple-touch-icon" href="/web_pwa_oca/icon192x192.png" />
+                <link
+                    rel="apple-touch-icon"
+                    sizes="512x512"
+                    href="/web_pwa_oca/icon512x512.png"
+                />
+            </t>
+            <t t-else="">
+                <!-- This icon must be 180x180 -->
+                <link
+                    rel="apple-touch-icon"
+                    href="/web_pwa_oca/static/img/icons/icon-192x192.png"
+                />
+                <link
+                    rel="apple-touch-icon"
+                    sizes="512x512"
+                    href="/web_pwa_oca/static/img/icons/icon-512x512.png"
+                />
+            </t>
+            <meta name="apple-mobile-web-app-title" t-att-content="pwa_name" />
             <!-- Add meta theme-color -->
             <t
                 t-set="pwa_theme_color"
@@ -41,6 +62,10 @@
             <script
                 type="text/javascript"
                 src="/web_pwa_oca/static/src/js/webclient.js"
+            />
+            <script
+                type="text/javascript"
+                src="/web_pwa_oca/static/src/js/app_menus.js"
             />
         </xpath>
     </template>

--- a/web_pwa_oca/tests/test_web_pwa_oca_controller.py
+++ b/web_pwa_oca/tests/test_web_pwa_oca_controller.py
@@ -8,6 +8,8 @@ import odoo.tests
 from odoo import exceptions
 from odoo.modules.module import get_resource_path
 
+from ..models.res_config_settings import DEFAULT_ICON_SIZE, PWA_ICON_SIZES
+
 
 class TestUi(odoo.tests.HttpCase):
     def setUp(self):
@@ -42,9 +44,14 @@ class TestUi(odoo.tests.HttpCase):
         # icon should remain the default one
         self.assertEqual(
             manifest_content["icons"][0]["src"],
-            "/web_pwa_oca/static/img/icons/icon-128x128.png",
+            "/web_pwa_oca/static/img/icons/icon-{def_size}x{def_size}.png".format(
+                def_size=DEFAULT_ICON_SIZE
+            ),
         )
-        self.assertEqual(manifest_content["icons"][0]["sizes"], "128x128")
+        self.assertEquals(
+            manifest_content["icons"][0]["sizes"],
+            "{def_size}x{def_size}".format(def_size=DEFAULT_ICON_SIZE),
+        )
         self.assertTrue(manifest_content["icons"][0]["type"].startswith("image/png"))
 
     def test_manifest_logo_upload(self):
@@ -64,10 +71,13 @@ class TestUi(odoo.tests.HttpCase):
 
         self.assertEqual(manifest_content["icons"][0]["src"], "/web_pwa_oca/icon.svg")
         self.assertTrue(manifest_content["icons"][0]["type"].startswith("image/svg"))
-        self.assertEqual(
-            manifest_content["icons"][0]["sizes"],
-            "128x128 144x144 152x152 192x192 256x256 512x512",
+        icon_sizes = " ".join(
+            map(
+                lambda size: "{}x{}".format(size[0], size[1]),
+                PWA_ICON_SIZES,
+            )
         )
+        self.assertEquals(manifest_content["icons"][0]["sizes"], icon_sizes)
 
         # Get the icon and compare it
         icon_data = self.url_open("/web_pwa_oca/icon.svg")

--- a/web_pwa_oca/views/res_config_settings_views.xml
+++ b/web_pwa_oca/views/res_config_settings_views.xml
@@ -32,6 +32,14 @@
                                     />
                                     <field name="pwa_short_name" />
                                 </div>
+                                <div class="row mt16">
+                                    <label
+                                        class="col-lg-3 o_light_label"
+                                        string="Home Action"
+                                        for="pwa_action_id"
+                                    />
+                                    <field name="pwa_action_id" />
+                                </div>
                                 <div class="row">
                                     <label
                                         class="col-lg-3 o_light_label"


### PR DESCRIPTION
- Add in the settings the option to choose a 'home action' when using PWA.
- Remove unused code
- Minor icons code refactor
- Expose a "hook" to manage requests

** NOTE: I can't test that in Apple applications it works correctly.