### PR TITLE
[16.0][IMP] web_timeline: Handle inverted date ranges

### DIFF
--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -531,9 +531,9 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 evt: evt,
                 style: `background-color: ${this.color};`,
             };
-            // Check if the event is instantaneous,
-            // if so, display it with a point on the timeline (no 'end')
-            if (date_stop && !moment(date_start).isSame(date_stop)) {
+            // Only specify range end when there actually is one.
+            // ➔ Instantaneous events / those with inverted dates are displayed as points.
+            if (date_stop && moment(date_start).isBefore(date_stop)) {
                 r.end = date_stop;
             }
             this.color = null;


### PR DESCRIPTION
Inverted dates make no functional sense, but when they do happen, this change allows displaying them as single points in the timeline (same as when begin=end).

We currently do have such demo data when installing project_timeline:
![Screenshot at 2024-03-21 12-24-31](https://github.com/OCA/web/assets/6347423/10e59b04-5a0f-4f2f-a431-b9c360d55c96)

# Before: office design tasks are missing
![Screenshot at 2024-03-21 11-53-24](https://github.com/OCA/web/assets/6347423/b68439a5-9efb-455d-a86a-7714f68d1b38)

# After: office design tasks are shown
![Screenshot at 2024-03-21 11-50-51](https://github.com/OCA/web/assets/6347423/09513e1f-633e-4fe2-9747-db1cf0135724)

