### PR TITLE
[16.0][IMP] web_timeline: Overflow text, add hover colors

### DIFF
--- a/web_timeline/readme/ROADMAP.rst
+++ b/web_timeline/readme/ROADMAP.rst
@@ -1,5 +1,5 @@
 * Implement a more efficient way of refreshing timeline after a record update;
-* Make `attrs` attribute work;
+* Make ``attrs`` attribute work;
 * Make action attributes work (create, edit, delete) like in form and tree views.
 * When grouping by m2m and more than one record is set, the timeline item appears only
   on one group. Allow showing in both groups.
@@ -7,3 +7,6 @@
   the group will not be set, because it could make disappear the records not related
   with the changes that we want to make. When the item is showed in all groups change
   the value according the group of the dragged item.
+* When an item label does not fit in its date-range box: ✅ the label correctly overflows
+  the box; ✅ clicking anywhere on the label allows moving the box; ❌ double-clicking
+  the label outside of the box does not open that item.

--- a/web_timeline/static/src/scss/web_timeline.scss
+++ b/web_timeline/static/src/scss/web_timeline.scss
@@ -1,3 +1,4 @@
+$vis-hover-background-color: linen;
 $vis-weekend-background-color: #dcdcdc;
 $vis-item-content-padding: 0 3px !important;
 
@@ -10,16 +11,18 @@ $vis-item-content-padding: 0 3px !important;
     }
 
     .vis-item {
-        &.vis-box:hover {
+        &:hover {
+            background-color: $vis-hover-background-color !important;
             cursor: pointer !important;
         }
-        &.vis-item-overflow {
+        .vis-item-overflow {
             overflow: visible;
         }
-
         .vis-item-content {
-            width: 100%;
             padding: $vis-item-content-padding;
+            &:hover {
+                background-color: $vis-hover-background-color !important;
+            }
         }
     }
 }


### PR DESCRIPTION
When an item label does not fit in its date-range box, overflow according to
https://visjs.github.io/vis-timeline/examples/timeline/items/rangeOverflowItem.html

Previous CSS code was already trying to do that, but was selecting `.vis-item.vis-item-content` instead of `.vis-item .vis-item-content`.

Displaying overflow text brings up layout issues solved by removing the forced-100% width instruction.

This change also adds highlight when hovering a box, which is useful on text that has overflown (as it has no borders).

In screenshots below I added an end date close to the start date on the first 2 tasks.
They almost have the same dates, to make sure the vis lib handles them correctly (they don't step on each other).

# Before: labels cut
![Screenshot at 2024-03-21 11-47-11](https://github.com/OCA/web/assets/6347423/45bf5bb5-3f7d-4ce3-867d-5fdb5087d7b8)

# After: labels overflow
![Screenshot at 2024-03-21 11-35-10](https://github.com/OCA/web/assets/6347423/fa686048-ce59-4d14-add7-ac3c6a39529f)

## With hover highlight
![Screenshot at 2024-03-21 11-35-30](https://github.com/OCA/web/assets/6347423/b0e0d233-3bbf-466a-93d0-b7d0e946f37d)
