### PR TITLE
[16.0][IMP] web_timeline: Add demo view on cron tasks

### DIFF
--- a/web_timeline/__manifest__.py
+++ b/web_timeline/__manifest__.py
@@ -17,6 +17,7 @@
     "website": "https://github.com/OCA/web",
     "depends": ["web"],
     "data": [],
+    "demo": ["demo/ir_cron_view.xml"],
     "maintainers": ["tarteo"],
     "application": False,
     "installable": True,

--- a/web_timeline/demo/ir_cron_view.xml
+++ b/web_timeline/demo/ir_cron_view.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!-- Add demo timeline view on crons so we can showcase this module without project_timeline. -->
+    <record id="ir_cron_timeline" model="ir.ui.view">
+        <field name="model">ir.cron</field>
+        <field name="type">timeline</field>
+        <field name="arch" type="xml">
+            <timeline date_start="nextcall" default_group_by="model_id" />
+        </field>
+    </record>
+    <record id="base.ir_cron_act" model="ir.actions.act_window">
+        <field name="view_mode">tree,form,calendar,timeline</field>
+    </record>
+</odoo>

--- a/web_timeline/readme/CONFIGURE.rst
+++ b/web_timeline/readme/CONFIGURE.rst
@@ -38,7 +38,9 @@ These are the variables available in template rendering:
 
 You also need to declare the view in an action window of the involved model.
 
-Example:
+See ``web_timeline/demo/ir_cron_view.xml`` for a very basic timeline view example added onto cron tasks.
+
+More evolved example, from ``project_timeline``:
 
 .. code-block:: xml
 


### PR DESCRIPTION
This way we can showcase this module without project_timeline.

Enable debug mode, go to Technical > Scheduled Actions, switch to timeline view:
![Screenshot at 2024-03-21 13-34-48](https://github.com/OCA/web/assets/6347423/0d510def-7a59-42ac-826c-8d8ede682947)
