### PR TITLE
[16.0][FIX] web_timeline: Redraw issues with initial mode

### DIFF
--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -86,10 +86,6 @@ odoo.define("web_timeline.TimelineView", function (require) {
             const mode = attrs.mode || attrs.default_window || "fit";
             const min_height = attrs.min_height || 300;
 
-            const current_window = {
-                start: new moment(),
-                end: new moment().add(24, "hours"),
-            };
             if (!isNullOrUndef(attrs.quick_create_instance)) {
                 this.quick_create_instance = "instance." + attrs.quick_create_instance;
             }
@@ -104,7 +100,6 @@ odoo.define("web_timeline.TimelineView", function (require) {
             this.rendererParams.model = this.modelName;
             this.rendererParams.view = this;
             this.rendererParams.options = this._preapre_vis_timeline_options(attrs);
-            this.rendererParams.current_window = current_window;
             this.rendererParams.date_start = date_start;
             this.rendererParams.date_stop = date_stop;
             this.rendererParams.date_delay = date_delay;


### PR DESCRIPTION
This commit fixes redraw issues when setting a `mode` attribute in the `timeline` view tag.

This mode specifies a default scale one would want to set; same as when clicking on Day/Week/Month buttons at the top of the view.

Initial rendering had issues here because data was loaded too soon, before the timeline component was rendered/ready. The fix is to load data into the component only after initial redraw event, called `changed` (see <https://visjs.github.io/vis-timeline/docs/timeline/#Events>).

There was old code attempting to call `on_scale_xxx_clicked` methods at load time to simulate clicks on these Day/Week/Month buttons, but these methods have been renamed so this code is no longer working.

This commit also removes the `current_window` instance variable, not needed and actually confusing as the timeline component already maintains its own start/end information (which we can query with `timeline.getWindow()`).

---

Screenshots below with project_timeline task view with `mode="month"`

# Before
Only 1 line at the bottom, rest is missing
![Screenshot at 2024-03-21 17-36-09](https://github.com/OCA/web/assets/6347423/42a30852-ffde-4a1a-a823-bc456810792f)

# After
![Screenshot at 2024-03-21 17-36-42](https://github.com/OCA/web/assets/6347423/50bb0032-1f70-425b-af06-4bbdeb6db5a9)
