### PR TITLE
[16.0][IMP] web_timeline: Align to top instead of bottom

### DIFF
--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -128,7 +128,7 @@ odoo.define("web_timeline.TimelineView", function (require) {
         _preapre_vis_timeline_options: function (attrs) {
             return {
                 groupOrder: "order",
-                orientation: "both",
+                orientation: {axis: "both", item: "top"},
                 selectable: true,
                 multiselect: true,
                 showCurrentTime: true,


### PR DESCRIPTION
This avoids somewhat ugly very large "Unassigned" first row.

See doc on https://visjs.github.io/vis-timeline/docs/timeline/ > "orientation" setting:
> Orientation of the timeline items: 'top' or 'bottom' (default). Determines whether items are aligned to the top or bottom of the Timeline.

Since our view always covers 100% height, the "bottom" default setting was producing that large first row.

This could be a per-view setting; I didn't add a setting for now as I believe this top-aligned behavior is always desirable (as far as I could see when showing this around, at least). I can add a setting if you feel it would be needed.

# Before
![Screenshot at 2024-04-03 18-37-00](https://github.com/OCA/web/assets/6347423/97f6f5fb-130f-4616-8dde-f1ff578914bb)

# After
![Screenshot at 2024-04-03 18-36-42](https://github.com/OCA/web/assets/6347423/929d3cb3-12f8-40eb-b1b7-75d878c51fa4)
