### PR TITLE
[16.0][IMP] web_timeline: Follow create/edit/delete attrs

### DIFF
--- a/web_timeline/readme/ROADMAP.rst
+++ b/web_timeline/readme/ROADMAP.rst
@@ -1,6 +1,5 @@
 * Implement a more efficient way of refreshing timeline after a record update;
 * Make ``attrs`` attribute work;
-* Make action attributes work (create, edit, delete) like in form and tree views.
 * When grouping by m2m and more than one record is set, the timeline item appears only
   on one group. Allow showing in both groups.
 * When grouping by m2m and dragging for changing the time or the group, the changes on

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -22,6 +22,10 @@ odoo.define("web_timeline.TimelineView", function (require) {
         return _.isUndefined(value) || _.isNull(value);
     }
 
+    function toBoolDefaultTrue(value) {
+        return isNullOrUndef(value) ? true : utils.toBoolElse(value, true);
+    }
+
     var TimelineView = AbstractView.extend({
         display_name: _lt("Timeline"),
         icon: "fa fa-tasks",
@@ -100,6 +104,9 @@ odoo.define("web_timeline.TimelineView", function (require) {
             this.rendererParams.model = this.modelName;
             this.rendererParams.view = this;
             this.rendererParams.options = this._preapre_vis_timeline_options(attrs);
+            this.rendererParams.can_create = toBoolDefaultTrue(attrs.create);
+            this.rendererParams.can_update = toBoolDefaultTrue(attrs.edit);
+            this.rendererParams.can_delete = toBoolDefaultTrue(attrs.delete);
             this.rendererParams.date_start = date_start;
             this.rendererParams.date_stop = date_stop;
             this.rendererParams.date_delay = date_delay;
@@ -127,9 +134,7 @@ odoo.define("web_timeline.TimelineView", function (require) {
                 selectable: true,
                 multiselect: true,
                 showCurrentTime: true,
-                stack: isNullOrUndef(attrs.stack)
-                    ? true
-                    : utils.toBoolElse(attrs.stack, true),
+                stack: toBoolDefaultTrue(attrs.stack),
                 margin: attrs.margin ? JSON.parse(attrs.margin) : {item: 2},
                 zoomKey: attrs.zoomKey || "ctrlKey",
             };


### PR DESCRIPTION
In addition to security rights (was already implemented), now follow `create="0"` / `edit="0"` / `delete="0"` attributes one can set onto the `timeline` tag, same as in other Odoo views.

I had to add a specific event for read-only double-clicks to distinguish with update ones (read-only double-clicks have item ID only, updates have more item info in a dict).

To test on runboat, open the ir.cron timeline view and play with:
* `create="0"` / 1
* `edit="0"` / 1
* `delete="0"` / 1
* `event_open_popup="0"` / 1