### PR TITLE
[16.0][FIX] web_responsive: fix status widget visibility

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -168,7 +168,7 @@ html .o_web_client .o_action_manager .o_action {
         .oe_title {
             .o_field_widget:not(.oe_inline) {
                 display: block;
-                span:not(.o_field_translate) {
+                span:not(.o_field_translate):not(.o_status) {
                     display: block;
                     max-width: 100%;
                     text-overflow: ellipsis;


### PR DESCRIPTION
Before this change the status widget was hidden as it had no width. You can check it installing the project module and going to a task. Now you can see the status widget along the task name.

![image](https://github.com/OCA/web/assets/5040182/84c5f36c-c860-4298-bd01-bb912d9cf997)


please review @pilarvargas-tecnativa @carlosdauden 