### PR TITLE
[15.0][FIX] web_pivot_computed_measure: Avoid Infinity errors by comparisons

### DIFF
--- a/web_pivot_computed_measure/static/src/pivot/pivot_renderer.esm.js
+++ b/web_pivot_computed_measure/static/src/pivot/pivot_renderer.esm.js
@@ -12,4 +12,10 @@ patch(PivotRenderer.prototype, "web_pivot_computed_measure.PivotRenderer", {
         }
         return this._super(...arguments);
     },
+    getFormattedVariation(cell) {
+        if (Math.abs(cell.value) === Infinity) {
+            return "-";
+        }
+        return this._super(...arguments);
+    },
 });


### PR DESCRIPTION
As with the values that computed measurements can take, comparisons can also take these values which are formatted by the function getFormattedVariation. So we extend this method to take infinite values into account.

cc @Tecnativa TT48745

ping @pedrobaeza @chienandalu  