### PR TITLE
[16.0][IMP] web_responsive: Set viewer width to 100% to better use the space

### DIFF
--- a/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
+++ b/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
@@ -37,7 +37,7 @@
                 display: none;
             }
             .o_AttachmentViewer_viewIframe {
-                width: 95%;
+                width: 100% !important;
             }
         }
     }


### PR DESCRIPTION
cc @Tecnativa TT48773

ping @pedrobaeza @chienandalu 

Before this changes, when previewing a pdf there was a lot of lost space
![image](https://github.com/OCA/web/assets/35952655/0155b115-42da-46fa-8c21-658c6e09a73f)

Now, it is filling all the space
![image](https://github.com/OCA/web/assets/35952655/e90d7886-c2ff-4faa-9c01-9e283229c1b7)
 