### PR TITLE
[15.0][FIX] web_responsive: Use recordParams when accesing to searchView on mobile interface to avoid loosing domain of form view

### DIFF
--- a/web_responsive/static/src/legacy/js/web_responsive.js
+++ b/web_responsive/static/src/legacy/js/web_responsive.js
@@ -146,6 +146,7 @@ odoo.define("web_responsive", function (require) {
             const options = this._super.apply(this, arguments);
             _.extend(options, {
                 on_clear: () => this.reinitialize(false),
+                domain: this.record.getDomain(this.recordParams),
             });
             return options;
         },


### PR DESCRIPTION
You can reproduce the error by installing sale_order_secondary_unit and doing this steps:

1. Add secondary units of measure on different products
2. Create a sale order and add a product with a secondary uom
3. Display the window on a Mobile resolution
4. Refresh
5. Try to change the secondary uom of the line
6. You will see all the secondary uoms created

With this changes, we use the correct domain as it is used by _toggleAutoComplete normal way

cc @Tecnativa TT48837

ping @chienandalu @sergio-teruel @pedrobaeza 