### PR TITLE
[17.0][IMP] web_refresher: Charge t-inherit-mode extension views just after the main

### DIFF
--- a/web_refresher/__manifest__.py
+++ b/web_refresher/__manifest__.py
@@ -13,7 +13,14 @@
             "web_refresher/static/src/js/refresher.esm.js",
             "web_refresher/static/src/js/control_panel.esm.js",
             "web_refresher/static/src/xml/refresher.xml",
-            "web_refresher/static/src/xml/control_panel.xml",
+            # Load the modification of the master template just after it,
+            # for having the modification in all the primary extensions.
+            # Example: the project primary view.
+            (
+                "after",
+                "web/static/src/search/control_panel/control_panel.xml",
+                "web_refresher/static/src/xml/control_panel.xml",
+            ),
         ],
     },
 }

--- a/web_refresher/static/description/index.html
+++ b/web_refresher/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -422,7 +423,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
By doing this, the extension view is charged just after the main, so if some other views are using this other, to make a primary one, like project is doing for project.task control_panel, the refresher will continue be shown.

FW-PORT of: https://github.com/OCA/web/pull/2804

cc @Tecnativa TT48551

ping @pedrobaeza @chienandalu 