### PR TITLE
[14.0][FIX][IMP] web_ir_actions_act_multi: uninstall issue

### DIFF
--- a/web_ir_actions_act_multi/README.rst
+++ b/web_ir_actions_act_multi/README.rst
@@ -82,6 +82,7 @@ Contributors
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
 
 * Manuel Calero - Tecnativa
+* Sajad KK
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_ir_actions_act_multi/models/ir_actions.py
+++ b/web_ir_actions_act_multi/models/ir_actions.py
@@ -7,7 +7,7 @@ class IrActionsActMulti(models.Model):
     _name = "ir.actions.act_multi"
     _description = "Action Mulit"
     _inherit = "ir.actions.actions"
-    _table = "ir_actions"
+    _table = "ir_act_multi"
 
     type = fields.Char(default="ir.actions.act_multi")
 

--- a/web_ir_actions_act_multi/static/description/index.html
+++ b/web_ir_actions_act_multi/static/description/index.html
@@ -427,6 +427,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Manuel Calero - Tecnativa</li>
+<li>Sajad KK</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
This commit fixes uninstallation issue of web_ir_actions_act_multi module. At the time of uninstallation, it removes several columns like name, binding_model_id, binding_type, binding_view_types... from ir_actions, ir_act_server, etc. This makes the database not usable anymore.

Fixes #2394 