### PR TITLE
[16.0][FIX] web_calendar_slot_duration: fixing behavior on slot duration

### DIFF
--- a/web_calendar_slot_duration/README.rst
+++ b/web_calendar_slot_duration/README.rst
@@ -47,6 +47,17 @@ action includes a context similar to this (example is the default value)::
 
     {"calendar_slot_duration": "00:30:00"}
 
+In addition, you can also configure the calendar view's default mode by adding::
+
+{"calendar_slot_duration": "00:30:00", "adapt_view_to_slot_duration": False}
+
+The ``adapt_view_to_slot_duration`` key is optional and defaults to ``True``.
+When set to ``False``, the calendar view will not adapt its view to the slot size.
+
+For example, if you want to set the default slot duration to 1 hour and 30 minutes,
+by default the calendar view will adapt its view to show slots of 1 hour and 30 minutes.
+Sometimes this is not desired, for example when you want to show every time slots by hour.
+
 It can be added in actions defined on python or as ``ir.actions.act_window``
 records.
 

--- a/web_calendar_slot_duration/readme/CONFIGURE.rst
+++ b/web_calendar_slot_duration/readme/CONFIGURE.rst
@@ -7,10 +7,10 @@ action includes a context similar to this (example is the default value)::
 
 In addition, you can also configure the calendar view's default mode by adding::
 
-{"calendar_slot_duration": "00:30:00", "adapt_view_to_slot_duration": False}
+    {"calendar_slot_duration": "00:30:00", "keep_default_view_slot_duration": True}
 
-The ``adapt_view_to_slot_duration`` key is optional and defaults to ``True``.
-When set to ``False``, the calendar view will not adapt its view to the slot size.
+The ``keep_default_view_slot_duration`` key is optional and defaults to ``False``.
+When set to ``True``, the calendar view will not adapt its view to the slot size.
 
 For example, if you want to set the default slot duration to 1 hour and 30 minutes,
 by default the calendar view will adapt its view to show slots of 1 hour and 30 minutes.

--- a/web_calendar_slot_duration/readme/CONFIGURE.rst
+++ b/web_calendar_slot_duration/readme/CONFIGURE.rst
@@ -5,5 +5,16 @@ action includes a context similar to this (example is the default value)::
 
     {"calendar_slot_duration": "00:30:00"}
 
+In addition, you can also configure the calendar view's default mode by adding::
+
+{"calendar_slot_duration": "00:30:00", "adapt_view_to_slot_duration": False}
+
+The ``adapt_view_to_slot_duration`` key is optional and defaults to ``True``.
+When set to ``False``, the calendar view will not adapt its view to the slot size.
+
+For example, if you want to set the default slot duration to 1 hour and 30 minutes,
+by default the calendar view will adapt its view to show slots of 1 hour and 30 minutes.
+Sometimes this is not desired, for example when you want to show every time slots by hour.
+
 It can be added in actions defined on python or as ``ir.actions.act_window``
 records.

--- a/web_calendar_slot_duration/static/description/index.html
+++ b/web_calendar_slot_duration/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -396,6 +395,15 @@ action includes a context similar to this (example is the default value):</p>
 <pre class="literal-block">
 {&quot;calendar_slot_duration&quot;: &quot;00:30:00&quot;}
 </pre>
+<p>In addition, you can also configure the calendar view’s default mode by adding:</p>
+<pre class="literal-block">
+{&quot;calendar_slot_duration&quot;: &quot;00:30:00&quot;, &quot;adapt_view_to_slot_duration&quot;: False}
+</pre>
+<p>The <tt class="docutils literal">adapt_view_to_slot_duration</tt> key is optional and defaults to <tt class="docutils literal">True</tt>.
+When set to <tt class="docutils literal">False</tt>, the calendar view will not adapt its view to the slot size.</p>
+<p>For example, if you want to set the default slot duration to 1 hour and 30 minutes,
+by default the calendar view will adapt its view to show slots of 1 hour and 30 minutes.
+Sometimes this is not desired, for example when you want to show every time slots by hour.</p>
 <p>It can be added in actions defined on python or as <tt class="docutils literal">ir.actions.act_window</tt>
 records.</p>
 </div>

--- a/web_calendar_slot_duration/static/src/js/calendar_common_renderer.esm.js
+++ b/web_calendar_slot_duration/static/src/js/calendar_common_renderer.esm.js
@@ -11,7 +11,10 @@ patch(
     {
         get options() {
             const options = this._super(...arguments);
-            if (this.env.searchModel.context.calendar_slot_duration) {
+            if (
+                this.env.searchModel.context.calendar_slot_duration &&
+                !this.env.searchModel.context.keep_default_view_slot_duration
+            ) {
                 options.slotDuration =
                     this.env.searchModel.context.calendar_slot_duration;
             }

--- a/web_calendar_slot_duration/static/src/js/calendar_model.esm.js
+++ b/web_calendar_slot_duration/static/src/js/calendar_model.esm.js
@@ -17,7 +17,14 @@ patch(CalendarModel.prototype, "WebCalendarSlotDurationCalendarModel", {
             const [hours, minutes, seconds] = slot_duration
                 .match(/(\d+):(\d+):(\d+)/)
                 .slice(1, 4);
-            const durationFloat = hours + minutes / 60 + seconds / 3600;
+            // Convert all to float
+            // if we use a context like {'calendar_slot_duration': '01:30:00'}
+            // we will have on the backend a duration of 10 hour and 30 minutes
+            // instead of 1 hour and 30 minutes
+            const durationFloat =
+                parseFloat(hours) +
+                parseFloat(minutes) / 60 +
+                parseFloat(seconds) / 3600;
             partialRecord.end = partialRecord.start.plus({hours: durationFloat});
         }
         return this._super(partialRecord, options);


### PR DESCRIPTION
Convert all to float :
if we use a context like {'calendar_slot_duration': '01:30:00'} we will have on the backend a duration of 10 hour and 30 minutes instead of 1 hour and 30 minutes

![image](https://github.com/OCA/web/assets/18470913/6938126e-86b0-4f92-a2f0-a4d6ac1c94e1)

And using a slot_duration > 1 hour, the calendar view will be adapted to the slot duration but has not a good presentation.
So I'm adding a possibility to adapt or not the calendar view using `adapt_view_to_slot_duration` on the context too.