### PR TITLE
[16.0][FIX] web_field_tooltip: access to ir.model and ir.model.fields…

### DIFF
--- a/web_field_tooltip/security/ir_model_access.xml
+++ b/web_field_tooltip/security/ir_model_access.xml
@@ -23,4 +23,24 @@
         <field name="perm_unlink" eval="1" />
     </record>
 
+    <record model="ir.model.access" id="ir_model_access_reader">
+        <field name="name">ir.model access reader</field>
+        <field name="model_id" ref="base.model_ir_model" />
+        <field name="group_id" ref="web_field_tooltip.group_tooltip_manager" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
+    <record model="ir.model.access" id="ir_model_fields_access_reader">
+        <field name="name">ir.model.fields access reader</field>
+        <field name="model_id" ref="base.model_ir_model_fields" />
+        <field name="group_id" ref="web_field_tooltip.group_tooltip_manager" />
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="0" />
+        <field name="perm_write" eval="0" />
+        <field name="perm_unlink" eval="0" />
+    </record>
+
 </odoo>

--- a/web_field_tooltip/views/ir_model_fields_tooltip.xml
+++ b/web_field_tooltip/views/ir_model_fields_tooltip.xml
@@ -18,10 +18,14 @@
                     <group name="first">
                         <group name="left">
                             <field name="active" invisible="1" />
-                            <field name="model_id" />
+                            <field
+                                name="model_id"
+                                options="{'create_edit': false, 'no_open': True}"
+                            />
                             <field
                                 name="field_id"
                                 domain="[('model_id', '=', model_id)]"
+                                options="{'create_edit': false, 'no_open': True}"
                             />
                         </group>
                         <group name="right">


### PR DESCRIPTION
If you are not admin you can't create any new tooltip as a tooltips manager because of the access to ir.model and ir.model.fields. Giving read access to this specific tooltip manager group seems to be acceptable.