### PR TITLE
[14.0][IMP] web_timeline: allign to top instead of bottom

### DIFF
--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -126,7 +126,7 @@ odoo.define("web_timeline.TimelineView", function (require) {
         _preapre_vis_timeline_options: function (attrs) {
             return {
                 groupOrder: "order",
-                orientation: "both",
+                orientation: {axis: "both", item: "top"},
                 selectable: true,
                 multiselect: true,
                 showCurrentTime: true,


### PR DESCRIPTION
simple but really useful, following the improvement in v16 https://github.com/OCA/web/pull/2790

