### PR TITLE
[16.0][FIX] web_responsive: Remove unnecessary media query

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -5,15 +5,6 @@
 
 $chatter_zone_width: 35% !important;
 
-// Support for long titles
-@include media-breakpoint-up(md) {
-    .o_form_view .oe_button_box + .oe_title,
-    .o_form_view .oe_button_box + .oe_avatar + .oe_title {
-        /* Button-box has a hardcoded width of 132px per button and have three columns */
-        width: calc(100% - 450px);
-    }
-}
-
 // Scroll all but top bar
 html .o_web_client .o_action_manager .o_action {
     @include media-breakpoint-down(sm) {


### PR DESCRIPTION
Remove unnecessary media query as odoo has support for long titles. This style causes an error in the layout of the affected views.

Before:
![image](https://github.com/OCA/web/assets/118818446/75c4d314-d65f-478a-8d63-711452f275d1)

After:
![image](https://github.com/OCA/web/assets/118818446/631ef3e0-12ce-4108-b2ec-9be2cafb9df1)

cc @Tecnativa

@chienandalu @CarlosRoca13 @sergio-teruel please review