### PR TITLE
[16.0][FIX] web_dialog_size: Fixes on legacy Dialogs

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.js
@@ -19,6 +19,10 @@ odoo.define("web_dialog_size.web_dialog_size", function (require) {
                 self.$modal
                     .find(".dialog_button_restore")
                     .on("click", self.proxy("_restore"));
+                self.$modal.find(">:first-child").draggable({
+                    handle: ".modal-header",
+                    helper: false,
+                });
                 return config.then(function (r) {
                     if (r.default_maximize) {
                         self._extending();
@@ -29,39 +33,16 @@ odoo.define("web_dialog_size.web_dialog_size", function (require) {
             });
         },
 
-        opened: function () {
-            return this._super.apply(this, arguments).then(
-                function () {
-                    if (this.$modal) {
-                        this.$modal.find(">:first-child").draggable({
-                            handle: ".modal-header",
-                            helper: false,
-                        });
-                    }
-                }.bind(this)
-            );
-        },
-
-        close: function () {
-            if (this.$modal) {
-                var draggable = this.$modal.find(">:first-child").draggable("instance");
-                if (draggable) {
-                    this.$modal.find(">:first-child").draggable("destroy");
-                }
-            }
-            return this._super.apply(this, arguments);
-        },
-
         _extending: function () {
             var dialog = this.$modal.find(".modal-dialog");
-            dialog.addClass("dialog_full_screen");
+            dialog.addClass("modal-dialog_full_screen");
             dialog.find(".dialog_button_extend").hide();
             dialog.find(".dialog_button_restore").show();
         },
 
         _restore: function () {
             var dialog = this.$modal.find(".modal-dialog");
-            dialog.removeClass("dialog_full_screen");
+            dialog.removeClass("modal-dialog_full_screen");
             dialog.find(".dialog_button_restore").hide();
             dialog.find(".dialog_button_extend").show();
         },

--- a/web_dialog_size/static/src/xml/web_dialog_size.xml
+++ b/web_dialog_size/static/src/xml/web_dialog_size.xml
@@ -3,9 +3,6 @@
     <!-- This is for old Dialog template.
     Because Odoo haven't done every template to OWL. -->
     <t t-extend="web.DialogWidget">
-        <t t-jquery="button.btn-close" t-operation="inner">
-            <i class="fa fa-close" />
-        </t>
         <t t-jquery="button.btn-close" t-operation="before">
             <button type="button" class="dialog_button_extend btn btn-secondary">
                 <i class="fa fa-expand" />


### PR DESCRIPTION
The problems found on Legacy Dialogs are the next:

1. The modal can't be dragged
2. The button for extending and reduce the modal is doing nothing
3. The x for close the modal is showed twice

You can test it with dialogs showed on Vault module

cc @Tecnativa TT49555

ping @pedrobaeza @victoralmau 