### PR TITLE
Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/web_widget_ckeditor/__manifest__.py
+++ b/web_widget_ckeditor/__manifest__.py
@@ -7,7 +7,7 @@
     "name": "CKEditor Widget",
     "summary": "Provides a widget for editing HTML fields using CKEditor",
     "version": "13.0.1.0.0",
-    "author": "Therp BV, Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Therp BV, Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ivantodorovich"],
     "website": "https://github.com/OCA/web",
     "category": "Web",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 13.0.