### PR TITLE
[IMP] web_environment_ribbon: hide the ribbon on hover, 

### DIFF
--- a/web_environment_ribbon/static/src/css/ribbon.css
+++ b/web_environment_ribbon/static/src/css/ribbon.css
@@ -21,7 +21,10 @@
     position: fixed;
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
     background: rgba(255, 0, 0, 0.6);
-    pointer-events: none;
+    &:hover {
+        opacity: 0;
+        transition: 0.2s ease;
+    }
 }
 
 .test-ribbon b {


### PR DESCRIPTION
Hi all. 
First thanks for this great module. this trivial PR improve the UI. on hover of the ribbon, the ribbon should be hidden to let user see more easily, the elements that are behind the ribbon.

Thanks for your review ! 

Note: This PR is in draft state because I don't figure out how to achive the following things : 
- make ribbon invisible when the mouse is hover the ribbon
- make items under the ribbon clickable.

-> removing point-events:none make items not clickable.
-> Let point-events:none disable .test-ribbon:hover

