### PR TITLE
[15.0][FIX] web_filter_header_button: compatibility issues

### DIFF
--- a/web_filter_header_button/static/src/control_panel/control_panel.xml
+++ b/web_filter_header_button/static/src/control_panel/control_panel.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-inherit="web.Legacy.ControlPanel" t-inherit-mode="extension" owl="1">
         <xpath expr="//div[hasclass('o_cp_bottom')]" position="after">
-            <t t-if="env.view.type !== 'form'">
+            <t t-if="env.view and env.view.type !== 'form'">
                 <FilterButton />
             </t>
         </xpath>


### PR DESCRIPTION
In custom views, like the reconciliation one, that use the control panel we must prevent loading the FilterButton component.

cc @Tecnativa TT49664

please review @CarlosRoca13 @sergio-teruel 