### PR TITLE
[17.0][FIX] web_favicon: Ensure web favicon is displayed on the website

### DIFF
--- a/web_favicon/models/res_company.py
+++ b/web_favicon/models/res_company.py
@@ -68,6 +68,9 @@ class ResCompany(models.Model):
     @api.model
     def _get_favicon(self):
         """Returns a local url that points to the image field of a given record."""
+        if self.env.context.get("website_id"):
+            website = self.env["website"].browse(self.env.context.get("website_id"))
+            return website.image_url(website, "favicon")
         company_id = (
             request.httprequest.cookies.get("cids")
             if request.httprequest.cookies.get("cids")

--- a/web_favicon/tests/test_web_favicon.py
+++ b/web_favicon/tests/test_web_favicon.py
@@ -46,3 +46,29 @@ class TestWebFavicon(TransactionCase):
         Company = self.env["res.company"]
         company = Company.create({"name": "Test Company"})
         self.assertTrue(company.favicon, "Default favicon not set on company creation.")
+
+    def test_03_website_favicon(self):
+        """Test if favicon URL is correctly returned when website_id is in context."""
+        if self.env["ir.module.module"].search(
+            [("name", "=", "website"), ("state", "=", "installed")]
+        ):
+            company = self.env["res.company"].create(
+                {
+                    "name": "Test Company with Website",
+                }
+            )
+            website = self.env["website"].create(
+                {
+                    "name": "Test Website",
+                    "domain": "www.test.com",
+                    "company_id": company.id,
+                }
+            )
+            website.favicon = website._default_favicon()
+            favicon_url = company.with_context(website_id=website.id)._get_favicon()
+            expected_favicon_url = website.image_url(website, "favicon")
+            self.assertEqual(
+                favicon_url,
+                expected_favicon_url,
+                "The favicon URL should match the expected value.",
+            )


### PR DESCRIPTION
When a  favicon is set for a website, it incorrectly uses the company's favicon instead of the website's specific favicon. This causes confusion and inconsistency in the branding of the website.

This commit fixes the issue by ensuring that the website's custom favicon is correctly displayed when set, overriding the company's favicon for that specific website.

Steps to reproduce:
1. Set a custom favicon for a website.
2. Set another favicon for the company itself.
3. Observe that the company's favicon is used instead of the website's custom favicon.

With this fix, the website's custom favicon is now correctly displayed.

Video with the issue --> https://drive.google.com/file/d/1e8EYmIAb05fXfW_ec2P5gMj6iSH1KoZ-/view