### PR TITLE
[16.0][FIX] web_refresher: Define displayRefresher in setup instead of using a getter

### DIFF
--- a/web_refresher/static/src/js/control_panel.esm.js
+++ b/web_refresher/static/src/js/control_panel.esm.js
@@ -24,11 +24,8 @@ patch(ControlPanel.prototype, "web_refresher.ControlPanel", {
             searchModel: this.env.searchModel,
             pagerProps: this.pagerProps,
         };
-    },
-    /**
-     * @returns {Boolean}
-     */
-    get displayRefresher() {
-        return !this.forbiddenSubTypes.includes(this.env.config.viewSubType);
+        this.displayRefresher = !this.forbiddenSubTypes.includes(
+            this.env.config.viewSubType
+        );
     },
 });


### PR DESCRIPTION
Before this changes whe trying to access to a view with the refresher, in mobile view, an error was thrown.

As it is not necessary to define the value in a get function, defining the value in the setup solves the problem.

cc @Tecnativa TT50296

ping @pedrobaeza @victoralmau 