### PR TITLE
[16.0][IMP] web_responsive: Set AttachmentViewer z-index upper than chatter

### DIFF
--- a/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
+++ b/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss
@@ -14,7 +14,7 @@
         }
         .o_AttachmentViewer {
             // On-top of navbar
-            z-index: 10;
+            z-index: 1100;
             position: absolute;
             right: 0;
             top: 0;


### PR DESCRIPTION
Before this changes when oppening an attachment from the chatter the attachment was behind the chatter and if we try to hide it, the attachement disappears.

Example:
![Error shown](https://github.com/user-attachments/assets/313ba73a-9480-4bd1-b6db-a73b358db9ea)

With this changes the AttachmentViewer appears in front of the chatter and the problem does not exists anymore.

Example:
![solución](https://github.com/user-attachments/assets/5a129c25-a83e-440c-8e33-e2aa5c01a725)

cc @Tecnativa TT50272 

ping @pedrobaeza @pilarvargas-tecnativa 