### PR TITLE
[15.0][FIX] web_m2x_options: Functions used on buttons are not working

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -29,6 +29,11 @@ odoo.define("web_m2x_options.web_m2x_options", function (require) {
         init: function (parent, name, value) {
             this.name = name;
             this.value = value;
+            // Define methods for the dialog binding the parent Object to make the
+            // actions on the correct context.
+            this.quickCreate = parent._quickCreate.bind(parent);
+            this.searchCreatePopup = parent._searchCreatePopup.bind(parent);
+            this.createContext = parent._createContext.bind(parent);
             this._super(parent, {
                 title: _.str.sprintf(_t("Create a %s"), this.name),
                 size: "medium",
@@ -37,14 +42,8 @@ odoo.define("web_m2x_options.web_m2x_options", function (require) {
                         text: _t("Create"),
                         classes: "btn-primary",
                         click: function () {
-                            if (this.$("input").val()) {
-                                this.trigger_up("quick_create", {
-                                    value: this.$("input").val(),
-                                });
-                                this.close(true);
-                            } else {
-                                this.$("input").focus();
-                            }
+                            this.quickCreate(this.value);
+                            this.close(true);
                         },
                     },
                     {
@@ -52,10 +51,8 @@ odoo.define("web_m2x_options.web_m2x_options", function (require) {
                         classes: "btn-primary",
                         close: true,
                         click: function () {
-                            this.trigger_up("search_create_popup", {
-                                view_type: "form",
-                                value: this.$("input").val(),
-                            });
+                            const valueContext = this.createContext(this.value);
+                            this.searchCreatePopup("form", false, valueContext);
                         },
                     },
                     {


### PR DESCRIPTION
Before this PR when trying to create a record using the Dialog, when pressing the buttons Create or Create and Edit they are having no effect.
![buttons not working](https://github.com/user-attachments/assets/37bd5d02-2c07-4a1d-952e-a1ecf7aeeb25)

After this PR the code is addapted to the new dialog to make the buttons work as usual.
![buttons working gif](https://github.com/user-attachments/assets/96d5b5b3-682d-40a7-bbb4-d528a28a6a61)

Steps to reproduce the problem:
    1. Go to any m2o field
    2. Write a name that does not exist
    3. Loose the focus
    4. Press on button "Create" or "Create and Edit"

cc @Tecnativa TT50338

ping @carolinafernandez-tecnativa @pilarvargas-tecnativa 