### PR TITLE
[16.0][FIX] web_company_color: Set defaults hardcoded to avoid errors charging the assetbundle

### DIFF
--- a/web_company_color/__manifest__.py
+++ b/web_company_color/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Web Company Color",
     "category": "web",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.2.1",
     "author": "Alexandre Díaz, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",
     "depends": ["web", "base_sparse_field"],

--- a/web_company_color/migrations/16.0.1.2.1/post-migration.py
+++ b/web_company_color/migrations/16.0.1.2.1/post-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2024 Tecnativa - Carlos Roca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    companies = env["res.company"].search([("company_colors", "!=", False)])
+    companies.scss_create_or_update_attachment()

--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -83,8 +83,15 @@ class ResCompany(models.Model):
         .o_arrow_button.btn-primary.disabled {
           color: %(color_link_text)s !important;
         }
-        .o_required_modifier.o_input, .o_required_modifier .o_input {
-          background-color: lighten(%(color_button_bg)s, 10%%) !important;
+        .o_required_modifier{
+          :focus-within {
+            --o-input-border-color: %(color_button_bg)s !important;
+            --o-caret-color: %(color_button_bg)s !important;
+          }
+          input:hover, .o_field_many2one_selection:hover {
+            --o-input-border-color: %(color_button_bg)s !important;
+            --o-caret-color: %(color_button_bg)s !important;
+          }
         }
     """
 
@@ -172,14 +179,13 @@ class ResCompany(models.Model):
                 "color_navbar_bg": (values.get("color_navbar_bg") or "$o-brand-odoo"),
                 "color_navbar_bg_hover": (values.get("color_navbar_bg_hover")),
                 "color_navbar_text": (values.get("color_navbar_text") or "#FFF"),
-                "color_button_bg": values.get("color_button_bg") or "$primary",
+                "color_button_bg": values.get("color_button_bg") or "#71639e",
                 "color_button_bg_hover": values.get("color_button_bg_hover")
-                or 'darken(theme-color("primary"), 10%)',
+                or "darken(#71639e, 10%)",
                 "color_button_text": values.get("color_button_text") or "#FFF",
-                "color_link_text": values.get("color_link_text")
-                or 'theme-color("primary")',
+                "color_link_text": values.get("color_link_text") or "#71639e",
                 "color_link_text_hover": values.get("color_link_text_hover")
-                or 'darken(theme-color("primary"), 10%)',
+                or "darken(#71639e, 10%)",
             }
         )
         return values

--- a/web_company_color/static/description/index.html
+++ b/web_company_color/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -430,7 +430,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
When trying to charge the assetbundle the theme-color("primary") function is not found what causes problems when trying to set the default values.
![Example_no_change](https://github.com/user-attachments/assets/9dae7ede-f863-413c-a2fc-2c6306e90836)

With this changes the default value is the value set on https://github.com/odoo/odoo/blob/ad9f8fae717aae4cad5b3715c1f73ee906b64f8d/addons/web/static/src/scss/primary_variables.scss#L55 this change avoid the problems and the module works fine.
![Example_change](https://github.com/user-attachments/assets/73d87021-afe9-44ab-a244-8d8fb0c258e0)

Addapted too the class for required fields.

cc @Tecnativa TT50098

ping @sergio-teruel @pilarvargas-tecnativa 