### PR TITLE
[16.0][FIX] web_widget_numeric_step: Remove focus to avoid annoying flickering effect

### DIFF
--- a/web_widget_numeric_step/static/src/numeric_step.esm.js
+++ b/web_widget_numeric_step/static/src/numeric_step.esm.js
@@ -4,17 +4,12 @@ import {registry} from "@web/core/registry";
 import {standardFieldProps} from "@web/views/fields/standard_field_props";
 import {_lt} from "@web/core/l10n/translation";
 import {FloatField} from "@web/views/fields/float/float_field";
-import {hasTouch} from "@web/core/browser/feature_detection";
 
 export class NumericStep extends FloatField {
     setup() {
         super.setup();
     }
     _onStepClick(ev) {
-        const $el = $(ev.target).parent().parent().find("input");
-        if (!hasTouch()) {
-            $el.focus();
-        }
         const mode = $(ev.target).data("mode");
         this._doStep(mode);
     }


### PR DESCRIPTION
The focus introduced on the 16.0 migration is causing a flickering effect that is a bit annoying and does not make complete sense, because if you click more than once the cursor is positioned at the end of the text, which makes it difficult to edit the input.

The counterpart of these changes is that to edit the input using the keyboard we will have to click on the field. Although this is how the module has been operating since its inception.

Before this changes:
![parpadeo](https://github.com/user-attachments/assets/847710b3-68e3-49c9-a522-a24e48d8985e)

After this changes:
![no parpadeo](https://github.com/user-attachments/assets/571d7000-0643-40a6-9d06-8822c10487b5)

cc @Tecnativa TT50439

ping @chienandalu @pedrobaeza 