### PR TITLE
[16.0][FIX] web_responsive: Remove overflow:visible to tables to avoid side effects

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -250,7 +250,6 @@ html .o_web_client .o_action_manager .o_action {
 // Sticky Header & Footer in List View
 .o_list_view {
     .table-responsive {
-        overflow: visible;
         .o_list_table {
             // th & td are here for compatibility with chrome
             thead tr:nth-child(1) th {


### PR DESCRIPTION
Remove overflow:visible to tables to avoid side effects

**Without `web_responsive`**
![sin-web-responsive](https://github.com/user-attachments/assets/4a537fea-6e17-4ab9-a3a4-94ed4e5a31a0)

**With `web_responsive` - before**
![antes-web_responsive](https://github.com/user-attachments/assets/fe196ef5-cea7-495d-8e8a-c05001bd14ea)

**With `web_responsive` - after**
![despues-web_responsive](https://github.com/user-attachments/assets/58afc164-34dd-4cf0-8dc1-165fcab4aa64)

Please @CarlosRoca13 can you review it?

@Tecnativa TT50468