### PR TITLE
[16.0][FIX] web_refresher: bug when clicking on production plan

### DIFF
--- a/web_refresher/__manifest__.py
+++ b/web_refresher/__manifest__.py
@@ -10,11 +10,15 @@
     "assets": {
         "web.assets_backend": [
             "web_refresher/static/src/**/*.scss",
-            "web_refresher/static/src/**/*.esm.js",
             "web_refresher/static/src/xml/refresher.xml",
             # Load the modification of the master template just after it,
             # for having the modification in all the primary extensions.
             # Example: the project primary view.
+            (
+                "after",
+                "web/static/src/search/control_panel/control_panel.js",
+                "web_refresher/static/src/**/*.esm.js",
+            ),
             (
                 "after",
                 "web/static/src/search/control_panel/control_panel.xml",


### PR DESCRIPTION
Issue: https://github.com/OCA/web/issues/2898

The problem described above occurred in enterprise modules