### PR TITLE
[17.0][FIX] web_m2x_options: Error when installing employee module

### DIFF
--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -6,7 +6,11 @@ import {
 } from "@web/views/fields/many2many_tags/many2many_tags_field";
 import {Many2OneField, many2OneField} from "@web/views/fields/many2one/many2one_field";
 import {FormController} from "@web/views/form/form_controller";
-import {Many2OneAvatarField} from "@web/views/fields/many2one_avatar/many2one_avatar_field";
+import {
+    KanbanMany2OneAvatarField,
+    Many2OneAvatarField,
+} from "@web/views/fields/many2one_avatar/many2one_avatar_field";
+
 import {Many2XAutocomplete} from "@web/views/fields/relational_utils";
 import {evaluateBooleanExpr} from "@web/core/py_js/py";
 import {isX2Many} from "@web/views/utils";
@@ -21,6 +25,12 @@ Many2OneField.props = {
 };
 Many2XAutocomplete.props = {
     ...Many2XAutocomplete.props,
+    fieldColor: {type: String, optional: true},
+    fieldColorOptions: {type: Object, optional: true},
+};
+
+KanbanMany2OneAvatarField.props = {
+    ...KanbanMany2OneAvatarField.props,
     fieldColor: {type: String, optional: true},
     fieldColorOptions: {type: Object, optional: true},
 };


### PR DESCRIPTION
When web_m2x_options is installed, and you install the employee module, you cannot open the employee app and get this error message (development mode needs to be active): 

![image](https://github.com/user-attachments/assets/d42c2939-1a56-4b40-9f9f-ae821c640bbd)

The components Many2OneAvatarUserField and KanbanMany2OneAvatarUserField causing this error.

~~I am not sure if this is the best solution, because it also changes the dependency from "web" to "mail".~~
Review feedback highly welcome. 