### PR TITLE
[17.0][FIX] web_m2x_options: Error opening product form on shopfloor

### DIFF
--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -355,7 +355,7 @@ patch(FormController.prototype, {
                 viewType = isSmall ? "kanban" : "list";
             }
             field.viewMode = viewType;
-            if (field.views[viewType] && limit) {
+            if (field.views && field.views[viewType] && limit) {
                 field.views[viewType].limit = limit;
             }
         }


### PR DESCRIPTION
Error when trying to open product in shopfloor. Because we are trying to get the viewType from an undefined field.views
![image](https://github.com/user-attachments/assets/5647ea23-ea17-4c94-8ce5-19183fde1efc)
