### PR TITLE
[15.0][FIX] web_notify: don't ignore actions without custom params

### DIFF
--- a/web_notify/static/src/js/services/notification_services.esm.js
+++ b/web_notify/static/src/js/services/notification_services.esm.js
@@ -10,6 +10,7 @@ export const webNotificationService = {
         let webNotifTimeouts = {};
         /**
          * Displays the web notification on user's screen
+         * @param {Array} notifications
          */
         function displaywebNotification(notifications) {
             Object.values(webNotifTimeouts).forEach((notif) =>
@@ -18,32 +19,35 @@ export const webNotificationService = {
             webNotifTimeouts = {};
             notifications.forEach((notif) => {
                 browser.setTimeout(() => {
+                    var buttons = [];
+                    if (notif.action) {
+                        const params =
+                            (notif.action.context && notif.action.context.params) || {};
+                        buttons = [
+                            {
+                                name: params.button_name || env._t("Open"),
+                                primary: true,
+                                onClick: async () => {
+                                    await action.doAction(notif.action);
+                                },
+                                ...(params.button_icon && {icon: params.button_icon}),
+                            },
+                        ];
+                    }
                     const notificationRemove = notification.add(Markup(notif.message), {
                         title: notif.title,
                         type: notif.type,
                         sticky: notif.sticky,
                         className: notif.className,
                         messageIsHtml: notif.html,
-                        buttons:
-                            notif.action &&
-                            notif.action.context &&
-                            notif.action.context.params
-                                ? [
-                                      {
-                                          name:
-                                              notif.action.context.params.button_name ||
-                                              env._t("Open"),
-                                          primary: true,
-                                          onClick: async function () {
-                                              await action.doAction(notif.action);
-                                              notificationRemove();
-                                          },
-                                          icon:
-                                              notif.action.context.params.button_icon ||
-                                              undefined,
-                                      },
-                                  ]
-                                : [],
+                        buttons: buttons.map((button) => {
+                            const onClick = button.onClick;
+                            button.onClick = async () => {
+                                await onClick();
+                                notificationRemove();
+                            };
+                            return button;
+                        }),
                     });
                 });
             });


### PR DESCRIPTION
In the previous improvement of adding parametrizable actions button properties to the notification we are ignoring regular actions with no parameters. This way, everything works as expected.

cc @Tecnativa please review @CarlosRoca13 @sergio-teruel 