### PR TITLE
[16.0][FIX] web_editor_class_selector: Avoid errors when custom CSS class is not present

### DIFF
--- a/web_editor_class_selector/static/src/js/odoo-editor/OdooEditor.esm.js
+++ b/web_editor_class_selector/static/src/js/odoo-editor/OdooEditor.esm.js
@@ -11,7 +11,7 @@ import {OdooEditor} from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
 patch(OdooEditor.prototype, "web_editor_class_selector.OdooEditor", {
     _updateToolbar(show) {
         const res = this._super(show);
-        if (!this.toolbar) {
+        if (!this.toolbar || !this.custom_class_css) {
             return res;
         }
         const sel = this.document.getSelection();


### PR DESCRIPTION

1. Go to the website
2. Open the editor
3. Add text and select it, a traceback is shown

@Tecnativa TT50538

@pedrobaeza 