### PR TITLE
[16.0][FIX] web_field_tooltip: set max width for the tooltip and fixed odoo dark mode

### DIFF
--- a/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.esm.js
+++ b/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.esm.js
@@ -19,7 +19,8 @@ export class FieldTooltip extends Component {
         this.showAddHelper =
             session.can_manage_tooltips && session.tooltip_show_add_helper;
         this.fieldTooltip = this.props.field.field_tooltip;
-
+        this.colorMode =
+            this.env.services.cookie.current.color_scheme === "dark" ? "dark" : "light";
         if (session.can_manage_tooltips) {
             this.dialogService = useService("dialog");
         }
@@ -30,6 +31,7 @@ export class FieldTooltip extends Component {
         return {
             title: props.field.string,
             help: markup(this.tooltipText),
+            colorMode: this.colorMode,
         };
     }
 

--- a/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.esm.js
+++ b/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.esm.js
@@ -66,7 +66,6 @@ export class FieldTooltip extends Component {
             {
                 closeOnClickAway: true,
                 position: "top",
-                title: "title",
             }
         );
     }

--- a/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.scss
+++ b/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.scss
@@ -33,4 +33,15 @@ sup.field-tooltip {
     .popover-content {
         background-color: white;
     }
+
+    &.popup-dark-mode {
+        .popover-title {
+            font-weight: bold;
+            background-color: #242733;
+        }
+
+        .popover-content {
+            background-color: unset;
+        }
+    }
 }

--- a/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.scss
+++ b/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.scss
@@ -18,6 +18,7 @@ sup.field-tooltip {
 
 .popup-div {
     min-width: 100px;
+    max-width: 400px;
     min-height: 30px;
 
     > * {

--- a/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.xml
+++ b/web_field_tooltip/static/src/components/field_tooltip/field_tooltip.xml
@@ -16,7 +16,9 @@
     </t>
 
     <t t-name="web_field_tooltip.FieldTooltipPopover" owl="1">
-        <div class="popup-div">
+        <div
+            t-attf-class="popup-div {{ props.colorMode === 'dark' ? 'popup-dark-mode' : '' }}"
+        >
             <div class="popover-title">
                 <span t-esc="props.title" />
             </div>


### PR DESCRIPTION
- set max width for the tooltip to prevent weird behaviors where a tooltip could be placed outside the window when its a content was a long text
- fixed popup colors when using odoo dark mode