### PR TITLE
[FIX] web_company_color: Colors where not shown correctly

### DIFF
--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -45,15 +45,22 @@ class ResCompany(models.Model):
             }
           }
         }
-        a[href],
-        a[tabindex],
-        .btn-link,
-        .o_external_button {
-          color: %(color_link_text)s !important;
-        }
+
+          a[href],
+          a[tabindex],
+          .btn-link,
+          .o_external_button {
+            color: %(color_link_text)s;
+            .o_main_navbar {
+            color: none;
+            }
+          }
         a:hover,
         .btn-link:hover {
-          color: %(color_link_text_hover)s !important;
+          color: %(color_link_text_hover)s;
+          .o_main_navbar {
+            color: none;
+          }
         }
         .btn-primary:not(.disabled),
         .ui-autocomplete .ui-menu-item > a.ui-state-active {


### PR DESCRIPTION
Without this change, we have the following top:

![Captura desde 2024-10-04 10-18-22](https://github.com/user-attachments/assets/53c49008-4442-4803-b420-f32d9e8ec195)

Now we have:

![image](https://github.com/user-attachments/assets/be0b94b4-e6c4-44f5-b2df-d79accc4c095)
