### PR TITLE
[15.0][FIX] web_widget_open_tab: add missing encoding on etree.tostring

### DIFF
--- a/web_widget_open_tab/models/ir_ui_view.py
+++ b/web_widget_open_tab/models/ir_ui_view.py
@@ -34,5 +34,5 @@ class Base(models.AbstractModel):
                 tree.insert(name_field[0].getparent().index(name_field[0]) + 1, id_elem)
             else:
                 tree.insert(0, id_elem)
-        res["arch"] = etree.tostring(arch)
+        res["arch"] = etree.tostring(arch, encoding="utf-8")
         return res


### PR DESCRIPTION
Related: https://github.com/odoo/odoo/pull/66866
@qrtl QT4867