### PR TITLE
[16.0][IMP] web_notify: close everywhere

### DIFF
--- a/web_notify/README.rst
+++ b/web_notify/README.rst
@@ -143,6 +143,7 @@ Contributors
 * Aitor Bouzas <aitor.bouzas@adaptivecity.com>
 * Shepilov Vladislav <shepilov.v@protonmail.com>
 * Kevin Khao <kevin.khao@akretion.com>
+* Carlos Jimeno <carlos.jimeno@braintec.com>
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * David Vidal

--- a/web_notify/models/res_users.py
+++ b/web_notify/models/res_users.py
@@ -1,5 +1,7 @@
 # Copyright 2016 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import uuid
+
 from odoo import _, api, exceptions, fields, models
 
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
@@ -122,7 +124,11 @@ class ResUsers(models.Model):
             target = self.partner_id
         if action:
             action = clean_action(action, self.env)
+
+        unique_id = str(uuid.uuid4())
+
         bus_message = {
+            "id": unique_id,
             "type": type_message,
             "message": message,
             "title": title,
@@ -132,4 +138,19 @@ class ResUsers(models.Model):
         }
 
         notifications = [[partner, "web.notify", [bus_message]] for partner in target]
+        self.env["bus.bus"]._sendmany(notifications)
+
+    @api.model
+    def notify_dismiss(self, notif_id):
+        partner_id = self.env.user.partner_id.id
+        bus_message = {
+            "id": notif_id,
+        }
+        notifications = [
+            [
+                (self.env.cr.dbname, "res.partner", partner_id),
+                "web.notify.dismiss",
+                [bus_message],
+            ]
+        ]
         self.env["bus.bus"]._sendmany(notifications)

--- a/web_notify/readme/CONTRIBUTORS.rst
+++ b/web_notify/readme/CONTRIBUTORS.rst
@@ -3,6 +3,7 @@
 * Aitor Bouzas <aitor.bouzas@adaptivecity.com>
 * Shepilov Vladislav <shepilov.v@protonmail.com>
 * Kevin Khao <kevin.khao@akretion.com>
+* Carlos Jimeno <carlos.jimeno@braintec.com>
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * David Vidal

--- a/web_notify/static/description/index.html
+++ b/web_notify/static/description/index.html
@@ -473,6 +473,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Aitor Bouzas &lt;<a class="reference external" href="mailto:aitor.bouzas&#64;adaptivecity.com">aitor.bouzas&#64;adaptivecity.com</a>&gt;</li>
 <li>Shepilov Vladislav &lt;<a class="reference external" href="mailto:shepilov.v&#64;protonmail.com">shepilov.v&#64;protonmail.com</a>&gt;</li>
 <li>Kevin Khao &lt;<a class="reference external" href="mailto:kevin.khao&#64;akretion.com">kevin.khao&#64;akretion.com</a>&gt;</li>
+<li>Carlos Jimeno &lt;<a class="reference external" href="mailto:carlos.jimeno&#64;braintec.com">carlos.jimeno&#64;braintec.com</a>&gt;</li>
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>David Vidal</li>
 </ul>

--- a/web_notify/tests/test_res_users.py
+++ b/web_notify/tests/test_res_users.py
@@ -26,6 +26,8 @@ class TestResUsers(common.TransactionCase):
         self.assertEqual(1, len(news))
         test_msg.update({"type": SUCCESS})
         payload = json.loads(news.message)["payload"][0]
+        self.assertIn("id", payload)
+        payload.pop("id", None)
         self.assertDictEqual(test_msg, payload)
 
     def test_notify_danger(self):
@@ -44,6 +46,8 @@ class TestResUsers(common.TransactionCase):
         self.assertEqual(1, len(news))
         test_msg.update({"type": DANGER})
         payload = json.loads(news.message)["payload"][0]
+        self.assertIn("id", payload)
+        payload.pop("id", None)
         self.assertDictEqual(test_msg, payload)
 
     def test_notify_warning(self):
@@ -62,6 +66,8 @@ class TestResUsers(common.TransactionCase):
         self.assertEqual(1, len(news))
         test_msg.update({"type": WARNING})
         payload = json.loads(news.message)["payload"][0]
+        self.assertIn("id", payload)
+        payload.pop("id", None)
         self.assertDictEqual(test_msg, payload)
 
     def test_notify_info(self):
@@ -80,6 +86,8 @@ class TestResUsers(common.TransactionCase):
         self.assertEqual(1, len(news))
         test_msg.update({"type": INFO})
         payload = json.loads(news.message)["payload"][0]
+        self.assertIn("id", payload)
+        payload.pop("id", None)
         self.assertDictEqual(test_msg, payload)
 
     def test_notify_default(self):
@@ -98,6 +106,8 @@ class TestResUsers(common.TransactionCase):
         self.assertEqual(1, len(news))
         test_msg.update({"type": DEFAULT})
         payload = json.loads(news.message)["payload"][0]
+        self.assertIn("id", payload)
+        payload.pop("id", None)
         self.assertDictEqual(test_msg, payload)
 
     def test_notify_many(self):
@@ -117,3 +127,14 @@ class TestResUsers(common.TransactionCase):
     def test_notify_admin_allowed_other_user(self):
         other_user = self.env.ref("base.user_demo")
         other_user.notify_info(message="hello")
+
+    def test_notify_dismiss(self):
+        bus_bus = self.env["bus.bus"]
+        domain = [("channel", "=", self.env.user.notify_default_channel_name)]
+        existing = bus_bus.search(domain)
+        notif_id = "test-notif-id"
+        self.env.user.notify_dismiss(notif_id)
+        news = bus_bus.search(domain) - existing
+        self.assertEqual(1, len(news))
+        payload = json.loads(news.message)["payload"][0]
+        self.assertEqual(payload["id"], notif_id)


### PR DESCRIPTION
If a user gets a notification with sticky: True and has multiple tabs open, it needs to be closed manually in each of the tabs.
With these changes, closing it from any tab should also close it in the rest of the tabs.