### PR TITLE
[16.0][IMP] web_field_tooltip: Enable translation

### DIFF
--- a/web_field_tooltip/models/ir_model_fields_tooltip.py
+++ b/web_field_tooltip/models/ir_model_fields_tooltip.py
@@ -35,7 +35,7 @@ class IrModelFieldsTooltip(models.Model):
         help="Set active to false to hide the Tooltip without removing it.",
     )
     field_name = fields.Char(related="field_id.name")
-    tooltip_text = fields.Html(required=True)
+    tooltip_text = fields.Html(required=True, translate=True)
 
     @api.model
     def default_get(self, fields_list):


### PR DESCRIPTION
Enable translation for tooltip text to support multi-language environments.
This change will not affect existing data.

@qrtl QT4613