### PR TITLE
[16.0][IMP] web_timeline: implementing readonly_field attribute: a boolean field to mark the event as not editable

### DIFF
--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -37,6 +37,8 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
             this.date_stop = params.date_stop;
             this.date_delay = params.date_delay;
             this.colors = params.colors;
+            this.readonly_field = params.readonly_field;
+
             this.fieldNames = params.fieldNames;
             this.default_group_by = params.default_group_by;
             this.dependency_arrow = params.dependency_arrow;
@@ -537,6 +539,9 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
             // ➔ Instantaneous events / those with inverted dates are displayed as points.
             if (date_stop && moment(date_start).isBefore(date_stop)) {
                 r.end = date_stop;
+            }
+            if (this.readonly_field && evt[this.readonly_field]) {
+                r.editable = false;
             }
             this.color = null;
             return r;

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -75,6 +75,10 @@ odoo.define("web_timeline.TimelineView", function (require) {
                 (item) => item.attrs.name
             );
             fieldNames = _.union(fieldNames, archFieldNames);
+            if (attrs.readonly_field) {
+                fieldNames.push(attrs.readonly_field);
+            }
+            const readonly_field = attrs.readonly_field;
 
             const colors = this.parse_colors();
             for (const color of colors) {
@@ -111,6 +115,7 @@ odoo.define("web_timeline.TimelineView", function (require) {
             this.rendererParams.date_stop = date_stop;
             this.rendererParams.date_delay = date_delay;
             this.rendererParams.colors = colors;
+            this.rendererParams.readonly_field = readonly_field;
             this.rendererParams.fieldNames = fieldNames;
             this.rendererParams.default_group_by = attrs.default_group_by;
             this.rendererParams.min_height = min_height;


### PR DESCRIPTION
Marks events as non editable following a field in the model