### PR TITLE
[16.0][FIX] web_advanced_search: display label name in partners search

### DIFF
--- a/web_advanced_search/static/src/search/filter_menu/custom_filter_item.esm.js
+++ b/web_advanced_search/static/src/search/filter_menu/custom_filter_item.esm.js
@@ -15,19 +15,21 @@ patch(CustomFilterItem.prototype, "web_advanced_search.CustomFilterItem", {
         this._super.apply(this, arguments);
         this.OPERATORS.relational = this.OPERATORS.char;
         this.FIELD_TYPES.many2one = "relational";
+        this.FIELD_TYPES.many2many = "relational";
+        this.FIELD_TYPES.one2many = "relational";
     },
     /**
      * @override
      */
     setDefaultValue(condition) {
-        const res = this._super.apply(this, arguments);
         const fieldType = this.fields[condition.field].type;
         const genericType = this.FIELD_TYPES[fieldType];
         if (genericType === "relational") {
             condition.value = 0;
             condition.displayedValue = "";
+            return;
         }
-        return res;
+        return this._super.apply(this, arguments);
     },
     /**
      * Add displayed value to preFilters for "relational" types.


### PR DESCRIPTION
Without this patch, when searching in the `res.partner` view for 'Tags is equal to "Something"', the search bar would display "Tags is equal to "123"' (the tag ID instead of its display name).

Before:
![image](https://github.com/user-attachments/assets/1191c3d8-b7e7-41f6-9422-e865246fbd37)


After:
![image](https://github.com/user-attachments/assets/d7b0ce29-ea11-4c98-ae28-e0c033a51be8)


@moduon MT-7870