### PR TITLE
[16.0][FIX] web_responsive: avoid break style of Sales Teams

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -158,7 +158,6 @@ html .o_web_client .o_action_manager .o_action {
         // Support for long title (with ellipsis)
         .oe_title {
             .o_field_widget:not(.oe_inline) {
-                display: block;
                 span:not(.o_field_translate):not(.o_status) {
                     display: block;
                     max-width: 100%;


### PR DESCRIPTION
Before:
![Screenshot from 2024-11-12 17-08-10](https://github.com/user-attachments/assets/5d04f0b9-8086-4125-88b8-a614ce39e95f)

After:
![Screenshot from 2024-11-12 17-07-51](https://github.com/user-attachments/assets/cf53f07a-d5c9-41fb-9d19-de77534d1dfe)
