### PR TITLE
[12.0][ADD] web_translate_dialog: remove hidden field from wizzard

### DIFF
--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -66,11 +66,24 @@ var TranslateDialog = Dialog.extend({
             }
         });
     },
+    get_list_hidden_field_names: function(parent) {
+        var field_list = [];
+        var record_id = this.record_id;
+        _.each(parent.renderer.allModifiersData, function(modifier){
+            var evaluatedmodifier = modifier.evaluatedModifiers[record_id];
+            if (modifier.node.tag == 'field' && evaluatedmodifier && evaluatedmodifier.hasOwnProperty("invisible") && evaluatedmodifier.invisible == true){
+                field_list.push(modifier.node.attrs.name);
+            }
+        });
+        return field_list;
+    }
+    ,
     get_translatable_fields: function(parent) {
         var field_list = {};
+        var hidden_fields = this.get_list_hidden_field_names(parent);
         _.each(parent.renderer.state.fields, function(field, name){
             var related_readonly = typeof field.related !== 'undefined' && field.readonly;
-            if (field.translate == true && !related_readonly && parent.renderer.state.getFieldNames().includes(name)){
+            if (field.translate == true && !related_readonly && parent.renderer.state.getFieldNames().includes(name) && !hidden_fields.includes(name)){
                 field_list[name] = field;
             }
         });

--- a/web_translate_dialog/static/src/js/web_translate_dialog.js
+++ b/web_translate_dialog/static/src/js/web_translate_dialog.js
@@ -71,7 +71,7 @@ var TranslateDialog = Dialog.extend({
         var record_id = this.record_id;
         _.each(parent.renderer.allModifiersData, function(modifier){
             var evaluatedmodifier = modifier.evaluatedModifiers[record_id];
-            if (modifier.node.tag == 'field' && evaluatedmodifier && evaluatedmodifier.hasOwnProperty("invisible") && evaluatedmodifier.invisible == true){
+            if (modifier.node.tag == 'field' && evaluatedmodifier?.invisible){
                 field_list.push(modifier.node.attrs.name);
             }
         });


### PR DESCRIPTION
This PR contain a new method to check fields evaluated as invisible = true. in this case the field shall not appear on the wizzard.  we shall not translate field not use in the form that is showed to the client.