### PR TITLE
[16.0][IMP] web_timeline - support multiple group-by levels and allow to group by m2m field

### DIFF
--- a/web_timeline/README.rst
+++ b/web_timeline/README.rst
@@ -181,8 +181,6 @@ Known issues / Roadmap
 
 * Implement a more efficient way of refreshing timeline after a record update;
 * Make ``attrs`` attribute work;
-* When grouping by m2m and more than one record is set, the timeline item appears only
-  on one group. Allow showing in both groups.
 * When grouping by m2m and dragging for changing the time or the group, the changes on
   the group will not be set, because it could make disappear the records not related
   with the changes that we want to make. When the item is showed in all groups change
@@ -190,6 +188,7 @@ Known issues / Roadmap
 * When an item label does not fit in its date-range box: ✅ the label correctly overflows
   the box; ✅ clicking anywhere on the label allows moving the box; ❌ double-clicking
   the label outside of the box does not open that item.
+* Take into account action window's context to overwrite the default group_by.
 
 Bug Tracker
 ===========
@@ -237,6 +236,10 @@ Contributors
 * `XCG Consulting <https://xcg-consulting.fr>`_:
 
   * Houzéfa Abbasbhay
+
+* `Komit <https://komit-consulting.com>`_:
+
+  * Cuong Nguyen Mtm <cuong.nmtm@komit-consulting.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_timeline/demo/ir_cron_view.xml
+++ b/web_timeline/demo/ir_cron_view.xml
@@ -5,7 +5,7 @@
         <field name="model">ir.cron</field>
         <field name="type">timeline</field>
         <field name="arch" type="xml">
-            <timeline date_start="nextcall" default_group_by="model_id" />
+            <timeline date_start="nextcall" default_group_by="interval_type,model_id" />
         </field>
     </record>
     <!-- Append our view_mode this way to avoid overwriting changes done by other modules. -->

--- a/web_timeline/readme/CONTRIBUTORS.rst
+++ b/web_timeline/readme/CONTRIBUTORS.rst
@@ -19,3 +19,7 @@
 * `XCG Consulting <https://xcg-consulting.fr>`_:
 
   * Houzéfa Abbasbhay
+
+* `Komit <https://komit-consulting.com>`_:
+
+  * Cuong Nguyen Mtm <cuong.nmtm@komit-consulting.com>

--- a/web_timeline/readme/ROADMAP.rst
+++ b/web_timeline/readme/ROADMAP.rst
@@ -1,7 +1,5 @@
 * Implement a more efficient way of refreshing timeline after a record update;
 * Make ``attrs`` attribute work;
-* When grouping by m2m and more than one record is set, the timeline item appears only
-  on one group. Allow showing in both groups.
 * When grouping by m2m and dragging for changing the time or the group, the changes on
   the group will not be set, because it could make disappear the records not related
   with the changes that we want to make. When the item is showed in all groups change
@@ -9,3 +7,4 @@
 * When an item label does not fit in its date-range box: ✅ the label correctly overflows
   the box; ✅ clicking anywhere on the label allows moving the box; ❌ double-clicking
   the label outside of the box does not open that item.
+* Take into account action window's context to overwrite the default group_by.

--- a/web_timeline/static/description/index.html
+++ b/web_timeline/static/description/index.html
@@ -553,8 +553,6 @@ with the dragged start and end date.</p>
 <ul class="simple">
 <li>Implement a more efficient way of refreshing timeline after a record update;</li>
 <li>Make <tt class="docutils literal">attrs</tt> attribute work;</li>
-<li>When grouping by m2m and more than one record is set, the timeline item appears only
-on one group. Allow showing in both groups.</li>
 <li>When grouping by m2m and dragging for changing the time or the group, the changes on
 the group will not be set, because it could make disappear the records not related
 with the changes that we want to make. When the item is showed in all groups change
@@ -562,6 +560,7 @@ the value according the group of the dragged item.</li>
 <li>When an item label does not fit in its date-range box: ✅ the label correctly overflows
 the box; ✅ clicking anywhere on the label allows moving the box; ❌ double-clicking
 the label outside of the box does not open that item.</li>
+<li>Take into account action window’s context to overwrite the default group_by.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
@@ -607,6 +606,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://xcg-consulting.fr">XCG Consulting</a>:<ul>
 <li>Houzéfa Abbasbhay</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://komit-consulting.com">Komit</a>:<ul>
+<li>Cuong Nguyen Mtm &lt;<a class="reference external" href="mailto:cuong.nmtm&#64;komit-consulting.com">cuong.nmtm&#64;komit-consulting.com</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/web_timeline/static/src/js/timeline_controller.esm.js
+++ b/web_timeline/static/src/js/timeline_controller.esm.js
@@ -6,6 +6,7 @@ import {Component} from "@odoo/owl";
 import Dialog from "web.Dialog";
 import {FormViewDialog} from "@web/views/view_dialogs/form_view_dialog";
 import core from "web.core";
+import field_utils from "web.field_utils";
 import time from "web.time";
 var _t = core._t;
 
@@ -51,56 +52,111 @@ export default AbstractController.extend({
             adjust_window: true,
         });
         const domains = params.domain || this.renderer.last_domains || [];
-        const contexts = params.context || [];
-        const group_bys = params.groupBy || this.renderer.last_group_bys || [];
-        this.last_domains = domains;
-        this.last_contexts = contexts;
 
-        const cleanGroupBys = (groupBys) => {
-            return groupBys.map((group) => {
-                if (group.includes(":")) {
-                    return group.split(":")[0];
-                }
-                return group;
-            });
-        };
-
-        // Select the group by
-        let n_group_bys = group_bys;
-        let arch_attrs_default_group_by = this.renderer.arch.attrs.default_group_by
+        // Determine the group_by specifiers to use
+        const current_group_bys_specifiers =
+            params.groupBy || this.renderer.last_group_bys || [];
+        const arch_default_specifiers = this.renderer.arch.attrs.default_group_by
             ? this.renderer.arch.attrs.default_group_by.split(",")
             : [];
-        arch_attrs_default_group_by = cleanGroupBys(arch_attrs_default_group_by);
 
-        if (!n_group_bys.length && arch_attrs_default_group_by.length) {
-            n_group_bys = arch_attrs_default_group_by;
-        } else {
-            n_group_bys = cleanGroupBys(n_group_bys);
+        let final_group_bys_specifiers = [];
+        if (current_group_bys_specifiers.length > 0) {
+            final_group_bys_specifiers = current_group_bys_specifiers;
+        } else if (arch_default_specifiers.length > 0) {
+            final_group_bys_specifiers = arch_default_specifiers;
         }
 
-        this.renderer.last_group_bys = n_group_bys;
+        // Store actual specifiers
+        this.renderer.last_group_bys = final_group_bys_specifiers;
         this.renderer.last_domains = domains;
 
-        let fields = this.renderer.fieldNames;
-        fields = _.uniq(fields.concat(n_group_bys));
+        // For the `fields` argument of search_read, we need these specifiers.
+        const group_bys_date_fields = final_group_bys_specifiers.filter(
+            (spec) =>
+                spec.includes(":") &&
+                (spec.includes(":year") ||
+                    spec.includes(":quarter") ||
+                    spec.includes(":month") ||
+                    spec.includes(":week") ||
+                    spec.includes(":day"))
+        );
+        const groups_bys_field_names = final_group_bys_specifiers.map(
+            (spec) => spec.split(":")[0]
+        );
+        const fields_for_search_read = _.uniq([
+            ...this.renderer.fieldNames,
+            ...groups_bys_field_names,
+        ]);
+
+        // For the `order` argument of search_read, Odoo expects base field names.
+        // Use arch_default_specifiers for ordering, cleaned to base names.
+        const arch_default_base_names_for_order = arch_default_specifiers.map((gb) =>
+            gb.includes(":") ? gb.split(":")[0] : gb
+        );
+
         $.when(
             res,
             this._rpc({
                 model: this.model.modelName,
                 method: "search_read",
                 kwargs: {
-                    fields: fields,
+                    // Use specifiers for fields to read
+                    fields: fields_for_search_read,
                     domain: domains,
-                    order: arch_attrs_default_group_by.map((group) => {
+                    order: arch_default_base_names_for_order.map((group) => {
+                        // Order by base names from arch default
                         return {name: group};
                     }),
                 },
                 context: this.getSession().user_context,
-            }).then((data) =>
-                this.renderer.on_data_loaded(data, n_group_bys, defaults.adjust_window)
-            )
+            }).then((data) => {
+                // Transform date fields for grouping
+                for (const d of data) {
+                    for (const date_group of group_bys_date_fields) {
+                        const base_field = date_group.split(":")[0];
+                        const date_value = d[base_field];
+                        if (date_value) {
+                            d[date_group] = this._getGroupedDate(
+                                date_group,
+                                date_value
+                            );
+                        }
+                    }
+                }
+                // Render
+                this.renderer.on_data_loaded(
+                    data,
+                    final_group_bys_specifiers,
+                    defaults.adjust_window
+                );
+            })
         );
         return res;
+    },
+
+    /**
+     * Get the grouped date value for a given date, based on the group type.
+     * @param {String} date_group The date group specifier (e.g., 'date_start:month').
+     * @param {String} date_value The date value to be grouped.
+     * @returns {String|Number} The grouped date value.
+     */
+    _getGroupedDate: function (date_group, date_value) {
+        const user_datetime = field_utils.parse.datetime(date_value);
+        const group_type = date_group.split(":")[1];
+        // Convert datetime to year, quarter, month, week, day with format:
+        //  2024, Q2 2024, June 2024, W24 2024, 13 Jun 2024
+        if (group_type === "year") {
+            return user_datetime.year();
+        } else if (group_type === "quarter") {
+            return "Q" + user_datetime.quarter() + " " + user_datetime.year();
+        } else if (group_type === "month") {
+            return user_datetime.format("MMMM YYYY");
+        } else if (group_type === "week") {
+            return "W" + user_datetime.isoWeek() + " " + user_datetime.year();
+        } else if (group_type === "day") {
+            return user_datetime.format("DD MMM YYYY");
+        }
     },
 
     /**
@@ -112,18 +168,42 @@ export default AbstractController.extend({
      * @returns {jQuery.Deferred}
      */
     _onGroupClick: function (event) {
-        const groups = event.data.item.group.split("/");
-        const [group_key, group_value] = groups[groups.length - 1].split("-");
-        if (!group_value || group_value === "false") return;
-        const group_model = this.renderer.fieldsGet[group_key].relation;
-        if (!group_model) return;
-        return this.do_action({
-            type: "ir.actions.act_window",
-            res_model: group_model,
-            res_id: parseInt(group_value, 10),
-            target: "new",
-            views: [[false, "form"]],
-        });
+        try {
+            const groupPathSegments = JSON.parse(event.data.item.group);
+            if (!Array.isArray(groupPathSegments) || groupPathSegments.length === 0)
+                return;
+
+            const lastSegment = groupPathSegments[groupPathSegments.length - 1];
+            const group_key = lastSegment.field;
+            const group_value = lastSegment.value;
+
+            if (
+                group_value === false ||
+                group_value === null ||
+                group_value === undefined
+            )
+                return;
+
+            const fieldInfo = this.renderer.fields[group_key];
+            if (!fieldInfo || !fieldInfo.relation) return;
+            const group_model = fieldInfo.relation;
+
+            return this.do_action({
+                type: "ir.actions.act_window",
+                res_model: group_model,
+                // Assuming value is the ID
+                res_id: parseInt(group_value, 10),
+                target: "new",
+                views: [[false, "form"]],
+            });
+        } catch (e) {
+            console.error(
+                "Error parsing group JSON for click event:",
+                event.data.item.group,
+                e
+            );
+            return Promise.resolve();
+        }
     },
 
     /**
@@ -221,12 +301,23 @@ export default AbstractController.extend({
             data[this.date_delay] = diff_seconds / 3600;
         }
 
-        const group_record_values = this.renderer.groups.reduce((acc, group) => {
-            if (group.id === item.group) {
-                return group.group_record_values;
+        const group_record_values = {};
+        if (item.group && this.renderer.groups) {
+            const groupInfo = this.renderer.groups.find((g) => g.id === item.group);
+            if (groupInfo && groupInfo.group_record_values) {
+                // Skip date and datetime fields
+                for (const key of Object.keys(groupInfo.group_record_values)) {
+                    if (
+                        fields[key] &&
+                        (fields[key].type === "date" || fields[key].type === "datetime")
+                    ) {
+                        continue;
+                    }
+                    group_record_values[key] = groupInfo.group_record_values[key];
+                }
             }
-            return acc;
-        }, {});
+        }
+
         data = {
             ...data,
             ...group_record_values,
@@ -323,11 +414,31 @@ export default AbstractController.extend({
                 (moment(item.end) - moment(item.start)) / 3600000;
         }
         if (item.group) {
-            const groups = item.group.split("/");
-            for (let i = 0; i < groups.length; i++) {
-                const [group_key, group_value] = groups[i].split("-");
-                default_context["default_".concat(group_key)] =
-                    Number(group_value) || group_value;
+            try {
+                const groupPathSegments = JSON.parse(item.group);
+                if (Array.isArray(groupPathSegments)) {
+                    groupPathSegments.forEach((segment) => {
+                        // Do not set m2m fields as default context as they are not single values
+                        if (
+                            this.renderer.fields[segment.field] &&
+                            this.renderer.fields[segment.field].type === "many2many"
+                        ) {
+                            return;
+                        }
+                        if (
+                            segment.value !== false &&
+                            segment.value !== null &&
+                            segment.value !== undefined
+                        ) {
+                            default_context["default_".concat(segment.field)] =
+                                Number.isInteger(segment.value)
+                                    ? segment.value
+                                    : segment.value;
+                        }
+                    });
+                }
+            } catch (e) {
+                console.error("Error parsing group JSON for add event:", item.group, e);
             }
         }
         // Show popup

--- a/web_timeline/static/src/js/timeline_model.js
+++ b/web_timeline/static/src/js/timeline_model.js
@@ -53,13 +53,18 @@ odoo.define("web_timeline.TimelineModel", function (require) {
          * @returns {jQuery.Deferred}
          */
         _loadTimeline: function () {
+            const order = this.default_group_by.split(",").map((group) => {
+                // Handle the case where the group by is a field with a group operator
+                // e.g. date:month
+                return {name: group.includes(":") ? group.split(":")[0] : group};
+            });
             return this._rpc({
                 model: this.modelName,
                 method: "search_read",
                 kwargs: {
                     fields: this.fieldNames,
                     domain: this.data.domain,
-                    order: [{name: this.default_group_by}],
+                    order: order,
                     context: this.data.context,
                 },
             }).then((events) => {

--- a/web_timeline/static/src/js/timeline_model.js
+++ b/web_timeline/static/src/js/timeline_model.js
@@ -53,18 +53,25 @@ odoo.define("web_timeline.TimelineModel", function (require) {
          * @returns {jQuery.Deferred}
          */
         _loadTimeline: function () {
-            const order = this.default_group_by.split(",").map((group) => {
+            const groupByFields = this.default_group_by
+                ? this.default_group_by.split(",")
+                : [];
+            const orderFields = groupByFields.map((group) => {
                 // Handle the case where the group by is a field with a group operator
-                // e.g. date:month
+                // e.g. date:month. For ordering, Odoo expects the base field name.
                 return {name: group.includes(":") ? group.split(":")[0] : group};
             });
+            // For fields to read, Odoo expects the full specifier if it's a :operator group,
+            // as this will be the key in the returned records.
+            const fieldsToRead = _.uniq([...this.fieldNames, ...groupByFields]);
+
             return this._rpc({
                 model: this.modelName,
                 method: "search_read",
                 kwargs: {
-                    fields: this.fieldNames,
+                    fields: fieldsToRead,
                     domain: this.data.domain,
-                    order: order,
+                    order: orderFields,
                     context: this.data.context,
                 },
             }).then((events) => {

--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -342,7 +342,6 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                         event
                     )
                 );
-                this.fieldsGet = await this.get_fields_get(group_bys);
                 return this.on_data_loaded_2(nevents, group_bys, adjust_window);
             });
         },
@@ -369,25 +368,36 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 }
             }
             this.split_groups(events, group_bys).then((groups) => {
+                // This.groups contains all unique group objects
                 this.groups = groups;
+                // Ensure relevant groups are visible
                 for (const d of data) {
-                    // Check if the group should be visible
-                    // If d.group is 'partner_id-35/category_id-4/city_id-false'
-                    // it means there are 3 groups to check
-                    // partner_id-35, partner_id-35/category_id-4, partner_id-35/category_id-4/city_id-false
-                    const groupParts = d.group.split("/");
-                    let groupPath = "";
-                    const groupsToCheck = groupParts.map((part, index) => {
-                        groupPath = index === 0 ? part : `${groupPath}/${part}`;
-                        return groupPath;
-                    });
-                    for (const gtc of groupsToCheck) {
-                        if (gtc.endsWith("-false")) {
-                            const group = groups.find((g) => g.id === gtc);
-                            if (group) {
+                    // D is a vis.js item, d.group is a single JSON string path
+                    const itemGroupPathJson = d.group;
+                    try {
+                        // Parse the item's full group path
+                        const itemPathSegments = JSON.parse(itemGroupPathJson);
+
+                        // Iterate through all prefixes of this item's group path (e.g., [seg1], [seg1, seg2], ...)
+                        for (let i = 0; i < itemPathSegments.length; i++) {
+                            const subPathJson = JSON.stringify(
+                                itemPathSegments.slice(0, i + 1)
+                            );
+                            // Find the actual group object corresponding to this sub-path
+                            const group = groups.find((g) => g.id === subPathJson);
+                            if (group && !group.visible) {
+                                // If a group in the item's hierarchy was initially not visible (e.g., an "UNASSIGNED" group),
+                                // make it visible because an item actually belongs to this path.
                                 group.visible = true;
                             }
                         }
+                    } catch (e) {
+                        console.error(
+                            "Error processing group visibility for item. Group JSON string was:",
+                            itemGroupPathJson,
+                            "Error:",
+                            e
+                        );
                     }
                 }
                 this.timeline.setGroups(groups);
@@ -410,7 +420,13 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
          */
         split_groups: async function (events, group_bys) {
             if (group_bys.length === 0) {
-                return events;
+                // No grouping, but vis.js expects groups if items have a 'group' property.
+                // Create a single default group if items might have group properties.
+                // However, event_data_transform might assign 'undefined-false' if no groups.
+                // For safety, ensure at least one group if group_bys is empty but items might specify groups.
+                // This case should ideally be handled by ensuring items don't have group props if no group_bys.
+                // For now, returning an empty array, assuming items won't have group property.
+                return [];
             }
             const groups = [];
             let seq = 1;
@@ -420,39 +436,88 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 return acc;
             }, {});
 
-            const createGroup = (id, name, parents, lvl) => {
-                const parentGroups = parents.length ? parents : [null];
+            // Memoization for M2M name_get calls
+            const m2mNameCache = {};
+            const getM2MNames = async (model, ids) => {
+                const cacheKey = `${model}-${ids.sort().join(",")}`;
+                if (m2mNameCache[cacheKey]) {
+                    return m2mNameCache[cacheKey];
+                }
+                const names = await this._rpc({
+                    model: model,
+                    method: "name_get",
+                    args: [ids],
+                    context: this.getSession().user_context,
+                });
+                const result = names.map((name) => ({id: name[0], content: name[1]}));
+                m2mNameCache[cacheKey] = result;
+                return result;
+            };
+
+            const createGroup = (
+                segmentObject,
+                displayName,
+                parentGroupsInput,
+                lvl
+            ) => {
+                // SegmentObject is like {field: "partner_id", value: 35}
+                // displayName is the human-readable name for this segment, e.g., "Azure Interior"
+                const parentGroups =
+                    parentGroupsInput && parentGroupsInput.length
+                        ? parentGroupsInput
+                        : [null];
                 const createdGroups = [];
+
                 for (const parent of parentGroups) {
-                    const subGroupId = parent ? `${parent.id}/${id}` : id;
-                    let group = groups.find((g) => g.id === subGroupId);
+                    let newPathSegments = [];
+                    if (parent && parent.id) {
+                        // Parent is a group object, parent.id is JSON string
+                        try {
+                            const parentPathSegments = JSON.parse(parent.id);
+                            newPathSegments = [...parentPathSegments, segmentObject];
+                        } catch (e) {
+                            console.error(
+                                "Error parsing parent group ID:",
+                                parent.id,
+                                e
+                            );
+                            // Fallback
+                            newPathSegments = [segmentObject];
+                        }
+                    } else {
+                        newPathSegments = [segmentObject];
+                    }
+                    const subGroupId = JSON.stringify(newPathSegments);
+
+                    let group = groups && groups.find((g) => g.id === subGroupId);
                     if (!group) {
                         const group_record_values = {};
-                        const group_parts = subGroupId.split("/");
-                        for (let i = 0; i < group_parts.length; i++) {
-                            const [groupKey, groupValue] = group_parts[i].split("-");
-                            // Skip updating m2m field as it is complicated to handle drag and drop
-                            if (this.fieldsGet[groupKey].type === "many2many") {
-                                continue;
+                        newPathSegments.forEach((segment) => {
+                            // Do not set m2m fields for group_record_values as they are not single values for writing
+                            if (
+                                this.fields[segment.field] &&
+                                this.fields[segment.field].type === "many2many"
+                            ) {
+                                return;
                             }
-                            group_record_values[groupKey] =
-                                groupValue === "false"
-                                    ? false
-                                    : Number(groupValue) || groupValue;
-                        }
+                            group_record_values[segment.field] = segment.value;
+                        });
+
                         group = {
                             id: subGroupId,
-                            content: name || "UNASSIGNED",
+                            content: displayName || "UNASSIGNED",
                             group_record_values,
-                            order: name === "UNASSIGNED" ? -1 : seq,
+                            // Ensure unique order
+                            order: displayName === "UNASSIGNED" ? seq++ : seq++,
                             treeLevel: lvl,
-                            visible: name !== "UNASSIGNED",
+                            // Default visibility
+                            visible: displayName !== "UNASSIGNED",
                         };
-                        seq += 1;
                         groups.push(group);
                     }
                     createdGroups.push(group);
-                    if (parent) {
+
+                    if (parent && parent.id) {
                         if (!parent.nestedGroups) {
                             parent.nestedGroups = [];
                         }
@@ -464,50 +529,152 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 return createdGroups;
             };
 
+            /* eslint-disable complexity */
             const processGroup = async (
-                grouped_field,
+                // E.g. "partner_id" or "date_start:month"
+                grouped_field_spec,
+                // E.g. [3, "Azure Interior"] or "January 2024" or 3 (if just id) or [10,11] for m2m
                 groupValue,
-                groupKey,
                 groupLvl,
                 parentGroups
             ) => {
-                if (groupValue && Array.isArray(groupValue)) {
-                    if (this.fieldsGet[grouped_field].type === "many2many") {
-                        const groupModel = this.fieldsGet[grouped_field].relation;
-                        const listValues = await this.get_m2m_grouping_datas(
-                            groupModel,
-                            groupValue
+                const base_grouped_field = grouped_field_spec.includes(":")
+                    ? grouped_field_spec.split(":")[0]
+                    : grouped_field_spec;
+                const fieldInfo = this.fields[base_grouped_field];
+
+                if (fieldInfo.type === "many2many") {
+                    const m2mIds = Array.isArray(groupValue)
+                        ? groupValue
+                        : groupValue
+                        ? [groupValue]
+                        : [];
+                    if (m2mIds.length === 0) {
+                        return createGroup(
+                            {
+                                field: base_grouped_field,
+                                value: false,
+                                spec: grouped_field_spec,
+                            },
+                            "UNASSIGNED",
+                            parentGroups,
+                            groupLvl
                         );
-                        const createdM2mGroups = [];
-                        for (const vals of listValues) {
-                            if (groupValue.includes(vals.id) || vals.id === false) {
-                                const newM2mGroups = createGroup(
-                                    `${groupKey}-${vals.id}`,
-                                    vals.content,
-                                    parentGroups,
-                                    groupLvl
-                                );
-                                createdM2mGroups.push(...newM2mGroups);
-                            }
-                        }
-                        return createdM2mGroups;
                     }
-                    const groupId = `${groupKey}-${groupValue[0]}`;
-                    const groupName = groupValue[1];
-                    return createGroup(groupId, groupName, parentGroups, groupLvl);
+                    const listValues = await getM2MNames(fieldInfo.relation, m2mIds);
+                    const createdM2mGroups = [];
+                    for (const vals of listValues) {
+                        // Vals is {id: ..., content: ...}
+                        if (m2mIds.includes(vals.id)) {
+                            const newM2mGroups = createGroup(
+                                {
+                                    field: base_grouped_field,
+                                    value: vals.id,
+                                    spec: grouped_field_spec,
+                                },
+                                vals.content,
+                                parentGroups,
+                                groupLvl
+                            );
+                            createdM2mGroups.push(...newM2mGroups);
+                        }
+                    }
+                    if (createdM2mGroups.length === 0 && m2mIds.length > 0) {
+                        for (const id of m2mIds) {
+                            const newM2mGroups = createGroup(
+                                {
+                                    field: base_grouped_field,
+                                    value: id,
+                                    spec: grouped_field_spec,
+                                },
+                                `ID: ${id}`,
+                                parentGroups,
+                                groupLvl
+                            );
+                            createdM2mGroups.push(...newM2mGroups);
+                        }
+                    } else if (m2mIds.length === 0) {
+                        return createGroup(
+                            {
+                                field: base_grouped_field,
+                                value: false,
+                                spec: grouped_field_spec,
+                            },
+                            "UNASSIGNED",
+                            parentGroups,
+                            groupLvl
+                        );
+                    }
+                    return createdM2mGroups;
+                    // Handling for date/datetime fields grouped by an operator (e.g., date_start:month)
+                    // Odoo returns the formatted string (e.g., "January 2024") as the groupValue directly.
                 } else if (
-                    groupValue &&
-                    ["string", "number"].includes(typeof groupValue)
+                    grouped_field_spec.includes(":") &&
+                    (fieldInfo.type === "date" || fieldInfo.type === "datetime")
                 ) {
+                    const displayName = groupValue ? String(groupValue) : "UNASSIGNED";
+                    // For date:operator groups, the `value` in the segment should be the formatted string itself,
+                    // as this is what Odoo provides and what we need for display and potential re-grouping.
                     return createGroup(
-                        `${groupKey}-${groupValue}`,
-                        groupValue,
+                        {
+                            field: base_grouped_field,
+                            value: groupValue,
+                            spec: grouped_field_spec,
+                        },
+                        displayName,
+                        parentGroups,
+                        groupLvl
+                    );
+                } else if (Array.isArray(groupValue)) {
+                    // Standard [id, name] for m2o, selection, etc.
+                    const id = groupValue[0];
+                    const name = groupValue[1];
+                    return createGroup(
+                        {
+                            field: base_grouped_field,
+                            value: id,
+                            spec: grouped_field_spec,
+                        },
+                        name,
+                        parentGroups,
+                        groupLvl
+                    );
+                } else if (
+                    groupValue !== undefined &&
+                    groupValue !== null &&
+                    groupValue !== false
+                ) {
+                    // Simple type (string, number, boolean true)
+                    if (fieldInfo.relation && typeof groupValue === "number") {
+                        const names = await getM2MNames(fieldInfo.relation, [
+                            groupValue,
+                        ]);
+                        const displayName =
+                            names.length > 0 ? names[0].content : `ID: ${groupValue}`;
+                        return createGroup(
+                            {
+                                field: base_grouped_field,
+                                value: groupValue,
+                                spec: grouped_field_spec,
+                            },
+                            displayName,
+                            parentGroups,
+                            groupLvl
+                        );
+                    }
+                    return createGroup(
+                        {
+                            field: base_grouped_field,
+                            value: groupValue,
+                            spec: grouped_field_spec,
+                        },
+                        String(groupValue),
                         parentGroups,
                         groupLvl
                     );
                 }
                 return createGroup(
-                    `${groupKey}-false`,
+                    {field: base_grouped_field, value: false, spec: grouped_field_spec},
                     "UNASSIGNED",
                     parentGroups,
                     groupLvl
@@ -515,20 +682,38 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
             };
 
             for (const evt of events) {
-                let parentGroups = [null];
-                for (const grouped_field of group_bys) {
-                    const groupValue = evt[grouped_field];
-                    const groupKey = grouped_field;
-                    const groupLvl = groupLevel[grouped_field];
-                    parentGroups = await processGroup(
-                        grouped_field,
+                let currentParentGroups = [null];
+                // Iterate using the full specifier, e.g., "date_start:month"
+                for (const grouped_field_spec of group_bys) {
+                    // Use the full specifier to get the value from the event
+                    const groupValue = evt[grouped_field_spec];
+                    const groupLvl = groupLevel[grouped_field_spec];
+                    currentParentGroups = await processGroup(
+                        grouped_field_spec,
                         groupValue,
-                        groupKey,
                         groupLvl,
-                        parentGroups
+                        currentParentGroups
                     );
+                    if (!currentParentGroups || currentParentGroups.length === 0) {
+                        // Safety break if a level yields no groups
+                        break;
+                    }
                 }
             }
+            // Ensure unique group ordering, especially for UNASSIGNED or items with same name
+            groups.sort((a, b) => {
+                if (a.treeLevel !== b.treeLevel) {
+                    return a.treeLevel - b.treeLevel;
+                }
+                if (a.content === "UNASSIGNED" && b.content !== "UNASSIGNED") return 1;
+                if (a.content !== "UNASSIGNED" && b.content === "UNASSIGNED") return -1;
+                if (a.content < b.content) return -1;
+                if (a.content > b.content) return 1;
+                // Fallback to sequence order
+                return a.order - b.order;
+            });
+            // Re-assign order based on sorted list for vis.js if it uses it for display
+            groups.forEach((g, index) => (g.order = index + 1));
             return groups;
         },
 
@@ -545,15 +730,6 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 });
             }
             return groups;
-        },
-
-        get_fields_get: async function (group_bys) {
-            return await this._rpc({
-                model: this.modelName,
-                method: "fields_get",
-                args: [group_bys],
-                context: this.getSession().user_context,
-            });
         },
 
         /**
@@ -605,40 +781,103 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
          * @private
          * @returns {Object}
          */
+        /* eslint-disable complexity */
         event_data_transform: function (evt) {
             const [date_start, date_stop] = this._get_event_dates(evt);
-            const evtGroup = [];
-            let group = "undefined-false";
-            for (const grouped_field of this.last_group_bys) {
-                evtGroup.push({[grouped_field]: evt[grouped_field]});
+
+            let currentPaths = [[]];
+
+            for (const grouped_field_spec of this.last_group_bys) {
+                // E.g. "user_id", "date_start:month"
+                const fieldValue = evt[grouped_field_spec];
+                const base_grouped_field = grouped_field_spec.includes(":")
+                    ? grouped_field_spec.split(":")[0]
+                    : grouped_field_spec;
+                const fieldInfo = this.fields[base_grouped_field];
+                const fieldSegments = [];
+
+                if (fieldInfo.type === "many2many") {
+                    const m2mIds = Array.isArray(fieldValue)
+                        ? fieldValue.filter((id) => id !== false && id !== null)
+                        : [];
+                    if (m2mIds.length === 0) {
+                        fieldSegments.push({
+                            field: base_grouped_field,
+                            value: false,
+                            spec: grouped_field_spec,
+                        });
+                    } else {
+                        m2mIds.forEach((valId) => {
+                            fieldSegments.push({
+                                field: base_grouped_field,
+                                value: valId,
+                                spec: grouped_field_spec,
+                            });
+                        });
+                    }
+                    // Handle date/datetime fields grouped by an operator (e.g., date_start:month)
+                    // The fieldValue will be the formatted string (e.g., "January 2024")
+                } else if (
+                    grouped_field_spec.includes(":") &&
+                    (fieldInfo.type === "date" || fieldInfo.type === "datetime")
+                ) {
+                    fieldSegments.push({
+                        field: base_grouped_field,
+                        value: fieldValue,
+                        spec: grouped_field_spec,
+                    });
+                } else if (Array.isArray(fieldValue)) {
+                    // [id, name]
+                    fieldSegments.push({
+                        field: base_grouped_field,
+                        value: fieldValue[0],
+                        spec: grouped_field_spec,
+                    });
+                } else if (
+                    fieldValue !== undefined &&
+                    fieldValue !== null &&
+                    fieldValue !== ""
+                ) {
+                    if (fieldValue === false && typeof fieldValue === "boolean") {
+                        fieldSegments.push({
+                            field: base_grouped_field,
+                            value: false,
+                            spec: grouped_field_spec,
+                        });
+                    } else {
+                        fieldSegments.push({
+                            field: base_grouped_field,
+                            value: fieldValue,
+                            spec: grouped_field_spec,
+                        });
+                    }
+                } else {
+                    fieldSegments.push({
+                        field: base_grouped_field,
+                        value: false,
+                        spec: grouped_field_spec,
+                    });
+                }
+                currentPaths = currentPaths.flatMap((path) =>
+                    fieldSegments.map((segment) => [...path, segment])
+                );
             }
 
-            group = evtGroup
-                .reduce((acc, eG) => {
-                    const entries = Object.entries(eG).flatMap(([f, value]) => {
-                        if (value instanceof Array) {
-                            if (this.fieldsGet[f].type === "many2many") {
-                                return value.length === 0
-                                    ? [`${f}-false`]
-                                    : value.map((v) => `${f}-${v}`);
-                            }
-                            return [`${f}-${value[0]}`];
-                        } else if (["string", "number"].includes(typeof value)) {
-                            return [`${f}-${value}`];
-                        }
-                        return [`${f}-false`];
-                    });
-                    if (acc.length === 0) {
-                        return entries.map((e) => [e]);
-                    }
-                    return acc.flatMap((a) => entries.map((e) => [...a, e]));
-                }, [])
-                .map((g) => g.join("/"))
-                .join(",");
+            const groupJSONStrings = currentPaths.map((path) => JSON.stringify(path));
 
             for (const color of this.colors) {
-                if (py.eval(`'${evt[color.field]}' ${color.opt} '${color.value}'`)) {
-                    this.color = color.color;
+                // Ensure evt[color.field] is not an array (e.g. m2o [id, name]) for py.eval
+                let evalValue = evt[color.field];
+                if (Array.isArray(evalValue)) {
+                    // Use ID for evaluation
+                    evalValue = evalValue[0];
+                }
+                try {
+                    if (py.eval(`'${evalValue}' ${color.opt} '${color.value}'`)) {
+                        this.color = color.color;
+                    }
+                } catch (e) {
+                    console.warn("Error evaluating color expression:", e);
                 }
             }
 
@@ -647,33 +886,31 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 content = this.render_timeline_item(evt);
             }
 
-            const groups = group.split(",");
             const r_list = [];
-            for (const g of groups) {
+            for (const jsonPathString of groupJSONStrings) {
                 const r = {
                     start: date_start,
                     content: content,
-                    // Append group to the id to avoid duplicate id, one item can be
-                    // appear/duplicated in multiple groups in case group by m2m field.
-                    id: evt.id + "_" + g,
+                    // Unique ID for vis.js item
+                    id: evt.id + "_" + jsonPathString,
                     record_id: evt.id,
+                    // Keep original Odoo record order if available
                     order: evt.order,
-                    group: g,
+                    // The group this specific vis.js item belongs to
+                    group: jsonPathString,
+                    // Keep original event data
                     evt: evt,
-                    style: `background-color: ${this.color};`,
+                    style: this.color ? `background-color: ${this.color};` : "",
                 };
-                // Only specify range end when there actually is one.
-                // ➔ Instantaneous events / those with inverted dates are displayed as points.
                 if (date_stop && moment(date_start).isBefore(date_stop)) {
                     r.end = date_stop;
                 }
-                this.color = null;
-                if (groups.length === 1) {
-                    return r;
-                }
                 r_list.push(r);
             }
-            return r_list;
+            // Reset color for next event
+            this.color = null;
+
+            return r_list.length === 1 ? r_list[0] : r_list;
         },
 
         /**

--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -224,7 +224,7 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
             }
 
             this.timeline = new vis.Timeline(this.$timeline.get(0), {}, this.options);
-            this.timeline.on("click", this.on_timeline_click);
+            this.timeline.on("doubleClick", this.on_timeline_click);
             if (!this.options.onUpdate) {
                 // In read-only mode, catch double-clicks this way.
                 this.timeline.on("doubleClick", this.on_timeline_double_click);
@@ -267,13 +267,15 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
             const keys = Object.keys(items);
             for (const key of keys) {
                 const item = items[key];
-                const data = datas.get(Number(key));
+                const data = datas.get(key);
                 if (!data || !data.evt) {
                     return;
                 }
                 for (const id of data.evt[this.dependency_arrow]) {
-                    if (keys.indexOf(id.toString()) !== -1) {
-                        this.draw_dependency(item, items[id]);
+                    for (const k of keys) {
+                        if (k.split("_")[0].toString() === id.toString()) {
+                            this.draw_dependency(item, items[k]);
+                        }
                     }
                 }
             }
@@ -331,7 +333,7 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 method: "name_get",
                 args: [ids],
                 context: this.getSession().user_context,
-            }).then((names) => {
+            }).then(async (names) => {
                 const nevents = _.map(events, (event) =>
                     _.extend(
                         {
@@ -340,6 +342,7 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                         event
                     )
                 );
+                this.fieldsGet = await this.get_fields_get(group_bys);
                 return this.on_data_loaded_2(nevents, group_bys, adjust_window);
             });
         },
@@ -357,10 +360,36 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
             this.grouped_by = group_bys;
             for (const evt of events) {
                 if (evt[this.date_start]) {
-                    data.push(this.event_data_transform(evt));
+                    var transformed = this.event_data_transform(evt);
+                    if (Array.isArray(transformed)) {
+                        data.push(...transformed);
+                    } else {
+                        data.push(transformed);
+                    }
                 }
             }
             this.split_groups(events, group_bys).then((groups) => {
+                this.groups = groups;
+                for (const d of data) {
+                    // Check if the group should be visible
+                    // If d.group is 'partner_id-35/category_id-4/city_id-false'
+                    // it means there are 3 groups to check
+                    // partner_id-35, partner_id-35/category_id-4, partner_id-35/category_id-4/city_id-false
+                    const groupParts = d.group.split("/");
+                    let groupPath = "";
+                    const groupsToCheck = groupParts.map((part, index) => {
+                        groupPath = index === 0 ? part : `${groupPath}/${part}`;
+                        return groupPath;
+                    });
+                    for (const gtc of groupsToCheck) {
+                        if (gtc.endsWith("-false")) {
+                            const group = groups.find((g) => g.id === gtc);
+                            if (group) {
+                                group.visible = true;
+                            }
+                        }
+                    }
+                }
                 this.timeline.setGroups(groups);
                 this.timeline.setItems(data);
                 const mode = !this.mode || this.mode === "fit";
@@ -384,67 +413,130 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 return events;
             }
             const groups = [];
-            groups.push({id: -1, content: _t("<b>UNASSIGNED</b>"), order: -1});
-            var seq = 1;
-            for (const evt of events) {
-                const grouped_field = _.first(group_bys);
-                const group_name = evt[grouped_field];
-                if (group_name) {
-                    if (group_name instanceof Array) {
-                        const group = _.find(
-                            groups,
-                            (existing_group) => existing_group.id === group_name[0]
-                        );
-                        if (_.isUndefined(group)) {
-                            // Check if group is m2m in this case add id -> value of all
-                            // found entries.
-                            await this._rpc({
-                                model: this.modelName,
-                                method: "fields_get",
-                                args: [[grouped_field]],
-                                context: this.getSession().user_context,
-                            }).then(async (fields) => {
-                                if (fields[grouped_field].type === "many2many") {
-                                    const list_values =
-                                        await this.get_m2m_grouping_datas(
-                                            fields[grouped_field].relation,
-                                            group_name
-                                        );
-                                    for (const vals of list_values) {
-                                        let is_inside = false;
-                                        for (const gr of groups) {
-                                            if (vals.id === gr.id) {
-                                                is_inside = true;
-                                                break;
-                                            }
-                                        }
-                                        if (!is_inside) {
-                                            vals.order = seq;
-                                            seq += 1;
-                                            groups.push(vals);
-                                        }
-                                    }
-                                } else {
-                                    groups.push({
-                                        id: group_name[0],
-                                        content: group_name[1],
-                                        order: seq,
-                                    });
-                                    seq += 1;
-                                }
-                            });
+            let seq = 1;
+
+            const groupLevel = group_bys.reduce((acc, g, index) => {
+                acc[g] = index + 1;
+                return acc;
+            }, {});
+
+            const createGroup = (id, name, parents, lvl) => {
+                const parentGroups = parents.length ? parents : [null];
+                const createdGroups = [];
+                for (const parent of parentGroups) {
+                    const subGroupId = parent ? `${parent.id}/${id}` : id;
+                    let group = groups.find((g) => g.id === subGroupId);
+                    if (!group) {
+                        const group_record_values = {};
+                        const group_parts = subGroupId.split("/");
+                        for (let i = 0; i < group_parts.length; i++) {
+                            const [groupKey, groupValue] = group_parts[i].split("-");
+                            // Skip updating m2m field as it is complicated to handle drag and drop
+                            if (this.fieldsGet[groupKey].type === "many2many") {
+                                continue;
+                            }
+                            group_record_values[groupKey] =
+                                groupValue === "false"
+                                    ? false
+                                    : Number(groupValue) || groupValue;
+                        }
+                        group = {
+                            id: subGroupId,
+                            content: name || "UNASSIGNED",
+                            group_record_values,
+                            order: name === "UNASSIGNED" ? -1 : seq,
+                            treeLevel: lvl,
+                            visible: name !== "UNASSIGNED",
+                        };
+                        seq += 1;
+                        groups.push(group);
+                    }
+                    createdGroups.push(group);
+                    if (parent) {
+                        if (!parent.nestedGroups) {
+                            parent.nestedGroups = [];
+                        }
+                        if (!parent.nestedGroups.includes(group.id)) {
+                            parent.nestedGroups.push(group.id);
                         }
                     }
+                }
+                return createdGroups;
+            };
+
+            const processGroup = async (
+                grouped_field,
+                groupValue,
+                groupKey,
+                groupLvl,
+                parentGroups
+            ) => {
+                if (groupValue && Array.isArray(groupValue)) {
+                    if (this.fieldsGet[grouped_field].type === "many2many") {
+                        const groupModel = this.fieldsGet[grouped_field].relation;
+                        const listValues = await this.get_m2m_grouping_datas(
+                            groupModel,
+                            groupValue
+                        );
+                        const createdM2mGroups = [];
+                        for (const vals of listValues) {
+                            if (groupValue.includes(vals.id) || vals.id === false) {
+                                const newM2mGroups = createGroup(
+                                    `${groupKey}-${vals.id}`,
+                                    vals.content,
+                                    parentGroups,
+                                    groupLvl
+                                );
+                                createdM2mGroups.push(...newM2mGroups);
+                            }
+                        }
+                        return createdM2mGroups;
+                    }
+                    const groupId = `${groupKey}-${groupValue[0]}`;
+                    const groupName = groupValue[1];
+                    return createGroup(groupId, groupName, parentGroups, groupLvl);
+                } else if (
+                    groupValue &&
+                    ["string", "number"].includes(typeof groupValue)
+                ) {
+                    return createGroup(
+                        `${groupKey}-${groupValue}`,
+                        groupValue,
+                        parentGroups,
+                        groupLvl
+                    );
+                }
+                return createGroup(
+                    `${groupKey}-false`,
+                    "UNASSIGNED",
+                    parentGroups,
+                    groupLvl
+                );
+            };
+
+            for (const evt of events) {
+                let parentGroups = [null];
+                for (const grouped_field of group_bys) {
+                    const groupValue = evt[grouped_field];
+                    const groupKey = grouped_field;
+                    const groupLvl = groupLevel[grouped_field];
+                    parentGroups = await processGroup(
+                        grouped_field,
+                        groupValue,
+                        groupKey,
+                        groupLvl,
+                        parentGroups
+                    );
                 }
             }
             return groups;
         },
 
-        get_m2m_grouping_datas: async function (model, group_name) {
-            const groups = [];
-            for (const gr of group_name) {
+        get_m2m_grouping_datas: async function (groupModel, groupValue) {
+            const groups = [{id: false, content: "UNASSIGNED"}];
+            for (const gr of groupValue) {
                 await this._rpc({
-                    model: model,
+                    model: groupModel,
                     method: "name_get",
                     args: [gr],
                     context: this.getSession().user_context,
@@ -453,6 +545,15 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 });
             }
             return groups;
+        },
+
+        get_fields_get: async function (group_bys) {
+            return await this._rpc({
+                model: this.modelName,
+                method: "fields_get",
+                args: [group_bys],
+                context: this.getSession().user_context,
+            });
         },
 
         /**
@@ -506,12 +607,34 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
          */
         event_data_transform: function (evt) {
             const [date_start, date_stop] = this._get_event_dates(evt);
-            let group = evt[this.last_group_bys[0]];
-            if (group && group instanceof Array && group.length > 0) {
-                group = _.first(group);
-            } else {
-                group = -1;
+            const evtGroup = [];
+            let group = "undefined-false";
+            for (const grouped_field of this.last_group_bys) {
+                evtGroup.push({[grouped_field]: evt[grouped_field]});
             }
+
+            group = evtGroup
+                .reduce((acc, eG) => {
+                    const entries = Object.entries(eG).flatMap(([f, value]) => {
+                        if (value instanceof Array) {
+                            if (this.fieldsGet[f].type === "many2many") {
+                                return value.length === 0
+                                    ? [`${f}-false`]
+                                    : value.map((v) => `${f}-${v}`);
+                            }
+                            return [`${f}-${value[0]}`];
+                        } else if (["string", "number"].includes(typeof value)) {
+                            return [`${f}-${value}`];
+                        }
+                        return [`${f}-false`];
+                    });
+                    if (acc.length === 0) {
+                        return entries.map((e) => [e]);
+                    }
+                    return acc.flatMap((a) => entries.map((e) => [...a, e]));
+                }, [])
+                .map((g) => g.join("/"))
+                .join(",");
 
             for (const color of this.colors) {
                 if (py.eval(`'${evt[color.field]}' ${color.opt} '${color.value}'`)) {
@@ -524,22 +647,33 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 content = this.render_timeline_item(evt);
             }
 
-            const r = {
-                start: date_start,
-                content: content,
-                id: evt.id,
-                order: evt.order,
-                group: group,
-                evt: evt,
-                style: `background-color: ${this.color};`,
-            };
-            // Only specify range end when there actually is one.
-            // ➔ Instantaneous events / those with inverted dates are displayed as points.
-            if (date_stop && moment(date_start).isBefore(date_stop)) {
-                r.end = date_stop;
+            const groups = group.split(",");
+            const r_list = [];
+            for (const g of groups) {
+                const r = {
+                    start: date_start,
+                    content: content,
+                    // Append group to the id to avoid duplicate id, one item can be
+                    // appear/duplicated in multiple groups in case group by m2m field.
+                    id: evt.id + "_" + g,
+                    record_id: evt.id,
+                    order: evt.order,
+                    group: g,
+                    evt: evt,
+                    style: `background-color: ${this.color};`,
+                };
+                // Only specify range end when there actually is one.
+                // ➔ Instantaneous events / those with inverted dates are displayed as points.
+                if (date_stop && moment(date_start).isBefore(date_stop)) {
+                    r.end = date_stop;
+                }
+                this.color = null;
+                if (groups.length === 1) {
+                    return r;
+                }
+                r_list.push(r);
             }
-            this.color = null;
-            return r;
+            return r_list;
         },
 
         /**
@@ -587,6 +721,7 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
          * @private
          */
         on_timeline_double_click: function (e) {
+            this.on_timeline_click(e);
             if (e.what === "item" && e.item !== -1) {
                 this._trigger(
                     e.item,

--- a/web_timeline/static/src/js/timeline_renderer.js
+++ b/web_timeline/static/src/js/timeline_renderer.js
@@ -236,8 +236,14 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
             this.canvas = new TimelineCanvas(this);
             this.canvas.appendTo(this.$centerContainer);
             this.timeline.on("changed", () => {
-                this.draw_canvas();
                 this.load_initial_data();
+                // Defer drawing until after DOM settles (e.g., after group collapse/expand)
+                const draw = () => this.draw_canvas();
+                if (typeof window !== "undefined" && window.requestAnimationFrame) {
+                    window.requestAnimationFrame(draw);
+                } else {
+                    setTimeout(draw, 0);
+                }
             });
         },
 
@@ -269,12 +275,17 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
                 const item = items[key];
                 const data = datas.get(key);
                 if (!data || !data.evt) {
-                    return;
+                    continue; // Skip items without data or event payload
                 }
-                for (const id of data.evt[this.dependency_arrow]) {
+                const deps = data.evt[this.dependency_arrow];
+                if (!Array.isArray(deps) || deps.length === 0) {
+                    continue;
+                }
+                for (const id of deps) {
                     for (const k of keys) {
                         if (k.split("_")[0].toString() === id.toString()) {
-                            this.draw_dependency(item, items[k]);
+                            const toItem = items[k];
+                            this.draw_dependency(item, toItem);
                         }
                     }
                 }
@@ -292,7 +303,23 @@ odoo.define("web_timeline.TimelineRenderer", function (require) {
          * @private
          */
         draw_dependency: function (from, to, options) {
+            // Skip if any item is missing, hidden, or its DOM node is not available/attached
+            if (!from || !to) {
+                return;
+            }
             if (!from.displayed || !to.displayed) {
+                return;
+            }
+            if (!from.dom || !to.dom || !from.dom.box || !to.dom.box) {
+                return;
+            }
+            // In some cases after collapsing a group, items can be logically displayed
+            // but their DOM nodes are detached. Guard against that situation.
+            if (
+                typeof document !== "undefined" &&
+                (!document.body.contains(from.dom.box) ||
+                    !document.body.contains(to.dom.box))
+            ) {
                 return;
             }
             const defaults = _.defaults({}, options, {

--- a/web_timeline/static/src/js/timeline_view.js
+++ b/web_timeline/static/src/js/timeline_view.js
@@ -70,6 +70,20 @@ odoo.define("web_timeline.TimelineView", function (require) {
                 }
             }
 
+            const fieldNamesCopy = [...fieldNames];
+            for (const field of fieldNamesCopy) {
+                if (field.includes(",")) {
+                    // Multiple group by fields
+                    fieldNames.pop(field);
+                    fieldNames.push(...field.split(","));
+                }
+                if (field.includes(":")) {
+                    // Group by date field may have a group operator, e.g. date:month
+                    fieldNames.pop(field);
+                    fieldNames.push(field.split(":")[0]);
+                }
+            }
+
             const archFieldNames = _.map(
                 _.filter(this.arch.children, (item) => item.tag === "field"),
                 (item) => item.attrs.name


### PR DESCRIPTION
Allowing to add multiple group-by levels

<img width="1642" alt="image" src="https://github.com/user-attachments/assets/81d19728-16ee-479f-b929-cd045fe3ffa5">

Test cases:

- [x] group by one field (group by m2o, selection, integer, m2m, date, ...)
- [x] group by multiple fields
- [x] group by 0 field: back to default group by
- [x] create a new record
- [x] drag and drop record to update
- [x] click on the group by to view the group by record detail
- [x] when group by m2m field, record is displayed multiple times if linked to multiple m2m records
- [x] when drag and drop, the value of the m2m field should not be updated as there is no best way to handle this
- [x] when creating a new record, set the default value for all grouped fields
- [x] handle group by non-relation fields: click on the group of selection or char field do not popup record form view to avoid error.
- [x] dependency_arrow between multiple collapse/expand groups