### PR TITLE
[17.0][FIX] web_responsive: Add support to serve menu icon in image url

### DIFF
--- a/web_responsive/static/src/components/apps_menu_tools.esm.js
+++ b/web_responsive/static/src/components/apps_menu_tools.esm.js
@@ -8,6 +8,11 @@
 
 export function getWebIconData(menu) {
     const result = "/web_responsive/static/img/default_icon_app.png";
+    const webIcon = menu.webIcon;
+    if (webIcon && webIcon.split(",").length === 2) {
+        const path = webIcon.replace(",", "/");
+        return path.startsWith("/") ? path : "/" + path;
+    }
     const iconData = menu.webIconData;
     if (!iconData) {
         return result;


### PR DESCRIPTION
Add support to serve menu icon in image URL format rather than base64.

It can take advantanges from browser caching and Nginx proxy.