### PR TITLE
[14.0] [IMP] web_m2x_options: use the correct context in search function

### DIFF
--- a/web_m2x_options/static/src/js/form.js
+++ b/web_m2x_options/static/src/js/form.js
@@ -127,7 +127,10 @@ odoo.define("web_m2x_options.web_m2x_options", function (require) {
                 self.field_color = self.nodeOptions.field_color;
                 self.colors = self.nodeOptions.colors;
 
-                var context = self.record.getContext(self.recordParams);
+                const context = Object.assign(
+                    self.record.getContext(self.recordParams),
+                    self.additionalContext
+                );
                 var domain = self.record.getDomain(self.recordParams);
 
                 var blacklisted_ids = self._getSearchBlacklist();


### PR DESCRIPTION
To make the search function more inheritable we are using the same context used in the same base search function (ref: https://github.com/odoo/odoo/blob/14.0/addons/web/static/src/js/fields/relational_fields.js#L568-L571)