### PR TITLE
[FIX] web_m2x_options: disable create button in search more dialog wh…

### DIFF
--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -73,6 +73,29 @@ patch(many2OneField, {
     m2o_options_props_create(props, attrs, options) {
         const ir_options = session.web_m2x_options;
         if (options.create === false) {
+            props.canCreate = false;
+        } else if (options.create) {
+            props.canCreate = attrs.can_create
+                ? evaluateBooleanExpr(attrs.can_create)
+                : true;
+        } else if (
+            ir_options["web_m2x_options.create"] === "False" &&
+            props.canCreate
+        ) {
+            props.canCreate = false;
+        } else if (
+            ir_options["web_m2x_options.create"] === "True" &&
+            !props.canCreate
+        ) {
+            props.canCreate = attrs.can_create
+                ? evaluateBooleanExpr(attrs.can_create)
+                : true;
+        }
+        return props;
+    },
+    m2o_options_props_quick_create(props, attrs, options) {
+        const ir_options = session.web_m2x_options;
+        if (options.create === false) {
             props.canQuickCreate = false;
         } else if (options.create) {
             props.canQuickCreate = attrs.can_create
@@ -163,6 +186,7 @@ patch(many2OneField, {
 
     m2o_options_props(props, attrs, options) {
         props = this.m2o_options_props_create(props, attrs, options);
+        props = this.m2o_options_props_quick_create(props, attrs, options);
         props = this.m2o_options_props_create_edit(props, attrs, options);
         props = this.m2o_options_props_limit(props, attrs, options);
         props = this.m2o_options_props_search_more(props, attrs, options);
@@ -205,6 +229,27 @@ patch(Many2OneField.prototype, {
 
 patch(many2ManyTagsField, {
     m2m_options_props_create(props, attrs, options) {
+        const ir_options = session.web_m2x_options;
+        // Create option already available for m2m fields
+        if (!options.create) {
+            if (
+                ir_options["web_m2x_options.create"] === "False" &&
+                props.canCreate
+            ) {
+                props.canCreate = false;
+            } else if (
+                ir_options["web_m2x_options.create"] === "True" &&
+                !props.canCreate
+            ) {
+                props.canCreate = attrs.can_create
+                    ? evaluateBooleanExpr(attrs.can_create)
+                    : true;
+            }
+        }
+        return props;
+    },
+
+    m2m_options_props_quick_create(props, attrs, options) {
         const ir_options = session.web_m2x_options;
         // Create option already available for m2m fields
         if (!options.create) {
@@ -283,6 +328,7 @@ patch(many2ManyTagsField, {
 
     m2m_options_props(props, attrs, options) {
         props = this.m2m_options_props_create(props, attrs, options);
+        props = this.m2m_options_props_quick_create(props, attrs, options);
         props = this.m2m_options_props_create_edit(props, attrs, options);
         props = this.m2m_options_props_limit(props, attrs, options);
         props = this.m2m_options_props_search_more(props, attrs, options);


### PR DESCRIPTION
With option `{'no_create': True}`, there is no create button in the "search more" dialog.

But with `web_m2x_options.create: False` this create button still appear.

Add some code to fix it.

Fix https://github.com/OCA/web/issues/2137