### PR TITLE
[16.0][IMP] web_widget_numeric_step: throttle update calls when scrolling on field

### DIFF
--- a/web_widget_numeric_step/static/src/numeric_step.esm.js
+++ b/web_widget_numeric_step/static/src/numeric_step.esm.js
@@ -22,10 +22,19 @@ export class NumericStep extends FloatField {
     }
     _onWheel(ev) {
         ev.preventDefault();
-        if (ev.deltaY > 0) {
-            this._doStep("minus");
-        } else {
-            this._doStep("plus");
+        if (!this._lastWheelTime) {
+            this._lastWheelTime = 0;
+        }
+        const now = Date.now();
+        const throttleLimit = 100;
+        if (now - this._lastWheelTime >= throttleLimit) {
+            this._lastWheelTime = now;
+
+            if (ev.deltaY > 0) {
+                this._doStep("minus");
+            } else {
+                this._doStep("plus");
+            }
         }
     }
     updateField(val) {


### PR DESCRIPTION
Before this changes, when scrolling on a field, the price update was collapsed because lots of calls to the function was made in a few seconds.

With this changes, the field update, when using the scroll is limited to 1 each 0,1 seconds and the info is updated correctly.

ping @carlos-lopez-tecnativa @chienandalu  