### PR TITLE
[17.0][IMP] web_company_color: apply colors in debug assets and edit menu colors

### DIFF
--- a/web_company_color/models/ir_qweb.py
+++ b/web_company_color/models/ir_qweb.py
@@ -30,6 +30,30 @@ class QWeb(models.AbstractModel):
             res += [asset.get_company_color_asset_node()]
         return res
 
+    def _generate_asset_links(
+        self,
+        bundle,
+        css=True,
+        js=True,
+        debug_assets=False,
+        assets_params=None,
+        rtl=False,
+    ):
+        res = super()._generate_asset_links(
+            bundle,
+            css=css,
+            js=js,
+            debug_assets=debug_assets,
+            assets_params=assets_params,
+            rtl=rtl,
+        )
+        if bundle == "web_company_color.company_color_assets":
+            asset = AssetsBundleCompanyColor(
+                bundle, [], env=self.env, css=True, js=True
+            )
+            res += [asset.get_company_color_asset_node()]
+        return res
+
     def _get_asset_content(self, bundle, assets_params=None):
         """Handle 'special' web_company_color bundle"""
         if bundle == "web_company_color.company_color_assets":

--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -120,6 +120,9 @@ class ResCompany(models.Model):
                 background-color: %(color_navbar_bg_hover)s !important;
             }
         }
+        .dropdown-item{
+            color: %(color_submenu_text)s !important;
+        }
     """
 
     company_colors = fields.Serialized()
@@ -137,6 +140,7 @@ class ResCompany(models.Model):
     color_link_text_hover = fields.Char(
         "Link Text Color Hover", sparse="company_colors"
     )
+    color_submenu_text = fields.Char("Submenu Text Color", sparse="company_colors")
     scss_modif_timestamp = fields.Char("SCSS Modif. Timestamp")
 
     @api.model_create_multi
@@ -213,6 +217,7 @@ class ResCompany(models.Model):
                 "color_link_text": values.get("color_link_text") or "#71639e",
                 "color_link_text_hover": values.get("color_link_text_hover")
                 or "darken(#71639e, 10%)",
+                "color_submenu_text": values.get("color_link_text") or "#374151",
             }
         )
         return values


### PR DESCRIPTION
Allow each company's colors to be visible when running in debug assets mode. Fix the menu colors so they don't look like hyperlinks.

@ForgeFlow 
@CarlosRoca13 