### PR TITLE
[17.0][FIX] web_responsive: Make showAppsMenuItem work again

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -16,7 +16,7 @@
     "Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "installable": True,
-    "depends": ["web", "mail"],
+    "depends": ["web_tour", "mail"],
     "development_status": "Production/Stable",
     "maintainers": ["Tardo", "SplashS"],
     "excludes": ["web_enterprise"],

--- a/web_responsive/static/tests/test_patch.js
+++ b/web_responsive/static/tests/test_patch.js
@@ -1,19 +1,25 @@
 /* Copyright 2021 ITerra - Sergey Shebanin
+ * Copyright 2025 Carlos Lopez - Tecnativa
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
-odoo.define("web_responsive.test_patch", function (require) {
-    "use strict";
+odoo.define(
+    "web_responsive.test_patch",
+    ["@web_tour/tour_service/tour_utils", "@web/core/utils/patch"],
+    function (require) {
+        "use strict";
 
-    const utils = require("web_tour.TourStepUtils");
+        const {stepUtils} = require("@web_tour/tour_service/tour_utils");
+        const {patch} = require("@web/core/utils/patch");
 
-    /* Make base odoo JS tests working */
-    utils.include({
-        showAppsMenuItem() {
-            return {
-                edition: "community",
-                trigger: ".o_navbar_apps_menu",
-                auto: true,
-                position: "bottom",
-            };
-        },
-    });
-});
+        patch(stepUtils, {
+            /* Make base odoo JS tests working */
+            showAppsMenuItem() {
+                return {
+                    edition: "community",
+                    trigger: "button.o_grid_apps_menu__button",
+                    auto: true,
+                    position: "bottom",
+                };
+            },
+        });
+    }
+);


### PR DESCRIPTION
In Odoo 17, the Class `TourStepUtils` was removed, and `stepUtils` is now an `object` instead of a `class`. When this module is installed, the tours stop working and throw the error:` Uncaught Error: Dependencies should be defined by an array:`

This commit adapts the code to align with these changes, ensuring that tours work correctly.

V16
https://github.com/odoo/odoo/blob/b97f0cfbd6b39d176f9b7e465f6da0722222b010/addons/web_tour/static/src/js/tour_step_utils.js#L7
V17
https://github.com/odoo/odoo/blob/77243bc85db87fad2196052036390f65bd451eeb/addons/web_tour/static/src/tour_service/tour_utils.js#L426

![image](https://github.com/user-attachments/assets/621cab41-03de-4ed2-8a23-a1149e132468)

@Tecnativa @CarlosRoca13 @pedrobaeza @yajo could you please review this, Thanks!