### PR TITLE
[16.0][IMP] web_timeline: Safer demo view action override

### DIFF
--- a/web_timeline/demo/ir_cron_view.xml
+++ b/web_timeline/demo/ir_cron_view.xml
@@ -8,7 +8,12 @@
             <timeline date_start="nextcall" default_group_by="model_id" />
         </field>
     </record>
-    <record id="base.ir_cron_act" model="ir.actions.act_window">
-        <field name="view_mode">tree,form,calendar,timeline</field>
-    </record>
+    <!-- Append our view_mode this way to avoid overwriting changes done by other modules. -->
+    <function model="ir.actions.act_window" name="write">
+        <value eval="[ref('base.ir_cron_act')]" />
+        <value
+            model="ir.actions.act_window"
+            eval="{'view_mode': obj().env.ref('base.ir_cron_act').view_mode + ',timeline'}"
+        />
+    </function>
 </odoo>


### PR DESCRIPTION
For the demo view added in https://github.com/OCA/web/pull/2776

This is ahead of another module I am working on where I will also be adding a demo view on cron tasks; that new module & web_timeline both override this same action to add their own demo view, so only 1 or the other would be testable on runboat.

I am not aware of a slicker way to do this (similar to [base_view_inheritance_extension](https://github.com/OCA/server-tools/tree/16.0/base_view_inheritance_extension)), I hope with the comment I added this remains readable.

Runboat check: Enable debug mode, go to Technical > Scheduled Actions, ensure timeline view got added same as before:
![Screenshot at 2025-01-30 10-31-34](https://github.com/user-attachments/assets/24a5b696-1f44-4cf0-bc37-08b3d873cfc8)
