### PR TITLE
[16.0][FIX] web_responsive: display search filters correctly

### DIFF
--- a/web_responsive/static/src/components/control_panel/control_panel.scss
+++ b/web_responsive/static/src/components/control_panel/control_panel.scss
@@ -152,13 +152,6 @@
             display: inline-block !important;
         }
 
-        .o_searchview_input_container > .o_searchview_autocomplete {
-            left: 0;
-            right: 0;
-            > li {
-                padding: 10px 0px;
-            }
-        }
         .o_searchview_quick {
             display: flex;
             flex: 1 1 auto;


### PR DESCRIPTION
When you search for data in the mobile size search bar of any view and a drop-down filter appears, the text overlaps the drop-down arrow. This error in the design is caused by the extra padding.

Before:

![image](https://github.com/user-attachments/assets/3a1d44c9-ae28-490f-97ee-2bdd7bf51412)

After:

![image](https://github.com/user-attachments/assets/bad46685-022c-4a96-b05a-515dd064549d)

cc @Tecnativa TT54811

@chienandalu @CarlosRoca13 please review