### PR TITLE
[16.0][IMP] web_responsive: Remove unnecessary calendar optimisation

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -27,12 +27,6 @@ html .o_web_client .o_action_manager .o_action {
         .fc-timeGridWeek-view .fc-axis {
             padding-left: 0px;
         }
-        .fc-dayGridMonth-view {
-            padding-left: 0px;
-            .fc-week-number {
-                display: none;
-            }
-        }
         .fc-dayGridYear-view {
             padding-left: 0px;
             > .fc-month-container {


### PR DESCRIPTION
Removed the optimisation of hiding the week number at a certain size for consistency with the responsive design of Odoo enterprise. It is a non-functional optimisation as it hides useful information that hardly takes up any space. It also causes incompatibilities in the design with extensions that do not take into account these specific changes.

Example before change causing incompatibility
![image](https://github.com/user-attachments/assets/ccf7f86b-d8f7-4417-b180-cbcb40862782)

After:
![image](https://github.com/user-attachments/assets/e5b5922d-fe71-4087-bac5-577129589699)

cc @Tecnativa TT54811

@chienandalu @CarlosRoca13 @pedrobaeza @sergio-teruel please review