### PR TITLE
[17.0][IMP] web_responsive: Remove unnecessary calendar optimisation

### DIFF
--- a/web_responsive/static/src/legacy/scss/web_responsive.scss
+++ b/web_responsive/static/src/legacy/scss/web_responsive.scss
@@ -24,12 +24,6 @@ $chatter_zone_width: 35% !important;
         height: 35px;
     }
     .o_calendar_widget {
-        .fc-dayGridMonth-view {
-            .fc-week-number {
-                display: none;
-            }
-        }
-
         .fc-timeGridDay-view {
             .fc-day-header {
                 vertical-align: middle;


### PR DESCRIPTION
Removed the optimisation of hiding the week number at a certain size for consistency with the responsive design of Odoo enterprise. It is a non-functional optimisation as it hides useful information that hardly takes up any space. It also causes incompatibilities in the design with extensions that do not take into account these specific changes.

fw port of https://github.com/OCA/web/pull/3075

cc @Tecnativa TT54811

@pedrobaeza @chienandalu @CarlosRoca13 please review