### PR TITLE
[16.0][ADD] web_action_conditionable: support forms

### DIFF
--- a/web_action_conditionable/README.rst
+++ b/web_action_conditionable/README.rst
@@ -28,7 +28,7 @@ web_action_conditionable
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-Add support for conditions on create and delete actions on One2Many fields.
+Add support for conditions on create and delete actions on One2Many fields, as well as conditions for create, delete, duplicate and edit actions on forms.
 
 **Table of contents**
 
@@ -38,19 +38,31 @@ Add support for conditions on create and delete actions on One2Many fields.
 Usage
 =====
 
-Odoo by default support:
+Odoo by default supports:
 
 ::
 
    <tree delete="false" create="false">
 
-with this module you can:
+with this module you can do:
 
 ::
 
    <tree delete="state=='draft'" create="state!='sent'">
 
 It works in any tree view, so you can use it in One2many.
+
+Similarly in forms you can write:
+
+::
+
+    <form create="false" delete="false" duplicate="false" edit="false">
+
+and with this module you can do:
+
+::
+
+    <form create="state=='draft'" delete="state!='done'" duplicate="some_field=='some value'" edit="state!='done'">
 
 Bug Tracker
 ===========
@@ -80,6 +92,7 @@ Contributors
 * Jasper Jumelet <jasper.jumelet@codeforward.nl>
 * `Trobz <https://trobz.com>`_:
     * Nguyễn Minh Chiến <chien@trobz.com>
+* Holger Brunn <mail@hunki-enterprises.com> (https://hunki-enterprises.com)
 
 Other credits
 ~~~~~~~~~~~~~

--- a/web_action_conditionable/readme/CONTRIBUTORS.rst
+++ b/web_action_conditionable/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 * Jasper Jumelet <jasper.jumelet@codeforward.nl>
 * `Trobz <https://trobz.com>`_:
     * Nguyễn Minh Chiến <chien@trobz.com>
+* Holger Brunn <mail@hunki-enterprises.com> (https://hunki-enterprises.com)

--- a/web_action_conditionable/readme/DESCRIPTION.rst
+++ b/web_action_conditionable/readme/DESCRIPTION.rst
@@ -1,1 +1,1 @@
-Add support for conditions on create and delete actions on One2Many fields.
+Add support for conditions on create and delete actions on One2Many fields, as well as conditions for create, delete, duplicate and edit actions on forms.

--- a/web_action_conditionable/readme/USAGE.rst
+++ b/web_action_conditionable/readme/USAGE.rst
@@ -1,13 +1,25 @@
-Odoo by default support:
+Odoo by default supports:
 
 ::
 
    <tree delete="false" create="false">
 
-with this module you can:
+with this module you can do:
 
 ::
 
    <tree delete="state=='draft'" create="state!='sent'">
 
 It works in any tree view, so you can use it in One2many.
+
+Similarly in forms you can write:
+
+::
+
+    <form create="false" delete="false" duplicate="false" edit="false">
+
+and with this module you can do:
+
+::
+
+    <form create="state=='draft'" delete="state!='done'" duplicate="some_field=='some value'" edit="state!='done'">

--- a/web_action_conditionable/static/description/index.html
+++ b/web_action_conditionable/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -370,7 +369,7 @@ ul.auto-toc {
 !! source digest: sha256:4bc330cf2cd18ff1c39c729eeae66a68dde8f3252b6825de70919e0f45dcc9fc
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/web/tree/16.0/web_action_conditionable"><img alt="OCA/web" src="https://img.shields.io/badge/github-OCA%2Fweb-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/web-16-0/web-16-0-web_action_conditionable"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/web&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>Add support for conditions on create and delete actions on One2Many fields.</p>
+<p>Add support for conditions on create and delete actions on One2Many fields, as well as conditions for create, delete, duplicate and edit actions on forms.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -387,15 +386,23 @@ ul.auto-toc {
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
-<p>Odoo by default support:</p>
+<p>Odoo by default supports:</p>
 <pre class="literal-block">
 &lt;tree delete=&quot;false&quot; create=&quot;false&quot;&gt;
 </pre>
-<p>with this module you can:</p>
+<p>with this module you can do:</p>
 <pre class="literal-block">
 &lt;tree delete=&quot;state=='draft'&quot; create=&quot;state!='sent'&quot;&gt;
 </pre>
 <p>It works in any tree view, so you can use it in One2many.</p>
+<p>Similarly in forms you can write:</p>
+<pre class="literal-block">
+&lt;form create=&quot;false&quot; delete=&quot;false&quot; duplicate=&quot;false&quot; edit=&quot;false&quot;&gt;
+</pre>
+<p>and with this module you can do:</p>
+<pre class="literal-block">
+&lt;form create=&quot;state=='draft'&quot; delete=&quot;state!='done'&quot; duplicate=&quot;some_field=='some value'&quot; edit=&quot;state!='done'&quot;&gt;
+</pre>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
@@ -429,6 +436,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </dd>
 </dl>
 </li>
+<li>Holger Brunn &lt;<a class="reference external" href="mailto:mail&#64;hunki-enterprises.com">mail&#64;hunki-enterprises.com</a>&gt; (<a class="reference external" href="https://hunki-enterprises.com">https://hunki-enterprises.com</a>)</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/web_action_conditionable/static/src/components/form_arch_parser.esm.js
+++ b/web_action_conditionable/static/src/components/form_arch_parser.esm.js
@@ -1,0 +1,15 @@
+/** @odoo-module **/
+import {FormArchParser} from "@web/views/form/form_arch_parser";
+import {patch} from "@web/core/utils/patch";
+
+patch(FormArchParser.prototype, "web_action_conditionable", {
+    parse(arch) {
+        const result = this._super(...arguments);
+        const parsedArch = this.parseXML(arch);
+        for (const action of ["create", "delete", "duplicate", "edit"]) {
+            result.activeActions[action + "_expression"] =
+                parsedArch.getAttribute(action);
+        }
+        return result;
+    },
+});

--- a/web_action_conditionable/static/src/components/form_controller.esm.js
+++ b/web_action_conditionable/static/src/components/form_controller.esm.js
@@ -1,0 +1,32 @@
+/** @odoo-module **/
+import {FormController} from "@web/views/form/form_controller";
+import {evaluateExpr} from "@web/core/py_js/py";
+import {patch} from "@web/core/utils/patch";
+
+patch(FormController.prototype, "web_action_conditionable", {
+    setup() {
+        this._super(...arguments);
+        owl.onWillRender(() => {
+            return this._evaluate_web_action_conditionable();
+        });
+    },
+    async _evaluate_web_action_conditionable() {
+        for (const action of ["create", "delete", "duplicate", "edit"]) {
+            try {
+                this.archInfo.activeActions[action] = evaluateExpr(
+                    this.archInfo.activeActions[action + "_expression"] || "True",
+                    this.model.root.data
+                );
+                if (action === "edit") {
+                    this.canEdit = this.archInfo.activeActions[action];
+                    this.model.root.switchMode(this.canEdit ? "edit" : "readonly");
+                }
+                if (action === "create") {
+                    this.canCreate = this.archInfo.activeActions[action];
+                }
+            } catch (exception) {
+                console.log(exception);
+            }
+        }
+    },
+});


### PR DESCRIPTION
This was supported in v8 but never made it into newer versions.

---

Similarly in forms you can write:


    <form create="false" delete="false" duplicate="false" edit="false">

and with this module you can do:

    <form create="state=='draft'" delete="state!='done'" duplicate="some_field=='some value'" edit="state!='done'">