### PR TITLE
[16.0][FIX] web_widget_product_label_section_and_note: Use a flag to change the icon based on product visibility.

### DIFF
--- a/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.esm.js
+++ b/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.esm.js
@@ -135,6 +135,7 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
         this.labelVisibility = useState({value: false});
         this.isProductVisible = useState({value: false});
         this.switchToLabel = false;
+        this.changeProductVisibility = true;
         this.columnIsProductAndLabel = useState({
             value: this.props.record.columnIsProductAndLabel,
         });
@@ -184,8 +185,10 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
             window.removeEventListener("afterprint", this.onAfterPrint);
         });
         onWillUpdateProps((newProps) => {
-            const label = newProps.record.data.name || "";
-            this.isProductVisible.value = label.includes(this.productName);
+            if (this.changeProductVisibility) {
+                const label = newProps.record.data.name || "";
+                this.isProductVisible.value = label.includes(this.productName);
+            }
         });
     }
 
@@ -257,9 +260,12 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
     }
 
     updateLabel(value) {
+        this.changeProductVisibility = false;
         this.props.record.update({
             name:
-                this.productName && this.productName !== value
+                this.productName &&
+                this.productName !== value &&
+                this.isProductVisible.value
                     ? `${this.productName}\n${value}`
                     : value,
         });


### PR DESCRIPTION
Before this commit, when `isProductVisible` was disabled and the user changed the label, this caused `isProductVisible` to change its value. After this commit, changing the label no longer modifies `isProductVisible`.

Backport of https://github.com/OCA/web/pull/3080/commits/65af83d508e8ebb6f337bdd53180f33a688dea7f
TT54841
@Tecnativa @pedrobaeza Please take a look according to [your comment](https://github.com/OCA/web/pull/3080#issuecomment-2637835290) from the migration PR.