### PR TITLE
[FIX][16.0] web_refresher: error when dom destroyed during timeout

### DIFF
--- a/web_refresher/static/src/js/refresher.esm.js
+++ b/web_refresher/static/src/js/refresher.esm.js
@@ -12,14 +12,6 @@ export function useRefreshAnimation(timeout) {
     const refreshClass = "o_content__refresh";
     let timeoutId = null;
 
-    /**
-     * @returns {DOMTokenList|null}
-     */
-    function contentClassList() {
-        const content = document.querySelector(".o_content");
-        return content ? content.classList : null;
-    }
-
     function clearAnimationTimeout() {
         if (timeoutId) {
             clearTimeout(timeoutId);
@@ -29,11 +21,20 @@ export function useRefreshAnimation(timeout) {
 
     function animate() {
         clearAnimationTimeout();
-        contentClassList().add(refreshClass);
-        timeoutId = setTimeout(() => {
-            contentClassList().remove(refreshClass);
-            clearAnimationTimeout();
-        }, timeout);
+        const content = document.querySelector(".o_content");
+        if (content) {
+            content.classList.add(refreshClass);
+            timeoutId = setTimeout(() => {
+                // Check if element still exists in DOM after timeout
+                if (
+                    document.contains(content) &&
+                    content.classList.contains(refreshClass)
+                ) {
+                    content.classList.remove(refreshClass);
+                }
+                clearAnimationTimeout();
+            }, timeout);
+        }
     }
 
     return animate;


### PR DESCRIPTION
If you navigate out of the current view while the refresh animation is running, you will receive the following error:

```
UncaughtClientError > TypeError
Uncaught Javascript Error > Cannot read properties of null (reading 'remove')
TypeError: Cannot read properties of null (reading 'remove')
    at http://127.0.0.1:8089/web/assets/5713-67df1f9/web.assets_backend.min.js:1860:125
```

This is due to the fact that the dom element does not exist anymore. This patch adds an extra check to ensure the content exists after the animation timeout finishes.