### PR TITLE
[18.0][FIX] web_widget_numeric_step: remove odoo-module tag and fix sort-import

### DIFF
--- a/web_widget_numeric_step/static/src/numeric_step.esm.js
+++ b/web_widget_numeric_step/static/src/numeric_step.esm.js
@@ -1,8 +1,6 @@
-/** @odoo-module */
-
+import {FloatField} from "@web/views/fields/float/float_field";
 import {_t} from "@web/core/l10n/translation";
 import {registry} from "@web/core/registry";
-import {FloatField} from "@web/views/fields/float/float_field";
 import {standardFieldProps} from "@web/views/fields/standard_field_props";
 
 export class NumericStep extends FloatField {


### PR DESCRIPTION
```
  11:1  warning  Imports should be sorted alphabetically  sort-imports

✖ 1 problem (0 errors, 1 warning)


trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
```