### PR TITLE
[17.0][FIX] web_timeline: Enable XSS protection

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -195,7 +195,6 @@ export class TimelineRenderer extends Component {
             // Delete an item by tapping the delete button top right
             this.options.editable.remove = true;
         }
-        this.options.xss = {disabled: true};
         this.timeline = new vis.Timeline(this.canvasRef.el, {}, this.options);
         this.timeline.on("click", this.on_timeline_click.bind(this));
         if (!this.options.onUpdate) {


### PR DESCRIPTION
XSS protection was disabled on this widget. It shouldn't happen.... vis-timeline was complaining about it...

A warning was raised:

`You disabled XSS protection for vis-Timeline. I sure hope you know what you\'re doing!`