### PR TITLE
[16.0][FIX] product_label_section_and_note_field: Update name directly before calling update to prevent a race condition.

### DIFF
--- a/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.esm.js
+++ b/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.esm.js
@@ -261,14 +261,17 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
 
     updateLabel(value) {
         this.changeProductVisibility = false;
-        this.props.record.update({
-            name:
-                this.productName &&
-                this.productName !== value &&
-                this.isProductVisible.value
-                    ? `${this.productName}\n${value}`
-                    : value,
-        });
+        const new_name =
+            this.productName &&
+            this.productName !== value &&
+            this.isProductVisible.value
+                ? `${this.productName}\n${value}`
+                : value;
+        // We need to update the record data directly because the record.update method
+        // updates the data asynchronously, and the new value will not be available
+        // in the `get Label` method immediately.
+        this.props.record.data.name = new_name;
+        this.props.record.update({name: new_name});
     }
 }
 


### PR DESCRIPTION
closes https://github.com/OCA/web/issues/3089

I tested this on V17, and the issue does not occur, it works fine.
TT55062
@Tecnativa @pedrobaeza @chienandalu could you please review this?