### PR TITLE
[17.0][FIX] web_responsive: Fix blank screen on search (support menus w/o xmlid)

### DIFF
--- a/web_responsive/static/src/components/menu_canonical_searchbar/searchbar.xml
+++ b/web_responsive/static/src/components/menu_canonical_searchbar/searchbar.xml
@@ -25,7 +25,7 @@
                 class="list-unstyled search-list"
                 t-ref="searchItems"
             >
-                <t t-foreach="state.rootItems" t-as="menu" t-key="menu.xmlid">
+                <t t-foreach="state.rootItems" t-as="menu" t-key="menu.id">
                     <li t-attf-class="search-item {{highlighted(menu_index)}}">
                         <a
                             t-attf-class="search-item__link"
@@ -59,7 +59,7 @@
                 >
                     <hr class="w-100" />
                 </li>
-                <t t-foreach="state.subItems" t-as="menu" t-key="menu.xmlid">
+                <t t-foreach="state.subItems" t-as="menu" t-key="menu.id">
                     <li t-attf-class="search-item {{highlighted(menu_index, true)}}">
                         <a
                             t-attf-class="search-item__link"


### PR DESCRIPTION
If a menu item is created manually via the Odoo UI, then it (likely) won't have an xmlid. This code should use `id` as the `t-key` instead, as that is *always* available.

Fixes #3104

**Explanation**: With asset debugging enabled, we get an error `Error: Got duplicate key in t-foreach`, because multiple elements have a blank `""` xmlid, and so we hit a key conflict.