### PR TITLE
[16.0][OU-FIX] web_chatter_position: Ensure correct values for 'chatter_position'

### DIFF
--- a/web_chatter_position/__manifest__.py
+++ b/web_chatter_position/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Chatter Position",
     "summary": "Add an option to change the chatter position",
-    "version": "16.0.1.0.2",
+    "version": "16.0.1.0.3",
     "author": "Hynsys Technologies, Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",
     "license": "LGPL-3",

--- a/web_chatter_position/migrations/16.0.1.0.3/post-migration.py
+++ b/web_chatter_position/migrations/16.0.1.0.3/post-migration.py
@@ -1,0 +1,21 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Field 'chatter_position' was defined in module 'web_responsive' before it was
+    # moved to 'web_chatter_position'. In 'web_responsive' the allowed values have
+    # been ['normal', 'sided'].
+    # In case users installed 'web_chatter_position' along with 'web_responsive' field
+    # 'chatter_position' potentially was already in the db with old values, which are
+    # not supported.
+    # This migration covers this scenario by correcting unsupported values.
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE res_users
+        SET chatter_position = 'auto'
+        WHERE chatter_position = 'normal'
+        """,
+    )


### PR DESCRIPTION
Field 'chatter_position' was defined in module 'web_responsive' before it was moved to 'web_chatter_position'.
In 'web_responsive' the allowed values have been ['normal', 'sided'] while the allowed values in 'web_chatter_position' are ['auto', 'bottom', 'sided']

In case users installed 'web_chatter_position' along with 'web_responsive', field 'chatter_position' potentially was already in the db with old values, which are not supported.

This migration covers this scenario by correcting unsupported values.

The issue was also fixed for future migrations in https://github.com/OCA/OpenUpgrade/pull/4807

@pedrobaeza Kindly asking for a review