### PR TITLE
[14.0][FIX] web_ir_actions_act_multi: Uninstallation Issue

### DIFF
--- a/web_ir_actions_act_multi/models/__init__.py
+++ b/web_ir_actions_act_multi/models/__init__.py
@@ -1,1 +1,2 @@
 from . import ir_actions
+from . import ir_model

--- a/web_ir_actions_act_multi/models/ir_model.py
+++ b/web_ir_actions_act_multi/models/ir_model.py
@@ -1,0 +1,37 @@
+from odoo import api, models
+
+
+class IrModelData(models.Model):
+    _inherit = "ir.model.data"
+
+    @api.model
+    def _module_data_uninstall(self, modules_to_remove):
+        # Set a flag to prevent the deletion of tables and columns
+        # related to ir.actions.act_multi.
+        if "web_ir_actions_act_multi" in modules_to_remove:
+            self = self.with_context(uninstall_web_ir_actions_act_multi=True)
+        return super(IrModelData, self)._module_data_uninstall(modules_to_remove)
+
+
+class IrModel(models.Model):
+    _inherit = "ir.model"
+
+    def _drop_table(self):
+        # Prevent the deletion of the table.
+        # The model is ir.actions.act_multi, but the actual table is ir_actions.
+        # This table is a core component and should not be removed.
+        if self.env.context.get("uninstall_web_ir_actions_act_multi"):
+            self -= self.filtered(lambda model: model.model == "ir.actions.act_multi")
+        return super()._drop_table()
+
+
+class IrModelFields(models.Model):
+    _inherit = "ir.model.fields"
+
+    def _drop_column(self):
+        # Prevent the deletion of columns in the ir_actions table.
+        # The model is ir.actions.act_multi, but the actual table is ir_actions.
+        # Since this table is a core component, its columns should not be deleted.
+        if self.env.context.get("uninstall_web_ir_actions_act_multi"):
+            self -= self.filtered(lambda field: field.model == "ir.actions.act_multi")
+        return super()._drop_column()


### PR DESCRIPTION
During uninstallation, Odoo attempts to delete columns and tables related to the `ir.actions.act_multi` model. However, this model shares the same table (`ir_actions`) with other core modules, meaning the table and its columns should not be removed.

Before this commit, this issue could render the database unusable. After this commit, the database remains intact, and the module can be uninstalled without problems.

Fix https://github.com/OCA/web/issues/2394

TT51961
@Tecnativa @pedrobaeza @chienandalu @augusto-weiss @gaikaz could you please review this?

I believe these changes are less risky than https://github.com/OCA/web/pull/2817
Note: Forward-port to v16 and included in the migration to v17: https://github.com/OCA/web/pull/2704