### PR TITLE
[17.0][IMP] web_widget_x2many_2d_matrix: allow to set options and attrs for field value

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.esm.js
@@ -3,6 +3,7 @@
 import {Component} from "@odoo/owl";
 import {X2Many2DMatrixRenderer} from "@web_widget_x2many_2d_matrix/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm";
 import {archParseBoolean} from "@web/views/utils";
+import {evaluateBooleanExpr} from "@web/core/py_js/py";
 import {registry} from "@web/core/registry";
 import {standardFieldProps} from "@web/views/fields/standard_field_props";
 
@@ -29,12 +30,24 @@ X2Many2DMatrixField.props = {
     isYClickable: {type: Boolean, optional: true},
     showRowTotals: {type: Boolean, optional: true},
     showColumnTotals: {type: Boolean, optional: true},
+    canOpen: {type: Boolean, optional: true},
+    canCreate: {type: Boolean, optional: true},
+    canWrite: {type: Boolean, optional: true},
+    canQuickCreate: {type: Boolean, optional: true},
+    canCreateEdit: {type: Boolean, optional: true},
 };
 
 X2Many2DMatrixField.components = {X2Many2DMatrixRenderer};
 export const x2Many2DMatrixField = {
     component: X2Many2DMatrixField,
-    extractProps({attrs}) {
+    extractProps({attrs, options}) {
+        const hasCreatePermission = attrs.can_create
+            ? evaluateBooleanExpr(attrs.can_create)
+            : true;
+        const hasWritePermission = attrs.can_write
+            ? evaluateBooleanExpr(attrs.can_write)
+            : true;
+        const canCreate = options.no_create ? false : hasCreatePermission;
         return {
             matrixFields: {
                 value: attrs.field_value,
@@ -51,6 +64,11 @@ export const x2Many2DMatrixField = {
                 "show_column_totals" in attrs
                     ? archParseBoolean(attrs.show_column_totals)
                     : true,
+            canOpen: !options.no_open,
+            canCreate,
+            canWrite: hasWritePermission,
+            canQuickCreate: canCreate && !options.no_quick_create,
+            canCreateEdit: canCreate && !options.no_create_edit,
         };
     },
 };

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.xml
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.xml
@@ -9,6 +9,11 @@
                 showColumnTotals="props.showColumnTotals"
                 readonly="props.readonly"
                 domain="props.domain"
+                canOpen="props.canOpen"
+                canCreate="props.canCreate"
+                canWrite="props.canWrite"
+                canQuickCreate="props.canQuickCreate"
+                canCreateEdit="props.canCreateEdit"
             />
         </div>
     </t>

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -163,6 +163,11 @@ export class X2Many2DMatrixRenderer extends Component {
             readonly: this.props.readonly,
             record: record,
             name: this.matrixFields.value,
+            canCreate: this.props.canCreate,
+            canOpen: this.props.canOpen,
+            canWrite: this.props.canWrite,
+            canQuickCreate: this.props.canQuickCreate,
+            canCreateEdit: this.props.canCreateEdit,
         };
         const domain = record.fields[this.matrixFields.value].domain;
         if (domain) {
@@ -185,4 +190,9 @@ X2Many2DMatrixRenderer.props = {
     domain: {type: [Array, Function], optional: true},
     showRowTotals: {type: Boolean, optional: true},
     showColumnTotals: {type: Boolean, optional: true},
+    canOpen: {type: Boolean, optional: true},
+    canCreate: {type: Boolean, optional: true},
+    canWrite: {type: Boolean, optional: true},
+    canQuickCreate: {type: Boolean, optional: true},
+    canCreateEdit: {type: Boolean, optional: true},
 };


### PR DESCRIPTION
In previous versions, options were able to be set for the field value. Since migration to 17.0, this feature was no longer working. With this improvement, we can now set this attributes again.

For more example see https://github.com/OCA/manufacture/pull/1443