### PR TITLE
[17.0][IMP] web_widget_x2many_2d_matrix: remove bg-colors to work with Odoo EE dark mode.

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.scss
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.scss
@@ -16,7 +16,6 @@ $x2many_2d_matrix_max_height: 450px;
             position: sticky;
             top: 0;
             z-index: 1;
-            background-color: $o-list-footer-bg-color;
 
             &.total {
                 right: 0;
@@ -26,14 +25,7 @@ $x2many_2d_matrix_max_height: 450px;
         > tbody {
             > tr {
                 &:nth-of-type(2n + 1) td.row-total,
-                &:nth-of-type(2n + 1) td:first-child {
-                    background-color: mix(#000, #fff, 1%);
-                }
                 &:nth-of-type(2n) td.row-total,
-                &:nth-of-type(2n) td:first-child {
-                    background-color: white;
-                }
-
                 > td {
                     text-align: right;
 
@@ -48,7 +40,6 @@ $x2many_2d_matrix_max_height: 450px;
                         border-right-width: 1px;
                         border-right-color: $gray-300;
                         border-right-style: solid;
-                        box-shadow: -1px 5px 10px $gray-300;
                     }
                     &.row-total {
                         padding: 0.5rem 0.75rem;
@@ -58,7 +49,6 @@ $x2many_2d_matrix_max_height: 450px;
                         border-left-width: 1px;
                         border-left-color: $gray-300;
                         border-left-style: solid;
-                        box-shadow: -1px 5px 10px $gray-300;
                     }
                 }
             }
@@ -66,7 +56,6 @@ $x2many_2d_matrix_max_height: 450px;
 
         > tfoot > tr > th {
             text-align: right;
-            background-color: $o-list-footer-bg-color;
             position: sticky;
             bottom: 0;
 
@@ -76,7 +65,6 @@ $x2many_2d_matrix_max_height: 450px;
                 border-left-width: 1px;
                 border-left-color: $gray-300;
                 border-left-style: solid;
-                background-color: white;
             }
         }
     }


### PR DESCRIPTION
The background color was needed in previous versions, however now the color is inherited by parent elements. Also removing shadow from totals.

Pre Changes:
![image](https://github.com/user-attachments/assets/dd384ef5-47d2-41b3-8dae-90d05fd2cd28)
![image](https://github.com/user-attachments/assets/643e240c-7aaf-4a90-a445-9f692a4df764)

Post Changes:
![image](https://github.com/user-attachments/assets/2c201967-3df1-45a3-87a5-ecd6caf61e0a)
![image](https://github.com/user-attachments/assets/efe91e74-15a2-4677-b9c4-d6456b301919)
