### PR TITLE
[18.0][IMP] web_widget_numeric_step: be able to add classes

### DIFF
--- a/web_widget_numeric_step/README.rst
+++ b/web_widget_numeric_step/README.rst
@@ -63,12 +63,13 @@ Example for an 0.25 step, min to -1 and max to 10 :
 
 **Available Options**
 
-- step > Amount to increase/decrease (default: 1.0)
-- min > Min. value allowed (default: no limit)
-- max > Max. value allowed (default: no limit)
-- auto_select > Select the content when the element get focus (default:
-  False)
-- placeholder > Define the placeholder text (default: None)
+-  step > Amount to increase/decrease (default: 1.0)
+-  min > Min. value allowed (default: no limit)
+-  max > Max. value allowed (default: no limit)
+-  auto_select > Select the content when the element get focus (default:
+   False)
+-  placeholder > Define the placeholder text (default: None)
+-  class > Define additional classes for the input (default: None)
 
 **Examples**
 
@@ -121,18 +122,18 @@ Authors
 Contributors
 ------------
 
-- `GRAP <http://www.grap.coop>`__:
+-  `GRAP <http://www.grap.coop>`__:
 
-  - Quentin DUPONT <quentin.dupont@grap.coop>
+   -  Quentin DUPONT <quentin.dupont@grap.coop>
 
-- `Tecnativa <https://www.tecnativa.com/>`__:
+-  `Tecnativa <https://www.tecnativa.com/>`__:
 
-  - Alexandre Díaz
-  - Carlos Roca
+   -  Alexandre Díaz
+   -  Carlos Roca
 
-- Helly kapatel <helly.kapatel@initos.com>
-- Thanakrit Pintana <thanakrit.p39@gmail.com>
-- Dhara Solanki <dhara.solanki@initos.com>
+-  Helly kapatel <helly.kapatel@initos.com>
+-  Thanakrit Pintana <thanakrit.p39@gmail.com>
+-  Dhara Solanki <dhara.solanki@initos.com>
 
 Maintainers
 -----------

--- a/web_widget_numeric_step/readme/USAGE.md
+++ b/web_widget_numeric_step/readme/USAGE.md
@@ -23,6 +23,7 @@ Example for an 0.25 step, min to -1 and max to 10 :
 - auto_select \> Select the content when the element get focus (default:
   False)
 - placeholder \> Define the placeholder text (default: None)
+- class \> Define additional classes for the input (default: None)
 
 **Examples**
 

--- a/web_widget_numeric_step/static/description/index.html
+++ b/web_widget_numeric_step/static/description/index.html
@@ -411,6 +411,7 @@ values).</p>
 <li>auto_select &gt; Select the content when the element get focus (default:
 False)</li>
 <li>placeholder &gt; Define the placeholder text (default: None)</li>
+<li>class &gt; Define additional classes for the input (default: None)</li>
 </ul>
 <p><strong>Examples</strong></p>
 <p>Iteration with 0.25 step, min to -1 and max to 10.</p>

--- a/web_widget_numeric_step/static/src/numeric_step.esm.js
+++ b/web_widget_numeric_step/static/src/numeric_step.esm.js
@@ -62,6 +62,7 @@ NumericStep.props = {
     min: {type: Number, optional: true},
     max: {type: Number, optional: true},
     placeholder: {type: String, optional: true},
+    additional_class: {type: String, optional: true},
 };
 NumericStep.defaultProps = {
     ...FloatField.defaultProps,
@@ -80,6 +81,7 @@ export const numericStep = {
             min: options.min,
             max: options.max,
             placeholder: attrs.placeholder,
+            additional_class: attrs.class,
         };
     },
 };

--- a/web_widget_numeric_step/static/src/numeric_step.xml
+++ b/web_widget_numeric_step/static/src/numeric_step.xml
@@ -6,7 +6,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <template>
     <t t-name="web_widget_numeric_step">
-        <div class="d-flex widget_numeric_step">
+        <div t-attf-class="d-flex widget_numeric_step {{props.additional_class or ''}}">
             <div class="input-group-prepend widget_numeric_step_btn">
                 <button
                     class="fa fa-minus btn btn-default btn_numeric_step"
@@ -24,7 +24,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 t-ref="numpadDecimal"
                 t-att-placeholder="props.placeholder"
                 t-att-type="props.inputType"
-                class="o_input input_numeric_step"
+                class="o_input"
                 inputmode="decimal"
                 t-att-step="props.step"
                 t-on-keydown="_onKeyDown"


### PR DESCRIPTION
- Adapted forward of https://github.com/OCA/web/pull/2883

If we set a class in the field it will get to the widget template.

cc @Tecnativa @sergio-teruel @CarlosRoca13 TT54358