### PR TITLE
[IMP] web_environment_ribbon: prepare running_env for ribbon name vals

### DIFF
--- a/web_environment_ribbon/models/web_environment_ribbon_backend.py
+++ b/web_environment_ribbon/models/web_environment_ribbon_backend.py
@@ -1,7 +1,10 @@
 # Copyright 2017 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import os
+
 from odoo import api, models
+from odoo.tools.config import config
 
 
 class WebEnvironmentRibbonBackend(models.AbstractModel):
@@ -10,7 +13,16 @@ class WebEnvironmentRibbonBackend(models.AbstractModel):
 
     @api.model
     def _prepare_ribbon_format_vals(self):
-        return {"db_name": self.env.cr.dbname}
+        running_env = (
+            config.get("running_env")
+            or os.environ.get("RUNNING_ENV")
+            or os.environ.get("ODOO_STAGE")
+            or "test"
+        )
+        return {
+            "db_name": self.env.cr.dbname,
+            "running_env": running_env,
+        }
 
     @api.model
     def _prepare_ribbon_name(self):


### PR DESCRIPTION
Allow developer to construct ribbon name by `running_env` (from [server_environment](https://github.com/OCA/server-env/tree/18.0/server_environment) module)

Reference: https://github.com/OCA/server-env/blob/894c98587156042a02b8d02646b7513f75642720/server_environment/server_env.py#L47-L61