### PR TITLE
[18.0][FIX]web_environment_ribbon: hide ribbon by default

### DIFF
--- a/web_environment_ribbon/static/src/components/environment_ribbon/ribbon.esm.js
+++ b/web_environment_ribbon/static/src/components/environment_ribbon/ribbon.esm.js
@@ -58,7 +58,7 @@ export class WebEnvironmentRibbon extends Component {
 }
 
 WebEnvironmentRibbon.props = {};
-WebEnvironmentRibbon.template = xml`<div class="test-ribbon" />`;
+WebEnvironmentRibbon.template = xml`<div class="test-ribbon" style="display:none"/>`;
 
 registry.category("main_components").add("WebEnvironmentRibbon", {
     Component: WebEnvironmentRibbon,


### PR DESCRIPTION
Since the showRibbon method doesn’t work in KnowledgePortalWebClient and the ribbon always appears empty.
![image](https://github.com/user-attachments/assets/abc73307-0312-46eb-be3f-581c8fc38251)
