### PR TITLE
[16.0][FIX] web_tree_many2one_clickable: Charge assets after list renderer component

### DIFF
--- a/web_tree_many2one_clickable/__manifest__.py
+++ b/web_tree_many2one_clickable/__manifest__.py
@@ -21,12 +21,24 @@
     "data": [],
     "assets": {
         "web.assets_backend": [
-            "web_tree_many2one_clickable/static/src/components/"
-            "many2one_button/many2one_button.esm.js",
-            "web_tree_many2one_clickable/static/src/components/"
-            "many2one_button/many2one_button.scss",
-            "web_tree_many2one_clickable/static/src/components/"
-            "many2one_button/many2one_button.xml",
+            (
+                "after",
+                "web/static/src/views/list/list_renderer.js",
+                "web_tree_many2one_clickable/static/src/components"
+                "/many2one_button/many2one_button.esm.js",
+            ),
+            (
+                "after",
+                "web/static/src/views/list/list_renderer.xml",
+                "web_tree_many2one_clickable/static/src/components"
+                "/many2one_button/many2one_button.xml",
+            ),
+            (
+                "after",
+                "web/static/src/views/list/list_renderer.scss",
+                "web_tree_many2one_clickable/static/src/components"
+                "/many2one_button/many2one_button.scss",
+            ),
         ]
     },
 }

--- a/web_tree_many2one_clickable/static/description/index.html
+++ b/web_tree_many2one_clickable/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -434,7 +434,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Before these changes, if a module with many2one fields was loaded before this one, an error occurred saying that the TreeMany2oneClickableButton component could not be found.

To reproduce the error: Install dms and web_tree_many2one_clickable, go to Documents > Files, switch to tree view, and display the Directory field.

By forcing the assets to load right after the web module, we prevent the other module from loading first, thus avoiding this error.

cc @Tecnativa TT55813

ping @pedrobaeza @victoralmau 