### PR TITLE
[18.0] web_pivot_computed_measure: run tests when item is visible

### DIFF
--- a/web_pivot_computed_measure/static/src/test/test.esm.js
+++ b/web_pivot_computed_measure/static/src/test/test.esm.js
@@ -12,7 +12,7 @@ registry.category("web_tour.tours").add("web_pivot_computed_measure_tour", {
         },
         {
             trigger:
-                '.o_app[data-menu-xmlid="web_pivot_computed_measure.demo_menu_res_partner_report_pivot"]',
+                '.o_app[data-menu-xmlid="web_pivot_computed_measure.demo_menu_res_partner_report_pivot"]:visible',
             run: "click",
         },
         {


### PR DESCRIPTION
while running tests here I get filure in OCA bot or odoo bot or them both :)

2025-04-17 13:31:05,481 280 INFO odoo odoo.addons.web_pivot_computed_measure.tests.test_ui_pivot.TestUIPivot.test_ui.browser: console.groupEnd 
2025-04-17 13:31:05,483 280 ERROR odoo odoo.addons.web_pivot_computed_measure.tests.test_ui_pivot.TestUIPivot.test_ui.browser: FAILED: [2/16] Tour web_pivot_computed_measure_tour → Step .o_app[data-menu-xmlid="web_pivot_computed_measure.demo_menu_res_partner_report_pivot"].
Element has been found.
BUT: Element is not visible. TIP: You can use :not(:visible) to force the search for an invisible element.
T
