### PR TITLE
[18.0][IMP] web_pivot_computed_measure: increate test tour delay time

### DIFF
--- a/web_pivot_computed_measure/tests/test_ui_pivot.py
+++ b/web_pivot_computed_measure/tests/test_ui_pivot.py
@@ -17,5 +17,5 @@ class TestUIPivot(common.HttpCase):
             "/odoo",
             "web_pivot_computed_measure_tour",
             login="admin",
-            step_delay=100,
+            step_delay=1000,
         )


### PR DESCRIPTION
Trying to increase time as the pivot can be seen and triggered and sometimes not in test bots of OCA and odoo

Having timeout > 100 is essential as from what I experienced testing bot can be exhaused or busy and fail with this module test.