### PR TITLE
[IMP] web_group_expand: Enable full group expansion on page.

### DIFF
--- a/web_group_expand/static/src/js/list_controller.esm.js
+++ b/web_group_expand/static/src/js/list_controller.esm.js
@@ -12,7 +12,9 @@ patch(ListController.prototype, {
         // We expand layer by layer. So first we need to find the highest
         // layer that's not already fully expanded.
         let layer = this.model.root.groups;
+        let max_length = 0;
         while (layer.length) {
+            max_length = Math.max(max_length, layer.length);
             const closed = layer.filter(function (group) {
                 return group._config.isFolded;
             });
@@ -30,7 +32,13 @@ patch(ListController.prototype, {
                 })
             );
         }
+        // Save the default value of MAX_NUMBER_OPENED_GROUPS to restore it later
+        const default_max_opened = this.model.constructor.MAX_NUMBER_OPENED_GROUPS;
+        // Set in MAX_NUMBER_OPENED_GROUPS the maximum number of groups that can be opened
+        this.model.constructor.MAX_NUMBER_OPENED_GROUPS = max_length;
         await this.model.root.load();
+        // Restore the default value of MAX_NUMBER_OPENED_GROUPS
+        this.model.constructor.MAX_NUMBER_OPENED_GROUPS = default_max_opened;
         this.model.notify();
     },
 
@@ -38,7 +46,9 @@ patch(ListController.prototype, {
         // We collapse layer by layer. So first we need to find the deepest
         // layer that's not already fully collapsed.
         let layer = this.model.root.groups;
+        let max_length = 0;
         while (layer.length) {
+            max_length = Math.max(max_length, layer.length);
             const next = flatten(
                 layer.map(function (group) {
                     return group.list.groups || [];
@@ -55,7 +65,13 @@ patch(ListController.prototype, {
             }
             layer = next;
         }
+        // Save the default value of MAX_NUMBER_OPENED_GROUPS to restore it later
+        const default_max_opened = this.model.constructor.MAX_NUMBER_OPENED_GROUPS;
+        // Set in MAX_NUMBER_OPENED_GROUPS the maximum number of groups that can be opened
+        this.model.constructor.MAX_NUMBER_OPENED_GROUPS = max_length;
         await this.model.root.load();
+        // Restore the default value of MAX_NUMBER_OPENED_GROUPS
+        this.model.constructor.MAX_NUMBER_OPENED_GROUPS = default_max_opened;
         this.model.notify();
     },
 });


### PR DESCRIPTION
Current behavior: Only the first 10 are expanded after clicking on the expand button
![image](https://github.com/user-attachments/assets/396deaf9-8e1b-49a2-9378-c8f5ed967afd)
 
Expected behavior: all the groups in the view are expanded:

When clicking the expand all button, and the method `load` is call for the model, Odoo set to unfolded only the first 10.
https://github.com/odoo/odoo/blob/0147c40ad1e3b49d8d74d6c98c4376385a80ef33/addons/web/static/src/model/relational_model/relational_model.js#L458

With this change, the limit is intended to be the number of groups to expand.