### PR TITLE
[17.0][FIX] web_timeline: Enable XSS filtering with whitelist for safer HTML rendering

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -195,7 +195,17 @@ export class TimelineRenderer extends Component {
             // Delete an item by tapping the delete button top right
             this.options.editable.remove = true;
         }
-        this.options.xss = {disabled: true};
+        // Configure XSS filtering options to mitigate potential security risks.
+        // Disabling XSS filtering can lead to vulnerabilities, as highlighted in:
+        // - CVE-2020-28487 (https://www.cve.org/CVERecord?id=CVE-2020-28487)
+        // - https://github.com/visjs/vis-timeline/pull/840
+        // The solution is to define a whitelist of allowed HTML elements and attributes.
+        // TODO: Check if this can be removed when this PR is merged: https://github.com/visjs/vis-timeline/pull/1860
+        this.options.xss = {
+            filterOptions: {
+                whiteList: this.getXSSWhiteList(),
+            },
+        };
         this.timeline = new vis.Timeline(this.canvasRef.el, {}, this.options);
         this.timeline.on("click", this.on_timeline_click.bind(this));
         if (!this.options.onUpdate) {
@@ -209,6 +219,23 @@ export class TimelineRenderer extends Component {
             this.draw_canvas();
             this.load_initial_data();
         });
+    }
+    /**
+     * Returns the XSS whitelist for the timeline library.
+     * This is used to filter out potentially harmful HTML elements and attributes.
+     * The white list allows only specific elements and attributes to be rendered.
+     * This is important for security reasons, as it helps prevent XSS attacks.
+     * @returns {Object} The XSS white list.
+     * Key: element name; value: array of allowed attributes.
+     */
+    getXSSWhiteList() {
+        // Add more elements to the whitelist as needed.
+        return {
+            div: ["class", "style"],
+            span: ["class", "name"],
+            small: ["class", "name"],
+            img: ["src", "width", "height", "alt", "loading", "class"],
+        };
     }
 
     /**


### PR DESCRIPTION
Before this commit, XSS filtering was disabled, which could introduce potential security risks. This commit adopts a safer approach, similar to PR https://github.com/OCA/web/pull/2525. After this commit, XSS filtering is re-enabled, and a whitelist of allowed HTML elements is provided.

This change can be tested with the `project_timeline_hr_timesheet` module, which adds custom classes. The elements are rendered correctly, and no more console warnings appear.

![image](https://github.com/user-attachments/assets/42f9e4b8-9ab8-40db-a49d-6da5b833eff3)

TT56064
@Tecnativa @pedrobaeza @CarlosRoca13 @JasminSForgeFlow could you please review this?