### PR TITLE
[17.0][FIX]: web_widget_x2many_2d_matrix: limit options values to x2many fields.

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -144,6 +144,11 @@ export class X2Many2DMatrixRenderer extends Component {
         );
     }
 
+    // More options can be included in the future, here are only added the ones tested initially.
+    _canOptions() {
+        return ["many2one"].includes(this.list.fields[this.matrixFields.value].type);
+    }
+
     getValueFieldProps(column, row) {
         const x = this.columns.findIndex((c) => c.value === column);
         const y = this.rows.findIndex((r) => r.value === row);
@@ -163,11 +168,13 @@ export class X2Many2DMatrixRenderer extends Component {
             readonly: this.props.readonly,
             record: record,
             name: this.matrixFields.value,
-            canCreate: this.props.canCreate,
-            canOpen: this.props.canOpen,
-            canWrite: this.props.canWrite,
-            canQuickCreate: this.props.canQuickCreate,
-            canCreateEdit: this.props.canCreateEdit,
+            ...(this._canOptions() && {
+                canCreate: this.props.canCreate,
+                canOpen: this.props.canOpen,
+                canWrite: this.props.canWrite,
+                canQuickCreate: this.props.canQuickCreate,
+                canCreateEdit: this.props.canCreateEdit,
+            }),
         };
         const domain = record.fields[this.matrixFields.value].domain;
         if (domain) {


### PR DESCRIPTION
Created from issue: https://github.com/OCA/web/issues/3167

@SodexisTeam @BT-mlopez 