### PR TITLE
[18.0][FIX] web_timeline: avoid sorting by many2many fields

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -60,11 +60,19 @@ export class TimelineModel extends Model {
         }
         let fields = this.params.fieldNames;
         fields = [...new Set(fields.concat(this.last_group_bys))];
+        // Avoid ordering by many2many fields
+        // because it is not supported by Odoo
+        // In the module sale_timesheet_timeline, it is used
+        // with default_group_by = task_user_ids
+        let field_to_order = this.params.default_group_by;
+        if (this.fields[field_to_order].type === "many2many") {
+            field_to_order = undefined;
+        }
         this.data = await this.keepLast.add(
             this.orm.call(this.model_name, "search_read", [], {
                 fields: fields,
                 domain: searchParams.domain,
-                order: this.params.default_group_by,
+                order: field_to_order,
                 context: searchParams.context,
             })
         );


### PR DESCRIPTION
When trying to order by a field of type many2many, Odoo up to version 17 does not raise an error, it only displays a warning in the log (e.g. in the module sale_timesheet_timeline when grouping by task_user_ids): WARNING sale_timesheet_timeline odoo.models: Model 'sale.order.line' cannot be sorted on field 'task_user_ids' (not a column). But starting from Odoo 18, this warning is now raised as an exception, so it becomes impossible to group by an m2m field because this module tries to order by the same field as default_group_by.

This commit at least prevents the error by avoiding sending the order field to the server in this case, and instead lets the order be taken from the model’s _order attribute.

TT56055

@Tecnativa @pedrobaeza @CarlosRoca13 could you please review this?

Steps to reproduce the issue
On any `timeline` view where the model has a `many2many` field (e.g. `project_timeline` `project.task`), edit the timeline view and set `default_group_by="user_ids"`, refresh the view, and you will get an error.
![image](https://github.com/user-attachments/assets/98b48972-130f-417a-91a3-5858eb3dc715)

![image](https://github.com/user-attachments/assets/c37ec3c3-e9d5-457b-aecd-a085d74ab403)
