### PR TITLE
[17.0] [ADD] web_widget_popover

### DIFF
--- a/web_widget_popover/README.rst
+++ b/web_widget_popover/README.rst
@@ -1,0 +1,1 @@
+# TO BE GENERATED

--- a/web_widget_popover/__manifest__.py
+++ b/web_widget_popover/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Web Widget Popover",
+    "summary": "Render an icon that displays the field content in a popover",
+    "version": "17.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/web",
+    "license": "AGPL-3",
+    "category": "Web",
+    "depends": ["web"],
+    "assets": {
+        "web.assets_backend": [
+            "web_widget_popover/static/src/**/*.js",
+            "web_widget_popover/static/src/**/*.xml",
+        ],
+    },
+}

--- a/web_widget_popover/pyproject.toml
+++ b/web_widget_popover/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/web_widget_popover/readme/CONTRIBUTORS.md
+++ b/web_widget_popover/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Iván Todorovich \<<ivan.todorovich@gmail.com>\>

--- a/web_widget_popover/readme/DESCRIPTION.md
+++ b/web_widget_popover/readme/DESCRIPTION.md
@@ -1,0 +1,1 @@
+The field will be rendered as a simple icon, that when hovered will display the field content as a tooltip.

--- a/web_widget_popover/readme/USAGE.md
+++ b/web_widget_popover/readme/USAGE.md
@@ -1,0 +1,11 @@
+Use the `popover` widget on `Char` or `Text` fields.
+
+```xml
+<field
+    name="warning_message"
+    widget="popover"
+    icon="fa-warning"
+    class="text-danger"
+    nolabel="1"
+/>
+```

--- a/web_widget_popover/static/src/popover.esm.js
+++ b/web_widget_popover/static/src/popover.esm.js
@@ -1,0 +1,42 @@
+/** @odoo-module **/
+
+import {_t} from "@web/core/l10n/translation";
+import {Component} from "@odoo/owl";
+import {registry} from "@web/core/registry";
+import {standardFieldProps} from "@web/views/fields/standard_field_props";
+
+export class IconPopoverField extends Component {
+    static template = "web_widget_popover.IconPopoverField";
+    static props = {
+        ...standardFieldProps,
+        icon: {type: String, optional: true},
+    };
+    static defaultProps = {
+        icon: "fa-info-circle",
+    };
+    get value() {
+        return this.props.record.data[this.props.name] || "";
+    }
+    get tooltipInfo() {
+        return JSON.stringify({message: this.value});
+    }
+}
+
+export const iconPopoverField = {
+    component: IconPopoverField,
+    displayName: _t("Icon Popover"),
+    supportedTypes: ["char", "text"],
+    supportedOptions: [
+        {
+            label: _t("Icon"),
+            name: "icon",
+            type: "string",
+            help: _t("FontAwesome icon to display"),
+        },
+    ],
+    extractProps: ({attrs}) => ({
+        icon: attrs.icon,
+    }),
+};
+
+registry.category("fields").add("popover", iconPopoverField);

--- a/web_widget_popover/static/src/popover.xml
+++ b/web_widget_popover/static/src/popover.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+    <t t-name="web_widget_popover.IconPopoverField">
+        <span
+            t-if="value"
+            t-attf-class="fa {{props.icon}}"
+            t-att-data-tooltip-info='tooltipInfo'
+            data-tooltip-template="web_widget_popover.PopoverTemplate"
+        />
+    </t>
+
+    <t t-name="web_widget_popover.PopoverTemplate">
+        <div class="o-tooltip px-1 py-2">
+            <span style="white-space: pre-wrap;" t-esc="message" />
+        </div>
+    </t>
+
+</templates>


### PR DESCRIPTION
The field will be rendered as a simple icon, that when hovered will display the field content as a tooltip.

Use the `popover` widget on `Char` or `Text` fields.

```xml
<field
    name="warning_message"
    widget="popover"
    icon="fa-warning"
    class="text-danger"
    nolabel="1"
/>
```