### PR TITLE
[16.0][IMP] x2many_2d_matrix: add support of Related fields

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.esm.js
@@ -29,13 +29,21 @@ export class X2Many2DMatrixField extends Component {
 
         const matchingRecords = this.list.records.filter((record) => {
             let recordX = record.data[fields.x];
-            let recordY = record.data[fields.y];
-            if (record.fields[fields.x].type === "many2one") {
+            const xType = record.fields[fields.x].type;
+            if (xType === "many2one") {
                 recordX = recordX[0];
+            } else if (xType === "reference") {
+                recordX = recordX.resId;
             }
-            if (record.fields[fields.y].type === "many2one") {
+
+            let recordY = record.data[fields.y];
+            const yType = record.fields[fields.y].type;
+            if (yType === "many2one") {
                 recordY = recordY[0];
+            } else if (yType === "reference") {
+                recordY = recordY.resId;
             }
+
             return recordX === x && recordY === y;
         });
         if (matchingRecords.length === 1) {

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -24,9 +24,13 @@ export class X2Many2DMatrixRenderer extends Component {
                 value: record.data[this.matrixFields.x],
                 text: record.data[this.matrixFields.x],
             };
-            if (record.fields[this.matrixFields.x].type === "many2one") {
+            const fieldType = record.fields[this.matrixFields.x].type; 
+            if (fieldType === "many2one") {
                 column.text = column.value[1];
                 column.value = column.value[0];
+            } else if (fieldType === "reference") {
+                column.text = column.value.displayName;
+                column.value = column.value.resId;
             }
             if (columns.findIndex((c) => c.value === column.value) !== -1) return;
             columns.push(column);
@@ -41,9 +45,13 @@ export class X2Many2DMatrixRenderer extends Component {
                 value: record.data[this.matrixFields.y],
                 text: record.data[this.matrixFields.y],
             };
-            if (record.fields[this.matrixFields.y].type === "many2one") {
+            const fieldType = record.fields[this.matrixFields.y].type; 
+            if (fieldType === "many2one") {
                 row.text = row.value[1];
                 row.value = row.value[0];
+            } else if (fieldType === "reference") {
+                row.text = row.value.displayName;
+                row.value = row.value.resId;
             }
             if (rows.findIndex((r) => r.value === row.value) !== -1) return;
             rows.push(row);
@@ -53,12 +61,19 @@ export class X2Many2DMatrixRenderer extends Component {
 
     _getPointOfRecord(record) {
         let xValue = record.data[this.matrixFields.x];
-        if (record.fields[this.matrixFields.x].type === "many2one") {
+        const xFieldType = record.fields[this.matrixFields.x].type;
+        if (xFieldType === "many2one") {
             xValue = xValue[0];
+        } else if (xFieldType === "reference") {
+            xValue = xValue.resId;
         }
+
         let yValue = record.data[this.matrixFields.y];
-        if (record.fields[this.matrixFields.y].type === "many2one") {
+        const yFieldType = record.fields[this.matrixFields.y].type;
+        if (yFieldType === "many2one") {
             yValue = yValue[0];
+        } else if (yFieldType === "reference") {
+            yValue = yValue.resId;
         }
 
         const x = this.columns.findIndex((c) => c.value === xValue);


### PR DESCRIPTION
This PR adds the support of pseudo-relational fields type "Reference" to x2many_2d_matrix.
See [Odoo's ORM documentation about Reference fields](https://www.odoo.com/documentation/16.0/developer/reference/backend/orm.html#pseudo-relational-fields).

Quite similarly to Many2one fields, the Reference fields' value and text must be fetched specifically.
This PR simply extends JavaScript conditions to test if fields are Many2one to add another condition to test if fields are Reference. If checked, text and value are retrieved correctly.

Example:

```
if (fieldType === "many2one") {
      column.text = column.value[1];
      column.value = column.value[0];
} else if (fieldType === "reference") {
      column.text = column.value.displayName;
      column.value = column.value.resId;
}
```

Note: this PR is a re-opening of [PR2987](https://github.com/OCA/web/pull/2987) to correct 1 introduced issue with many2one fields.