### PR TITLE
[UPD][14.0] web_widget_x2many_2d_matrix: license to LGPL

### DIFF
--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -14,7 +14,7 @@
         "Odoo Community Association (OCA)"
     ),
     "website": "https://github.com/OCA/web",
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "category": "Hidden/Dependency",
     "summary": "Show list fields as a matrix",
     "depends": ["web"],


### PR DESCRIPTION
Funny, I've been having discussions about this in the board before, and now it happens to me for the first time, that I'm aware of.

Issue I have:

- Customer is using [mrp_production_serial_matrix](https://github.com/OCA/manufacture/tree/14.0/mrp_production_serial_matrix) which depends on this module `web_widget_x2many_2d_matrix`. Because the matrix module was AGPL, all dependencies are, and rightfully should be.
- However, customer is also using Odoo `quality_mrp` module.
- `quality_mrp` does not play well with the matrix, so I need to make a glue module, which I think I'm not allowed to do, because it would depend both on an AGPL module and an Enterprise module, which have incompatible licenses.

Do I have any other choice than this?