### PR TITLE
[18.0][IMP] web_chatter_position: improve form and chatter layout styles

### DIFF
--- a/web_chatter_position/README.rst
+++ b/web_chatter_position/README.rst
@@ -32,6 +32,9 @@ Configurable chatter position from the user preferences.
 
 Supports Both Community & Enterprise Edition.
 
+Extends the functionality of the web client to get full width in the
+form view sheet.
+
 **Table of contents**
 
 .. contents::
@@ -66,19 +69,19 @@ Authors
 Contributors
 ------------
 
-- Hynsys Technologies <hynsystechnologies@gmail.com>
-- Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>
-- `Camptocamp <https://www.camptocamp.com>`__
+-  Hynsys Technologies <hynsystechnologies@gmail.com>
+-  Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>
+-  `Camptocamp <https://www.camptocamp.com>`__
 
-  - Iván Todorovich <ivan.todorovich@camptocamp.com>
+   -  Iván Todorovich <ivan.todorovich@camptocamp.com>
 
-- `Alitec Pte Ltd <http://www.alitec.sg>`__
+-  `Alitec Pte Ltd <http://www.alitec.sg>`__
 
-  - Jay Patel <jay@alitec.sg>
+   -  Jay Patel <jay@alitec.sg>
 
-- Trobz
+-  Trobz
 
-  - Tris Doan <tridm@trobz.com>
+   -  Tris Doan <tridm@trobz.com>
 
 Maintainers
 -----------

--- a/web_chatter_position/readme/DESCRIPTION.md
+++ b/web_chatter_position/readme/DESCRIPTION.md
@@ -1,3 +1,5 @@
 Configurable chatter position from the user preferences.
 
 Supports Both Community & Enterprise Edition.
+
+Extends the functionality of the web client to get full width in the form view sheet.

--- a/web_chatter_position/static/description/index.html
+++ b/web_chatter_position/static/description/index.html
@@ -372,6 +372,8 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/web/tree/18.0/web_chatter_position"><img alt="OCA/web" src="https://img.shields.io/badge/github-OCA%2Fweb-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/web-18-0/web-18-0-web_chatter_position"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/web&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>Configurable chatter position from the user preferences.</p>
 <p>Supports Both Community &amp; Enterprise Edition.</p>
+<p>Extends the functionality of the web client to get full width in the
+form view sheet.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/web_chatter_position/static/src/scss/chatter_form_adjustments.scss
+++ b/web_chatter_position/static/src/scss/chatter_form_adjustments.scss
@@ -1,0 +1,9 @@
+.o_form_view_container {
+    .o_form_sheet_bg .o_form_sheet {
+        max-width: none !important;
+        width: auto !important;
+    }
+    .o-mail-Form-chatter {
+        max-width: none;
+    }
+}


### PR DESCRIPTION
As web_sheet_full_width will be deprecated (see discussion(https://github.com/OCA/web/pull/3180#issuecomment-2930126999)), i moved the layout improvements it provided to web_chatter_position as recommended by @StefanRijnhart.