### PR TITLE
[16.0][FIX] web_responsive: Do not duplicate buttons

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -39,6 +39,7 @@
             "/web_responsive/static/src/components/hotkey/hotkey.xml",
             "/web_responsive/static/src/components/chatter_topbar/chatter_topbar.esm.js",
             "/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml",
+            "/web_responsive/static/src/components/chatter_topbar/chatter_topbar.scss",
             "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.scss",
             "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.esm.js",
             "/web_responsive/static/src/components/attachment_viewer/attachment_viewer.xml",

--- a/web_responsive/static/src/components/chatter_topbar/chatter_topbar.scss
+++ b/web_responsive/static/src/components/chatter_topbar/chatter_topbar.scss
@@ -1,0 +1,12 @@
+/* Copyright 2025 Dixmit
+ * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
+
+.o_ChatterTopbar {
+    .o_ChatterTopbar_buttonSendMessage[small],
+    .o_ChatterTopbar_buttonLogNote[small] {
+        font-size: 0px;
+        i {
+            font-size: 1rem;
+        }
+    }
+}

--- a/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml
+++ b/web_responsive/static/src/components/chatter_topbar/chatter_topbar.xml
@@ -1,92 +1,59 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright 2023 Onestein - Anjeel Haria
+    Copyright 2025 Dixmit
     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 -->
 <templates xml:space="preserve">
-    <!-- Modifying the ChatterTopBar for Mobile View -->
+    <!-- Moving some items from the chatter top bar for the mobile view -->
     <t
         t-name="web.Responsivemail.ChatterTopbar"
         t-inherit="mail.ChatterTopbar"
         owl="1"
         t-inherit-mode="extension"
     >
-        <xpath expr="//div[hasclass('o_ChatterTopbar')]" position="before">
-            <t t-if="ui.isSmall">
-                <div
-                    class="o_ChatterTopbar_rightSection d-flex border-bottom"
-                    style="max-height:45%"
-                    id="mobileChatterTopbar"
-                >
-                    <button
-                        t-if="chatterTopbar.chatter.thread.allAttachments.length === 0"
-                        class="o_ChatterTopbar_button o_ChatterTopbar_buttonAddAttachments btn btn-light btn-primary"
-                        type="button"
-                        t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasWriteAccess"
-                        t-on-click="chatterTopbar.chatter.onClickButtonAddAttachments"
-                        style="width:41%"
-                    >
-                        <i
-                            class="fa fa-paperclip fa-lg me-1"
-                            role="img"
-                            aria-label="Attachments"
-                        />
-                        <t t-if="chatterTopbar.chatter.isShowingAttachmentsLoading">
-                            <i
-                                class="o_ChatterTopbar_buttonAttachmentsCountLoader fa fa-circle-o-notch fa-spin"
-                                aria-label="Attachment counter loading..."
-                            />
-                        </t>
-                    </button>
-                    <button
-                        t-if="chatterTopbar.chatter.thread.allAttachments.length > 0"
-                        class="o_ChatterTopbar_button o_ChatterTopbar_buttonToggleAttachments btn btn-light btn-primary"
-                        type="button"
-                        t-att-disabled="!chatterTopbar.chatter.isTemporary and !chatterTopbar.chatter.hasReadAccess"
-                        t-att-aria-expanded="chatterTopbar.chatter.attachmentBoxView ? 'true' : 'false'"
-                        t-on-click="chatterTopbar.chatter.onClickButtonToggleAttachments"
-                        style="width:41%"
-                    >
-                        <i
-                            class="fa fa-paperclip fa-lg me-1"
-                            role="img"
-                            aria-label="Attachments"
-                        />
-                        <t t-if="!chatterTopbar.chatter.isShowingAttachmentsLoading">
-                            <span
-                                class="o_ChatterTopbar_buttonCount o_ChatterTopbar_buttonAttachmentsCount"
-                                t-esc="chatterTopbar.attachmentButtonText"
-                            />
-                        </t>
-                        <t t-if="chatterTopbar.chatter.isShowingAttachmentsLoading">
-                            <i
-                                class="o_ChatterTopbar_buttonAttachmentsCountLoader fa fa-circle-o-notch fa-spin"
-                                aria-label="Attachment counter loading..."
-                            />
-                        </t>
-                    </button>
-                    <t
-                        t-if="chatterTopbar.chatter.hasFollowers and chatterTopbar.chatter.thread"
-                    >
-                        <FollowerListMenu
-                            className="'o_ChatterTopbar_followerListMenu w-26'"
-                            record="chatterTopbar.chatter.followerListMenuView"
-                        />
-                            <t t-if="chatterTopbar.chatter.followButtonView">
-                                <FollowButton
-                                className="'o_ChatterTopbar_followButton'"
-                                record="chatterTopbar.chatter.followButtonView"
-                            />
-                            </t>
-                    </t>
-                </div>
-            </t>
-        </xpath>
+
         <xpath
-            expr="//div[hasclass('o_ChatterTopbar_rightSection') and not(@id='mobileChatterTopbar')]"
+            expr="//button[hasclass('o_ChatterTopbar_buttonScheduleActivity')]/span  "
             position="attributes"
         >
-            <attribute name="t-if">!ui.isSmall</attribute>
+            <attribute name="t-att-class">{
+                'd-none': ui.isSmall
+            }</attribute>
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonSendMessage')]"
+            position="inside"
+        >
+            <i
+                class="fa fa-paper-plane me-1"
+                role="img"
+                aria-label="Send message"
+                t-if="ui.isSmall"
+            />
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonLogNote')]"
+            position="inside"
+        >
+            <i
+                class="fa fa-sticky-note-o me-1"
+                role="img"
+                aria-label="Log note"
+                t-if="ui.isSmall"
+            />
+        </xpath>
+        <!-- We need to add an attribute to hide the text -->
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonSendMessage')]"
+            position="attributes"
+        >
+            <attribute name="t-att-small">ui.isSmall</attribute>
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonLogNote')]"
+            position="attributes"
+        >
+            <attribute name="t-att-small">ui.isSmall</attribute>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
Duplicating buttons will give problems on other modules that want to add buttons on the chatter

With this change:

![image](https://github.com/user-attachments/assets/f82df286-696a-439a-9dd1-795d75fa6816)
(you can scroll to the right)

Before:

![image](https://github.com/user-attachments/assets/a7dd4f28-b1f1-43cf-af23-dd8982df4d4d)

Before looked better. However, it came with the handicap of removing extensibility of this specific component.