### PR TITLE
[18.0][FIX] web_m2x_options: prevent crash on Many2OneReferenceField

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -105,11 +105,11 @@ create rights)
 To add these parameters go to Configuration -> Technical -> Parameters
 -> System Parameters and add new parameters like:
 
-- web_m2x_options.create: False
-- web_m2x_options.create_edit: False
-- web_m2x_options.limit: 10
-- web_m2x_options.search_more: True
-- web_m2x_options.field_limit_entries: 5
+-  web_m2x_options.create: False
+-  web_m2x_options.create_edit: False
+-  web_m2x_options.limit: 10
+-  web_m2x_options.search_more: True
+-  web_m2x_options.field_limit_entries: 5
 
 Example
 -------
@@ -131,9 +131,10 @@ set on a field ! If nothing works, add a debugger in the first line of
 something in a many2one field, javascript debugger should pause. If not
 verify your installation.
 
-- Instead of making the tags rectangle clickable, I think it's better to
-  put the text as a clickable link, so we will get a consistent
-  behaviour/aspect with other clickable elements (many2one...).
+-  Instead of making the tags rectangle clickable, I think it's better
+   to put the text as a clickable link, so we will get a consistent
+   behaviour/aspect with other clickable elements (many2one...).
+-  Properly support web_m2x_options on Many2OneReferenceField.
 
 Bug Tracker
 ===========
@@ -160,38 +161,42 @@ Authors
 Contributors
 ------------
 
-- David Coninckx <davconinckx@gmail.com>
+-  David Coninckx <davconinckx@gmail.com>
 
-- Emanuel Cino <ecino@compassion.ch>
+-  Emanuel Cino <ecino@compassion.ch>
 
-- Holger Brunn <hbrunn@therp.nl>
+-  Holger Brunn <hbrunn@therp.nl>
 
-- Nicolas JEUDY <nicolas@sudokeys.com>
+-  Nicolas JEUDY <nicolas@sudokeys.com>
 
-- Yannick Vaucher <yannick.vaucher@camptocamp.com>
+-  Yannick Vaucher <yannick.vaucher@camptocamp.com>
 
-- Zakaria Makrelouf <z.makrelouf@gmail.com>
+-  Zakaria Makrelouf <z.makrelouf@gmail.com>
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Jairo Llopis <jairo.llopis@tecnativa.com>
-  - David Vidal <david.vidal@tecnativa.com>
-  - Ernesto Tejeda <ernesto.tejeda87@gmail.com>
-  - Carlos Roca
+   -  Jairo Llopis <jairo.llopis@tecnativa.com>
+   -  David Vidal <david.vidal@tecnativa.com>
+   -  Ernesto Tejeda <ernesto.tejeda87@gmail.com>
+   -  Carlos Roca
 
-- Bhavesh Odedra <bodedra@opensourceintegrators.com>
+-  Bhavesh Odedra <bodedra@opensourceintegrators.com>
 
-- Dhara Solanki <dhara.solanki@initos.com> (http://www.initos.com)
+-  Dhara Solanki <dhara.solanki@initos.com> (http://www.initos.com)
 
-- `Trobz <https://trobz.com>`__:
+-  `Trobz <https://trobz.com>`__:
 
-  - Hoang Diep <hoang@trobz.com>
+   -  Hoang Diep <hoang@trobz.com>
 
-- `Sygel <https://sygel.es>`__:
+-  `Sygel <https://sygel.es>`__:
 
-  - Manuel Regidor <manuel.regidor@sygel.es>
-  - Valentín Vinagre <valentin.vinagre@sygel.es>
-  - Harald Panten <harald.panten@sygel.es>
+   -  Manuel Regidor <manuel.regidor@sygel.es>
+   -  Valentín Vinagre <valentin.vinagre@sygel.es>
+   -  Harald Panten <harald.panten@sygel.es>
+
+-  `ACSONE SA/NV <https://acsone.eu>`__:
+
+   -  Souheil BEJAOUI <souheil.bejaoui@acsone.eu>
 
 Other credits
 -------------

--- a/web_m2x_options/readme/CONTRIBUTORS.md
+++ b/web_m2x_options/readme/CONTRIBUTORS.md
@@ -27,3 +27,6 @@
   - Manuel Regidor \<<manuel.regidor@sygel.es>\>
   - Valentín Vinagre \<<valentin.vinagre@sygel.es>\>
   - Harald Panten \<<harald.panten@sygel.es>\>
+
+- [ACSONE SA/NV](https://acsone.eu):
+  - Souheil BEJAOUI \<<souheil.bejaoui@acsone.eu>\>

--- a/web_m2x_options/readme/ROADMAP.md
+++ b/web_m2x_options/readme/ROADMAP.md
@@ -7,3 +7,4 @@ your installation.
 - Instead of making the tags rectangle clickable, I think it's better to
   put the text as a clickable link, so we will get a consistent
   behaviour/aspect with other clickable elements (many2one...).
+- Properly support web_m2x_options on Many2OneReferenceField.

--- a/web_m2x_options/static/description/index.html
+++ b/web_m2x_options/static/description/index.html
@@ -472,9 +472,10 @@ set on a field ! If nothing works, add a debugger in the first line of
 something in a many2one field, javascript debugger should pause. If not
 verify your installation.</p>
 <ul class="simple">
-<li>Instead of making the tags rectangle clickable, I think it’s better to
-put the text as a clickable link, so we will get a consistent
+<li>Instead of making the tags rectangle clickable, I think it’s better
+to put the text as a clickable link, so we will get a consistent
 behaviour/aspect with other clickable elements (many2one…).</li>
+<li>Properly support web_m2x_options on Many2OneReferenceField.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
@@ -523,6 +524,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
 <li>Valentín Vinagre &lt;<a class="reference external" href="mailto:valentin.vinagre&#64;sygel.es">valentin.vinagre&#64;sygel.es</a>&gt;</li>
 <li>Harald Panten &lt;<a class="reference external" href="mailto:harald.panten&#64;sygel.es">harald.panten&#64;sygel.es</a>&gt;</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://acsone.eu">ACSONE SA/NV</a>:<ul>
+<li>Souheil BEJAOUI &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -3,6 +3,7 @@ import {
     Many2XAutocomplete,
 } from "@web/views/fields/relational_utils";
 import {Many2OneField, many2OneField} from "@web/views/fields/many2one/many2one_field";
+import {Many2OneReferenceField} from "@web/views/fields/many2one_reference/many2one_reference_field";
 import {FormController} from "@web/views/form/form_controller";
 import {evaluateBooleanExpr} from "@web/core/py_js/py";
 import {fieldColorProps} from "../views/fields/standard_field_props.esm";
@@ -113,6 +114,16 @@ patch(many2OneField, {
             dynamicInfo
         );
         return this.m2o_options_props(props, attrs, options);
+    },
+});
+
+// FIXME: Many2OneReferenceField does not support m2o_options_props.
+// This no-op prevents crashes, but proper option support is still missing.
+// See roadmap note in PR #3191
+patch(Many2OneReferenceField, {
+    // eslint-disable-next-line no-unused-vars
+    m2o_options_props(props, attrs, options) {
+        return props;
     },
 });
 


### PR DESCRIPTION
`Many2OneReferenceField` inherits the props definition from `Many2OneField` but does not inherit the prototype methods added via `patch` on `many2OneField`, including `m2o_options_props`

without this patch, calling `extractProps` on `Many2OneReferenceField` leads to `"this.m2o_options_props is not a function"` errors because this method is undefined

this fix adds a no-op `m2o_options_props` implementation on `Many2OneReferenceField` to ensure compatibility and safely bypass the `m2o_options_props` logic since it's not relevant for reference fields

to reproduce this bug, open any view with many2one reference field, example attachment form view

![image](https://github.com/user-attachments/assets/a3edf34f-3aef-4ff4-97df-c4c3e3b07753)
