### PR TITLE
[16.0][FIX] web_widget_x2many_2d_matrix

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -144,6 +144,9 @@ export class X2Many2DMatrixRenderer extends Component {
             record = this.matrix[y][x].records[0];
             value = this.matrix[y][x].value;
         }
+        if (!record) {
+            return false;
+        }
         if (this.list.fields[this.matrixFields.value].type === "boolean") {
             record.bypass_readonly = true;
         }

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.xml
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.xml
@@ -26,9 +26,12 @@
                     </td>
                     <td t-foreach="columns" t-as="column" t-key="column.value">
                         <t
-                            t-component="ValueFieldComponent"
-                            t-props="getValueFieldProps(column.value, row.value)"
+                            t-set="value"
+                            t-value="getValueFieldProps(column.value, row.value)"
                         />
+                        <t t-if="value">
+                            <t t-component="ValueFieldComponent" t-props="value" />
+                        </t>
                     </td>
                     <td
                         t-if="props.showRowTotals and _canAggregate()"

--- a/web_widget_x2many_2d_matrix/static/src/views/fields/boolean/boolean_field.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/views/fields/boolean/boolean_field.esm.js
@@ -5,7 +5,7 @@ import {BooleanField} from "@web/views/fields/boolean/boolean_field";
 
 patch(BooleanField.prototype, "web_widget_x2many_2d_matrix", {
     get isReadonly() {
-        if (this.props.record.bypass_readonly) {
+        if (this.props.record && this.props.record.bypass_readonly) {
             return false;
         }
         return this._super(...arguments);


### PR DESCRIPTION
When delete an attribute value in the attributes and when trying to access the attribute rules the following error appears:

![image](https://github.com/user-attachments/assets/6839145e-7c9c-405d-8149-c2435de6a48a)
