### PR TITLE
[18.0][FIX] web_widget_x2many_2d_matrix: don't break non-many2one value fields

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.31
+_commit: v1.32
 _src_path: git+https://github.com/OCA/oca-addons-repo-template
 additional_ruff_rules: []
 ci: GitHub

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -194,7 +194,7 @@ const config = [{
     },
 
 }, {
-    files: ["**/*.esm.js"],
+    files: ["**/*.esm.js", "**/*test.js"],
 
     languageOptions: {
         ecmaVersion: 2024,

--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -36,5 +36,8 @@
             "web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/"
             "x2many_2d_matrix_field.scss",
         ],
+        "web.assets_unit_tests": [
+            "web_widget_x2many_2d_matrix/static/tests/*",
+        ],
     },
 }

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -142,11 +142,6 @@ export class X2Many2DMatrixRenderer extends Component {
         );
     }
 
-    // More options can be included in the future, here are only added the ones tested initially.
-    _canOptions() {
-        return ["many2one"].includes(this.list.fields[this.matrixFields.value].type);
-    }
-
     getValueFieldProps(column, row) {
         const x = this.columns.findIndex((c) => c.value === column);
         const y = this.rows.findIndex((r) => r.value === row);
@@ -171,22 +166,26 @@ export class X2Many2DMatrixRenderer extends Component {
             canWrite: this.props.canWrite,
             canQuickCreate: this.props.canQuickCreate,
             canCreateEdit: this.props.canCreateEdit,
-            ...(this._canOptions() && {
-                canCreate: this.props.canCreate,
-                canOpen: this.props.canOpen,
-                canWrite: this.props.canWrite,
-                canQuickCreate: this.props.canQuickCreate,
-                canCreateEdit: this.props.canCreateEdit,
-            }),
         };
         const domain = record.fields[this.matrixFields.value].domain;
-        if ((Array.isArray(value) || typeof value === "string") && domain.length) {
+        if (
+            domain &&
+            (Array.isArray(value) || typeof value === "string") &&
+            domain.length
+        ) {
             result.domain = new Domain(
                 evaluateExpr(domain, record.evalContext)
             ).toList();
         }
         if (value === null) {
             result.readonly = true;
+        }
+        // Remove all props the field value component doesn't define
+        const valid_props = this._getValueFieldComponent().props;
+        for (const prop in result) {
+            if (!(prop in valid_props)) {
+                delete result[prop];
+            }
         }
         return result;
     }

--- a/web_widget_x2many_2d_matrix/static/tests/web_widget_x2many_2d_matrix.test.js
+++ b/web_widget_x2many_2d_matrix/static/tests/web_widget_x2many_2d_matrix.test.js
@@ -1,0 +1,69 @@
+import {defineModels, fields, models, mountView} from "@web/../tests/web_test_helpers";
+import {expect, test} from "@odoo/hoot";
+
+class Main extends models.Model {
+    line_ids = fields.One2many({
+        string: "Matrix",
+        relation: "line",
+        relation_field: "main_id",
+    });
+
+    _records = [{id: 1, line_ids: [1, 2, 3, 4]}];
+}
+class Line extends models.Model {
+    main_id = fields.Many2one({
+        relation: "main",
+    });
+    x = fields.Integer({});
+    y = fields.Integer({});
+    value_float = fields.Float({});
+    value_char = fields.Char({});
+
+    _records = [
+        {id: 1, main_id: 1, x: 0, y: 0, value_float: 42, value_char: "0/0"},
+        {id: 2, main_id: 1, x: 0, y: 1, value_float: 42, value_char: "0/1"},
+        {id: 3, main_id: 1, x: 1, y: 0, value_float: 42, value_char: "1/0"},
+        {id: 4, main_id: 1, x: 1, y: 1, value_float: 42, value_char: "1/1"},
+    ];
+}
+defineModels([Line, Main]);
+
+test("matrix displaying float fields are rendered correctly", async () => {
+    await mountView({
+        type: "form",
+        resModel: "main",
+        resId: 1,
+        arch: `
+        <form>
+            <field name="line_ids" widget="x2many_2d_matrix" field_x_axis="x" field_y_axis="y" field_value="value_float">
+                <list>
+                    <field name="x" />
+                    <field name="y" />
+                    <field name="value_float" />
+                </list>
+            </field>
+        </form>`,
+    });
+    expect(".o_field_widget input").toHaveCount(4);
+    expect(".col-total").toHaveText("168.00");
+});
+
+test("matrix displaying char fields are rendered correctly", async () => {
+    await mountView({
+        type: "form",
+        resModel: "main",
+        resId: 1,
+        arch: `
+        <form>
+            <field name="line_ids" widget="x2many_2d_matrix" field_x_axis="x" field_y_axis="y" field_value="value_char">
+                <list>
+                    <field name="x" />
+                    <field name="y" />
+                    <field name="value_char" />
+                </list>
+            </field>
+        </form>`,
+    });
+    expect(".o_field_widget input").toHaveCount(4);
+    expect(".col-total").toHaveCount(0);
+});

--- a/web_widget_x2many_2d_matrix/tests/__init__.py
+++ b/web_widget_x2many_2d_matrix/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_web_widget_x2many_2d_matrix

--- a/web_widget_x2many_2d_matrix/tests/test_web_widget_x2many_2d_matrix.py
+++ b/web_widget_x2many_2d_matrix/tests/test_web_widget_x2many_2d_matrix.py
@@ -1,0 +1,15 @@
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestWebWidgetX2Many2DMatrix(HttpCase):
+    def test_js(self):
+        self.browser_js(
+            "/web/tests?headless&loglevel=2&preset=desktop&timeout=15000&suite=e1a9aaa1",
+            "",
+            "",
+            login="admin",
+            timeout=1800,
+            success_signal="[HOOT] test suite succeeded",
+            error_checker=lambda x: "[HOOT]" not in x,
+        )


### PR DESCRIPTION
https://github.com/OCA/web/pull/3200 doesn't actually fix the problem, and also doesn't address breaking when the value field is of type char.

Added tests to avoid this kind of embarrassing regressions in the future.