### PR TITLE
[17.0][FIX] web_m2x_options: prevent crash on Many2OneReferenceField

### DIFF
--- a/web_m2x_options/README.rst
+++ b/web_m2x_options/README.rst
@@ -147,6 +147,8 @@ verify your installation.
 -  Instead of making the tags rectangle clickable, I think it's better
    to put the text as a clickable link, so we will get a consistent
    behaviour/aspect with other clickable elements (many2one...).
+-  Properly support web_m2x_options on field with type ===
+   "many2one_reference".
 
 Bug Tracker
 ===========

--- a/web_m2x_options/readme/ROADMAP.md
+++ b/web_m2x_options/readme/ROADMAP.md
@@ -7,3 +7,4 @@ your installation.
 - Instead of making the tags rectangle clickable, I think it's better to
   put the text as a clickable link, so we will get a consistent
   behaviour/aspect with other clickable elements (many2one...).
+- Properly support web_m2x_options on field with type === "many2one_reference".

--- a/web_m2x_options/static/description/index.html
+++ b/web_m2x_options/static/description/index.html
@@ -485,6 +485,8 @@ verify your installation.</p>
 <li>Instead of making the tags rectangle clickable, I think it’s better
 to put the text as a clickable link, so we will get a consistent
 behaviour/aspect with other clickable elements (many2one…).</li>
+<li>Properly support web_m2x_options on field with type ===
+“many2one_reference”.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -176,6 +176,12 @@ patch(many2OneField, {
             {attrs, context, decorations, options, string},
             dynamicInfo
         );
+        // FIXME: field of type === "many2one_reference" does not support m2o_options_props.
+        // This no-op prevents crashes, but proper option support is still missing.
+        // See roadmap note in PR #3205
+        if (!this.m2m_options_props) {
+            return props;
+        }
         const new_props = this.m2o_options_props(props, attrs, options);
         return new_props;
     },


### PR DESCRIPTION
without this patch, calling extractProps on `Many2OneField` with type "many2one_reference" to "this.m2o_options_props is not a function" errors because this method is undefined

this fix adds a no-op m2o_options_props implementation on `Many2OneField` with type "many2one_reference" to ensure compatibility and safely bypass the m2o_options_props logic since it's not relevant for reference fields

to reproduce this bug, open any view with many2one reference field, example automation rule form view with a "**Vallues Updated**"-trigger
![image](https://github.com/user-attachments/assets/4fca635e-c7ce-4699-9430-0e38c2d0fd86)
