### PR TITLE
[18.0][FIX] web_session_auto_close: Increase default timeout

### DIFF
--- a/web_session_auto_close/controllers/main.py
+++ b/web_session_auto_close/controllers/main.py
@@ -11,6 +11,6 @@ class WebSessionAutoCloseController(http.Controller):
         timeout_sec = (
             request.env["ir.config_parameter"]
             .sudo()
-            .get_param("web_session_auto_close.timeout", 15)
+            .get_param("web_session_auto_close.timeout", 600)
         )
         return int(timeout_sec) * 1000

--- a/web_session_auto_close/models/res_config_settings.py
+++ b/web_session_auto_close/models/res_config_settings.py
@@ -10,5 +10,5 @@ class ResConfigSettings(models.TransientModel):
     session_auto_close_timeout = fields.Integer(
         string="Session Auto-Close Timeout (seconds)",
         config_parameter="web_session_auto_close.timeout",
-        default=15,
+        default=600,
     )

--- a/web_session_auto_close/static/src/js/session_auto_close.esm.js
+++ b/web_session_auto_close/static/src/js/session_auto_close.esm.js
@@ -7,7 +7,7 @@ import {rpc} from "@web/core/network/rpc";
 import {session} from "@web/session";
 
 // Default session timeout in ms (will be updated from server settings)
-let SESSION_TIMEOUT = 15000;
+let SESSION_TIMEOUT = 600000;
 
 /**
  * Get the last recorded user activity timestamp from localStorage


### PR DESCRIPTION
The previous time was ridiculously small, affecting also any test on runboat where it's installed by default, but also not being a real case for anyone having to start session again after 15 seconds of inactivity.

Let's adjust it to a more reasonable 10 minutes delay.

@Tecnativa 