### PR TITLE
[18.0][FIX] web_m2x_options: Handle undefined m2m_options_props in many2one_reference

### DIFF
--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -112,6 +112,9 @@ patch(many2OneField, {
             {attrs, context, decorations, options, string},
             dynamicInfo
         );
+        if (!this.m2m_options_props) {
+            return props;
+        }
         return this.m2o_options_props(props, attrs, options);
     },
 });


### PR DESCRIPTION
inspired by: https://github.com/OCA/web/pull/3205#pullrequestreview-2983192860

Messages cannot be opened in Odoo 18. Same error like PR above.
![image](https://github.com/user-attachments/assets/39f0c006-d70c-43db-a53e-260c6c8d8405)
