### PR TITLE
[17.0][FIX] web_widget_x2many_2d_matrix: restore pre-v16 functionality

### DIFF
--- a/web_widget_x2many_2d_matrix/README.rst
+++ b/web_widget_x2many_2d_matrix/README.rst
@@ -95,6 +95,12 @@ want to calculate row totals. True by default
 show_column_totals If field_value is a numeric field, it indicates if
 you want to calculate column totals. True by default
 
+x_axis_clickable If the x axis field is a many2one field, render the
+values as links to the record in question
+
+y_axis_clickable If the y axis field is a many2one field, render the
+values as links to the record in question
+
 For the value field, you can set any attributes you'd set in a normal
 list view, ie if your value field is a many2one field and you want to
 disable creating records via this field, you'd write

--- a/web_widget_x2many_2d_matrix/README.rst
+++ b/web_widget_x2many_2d_matrix/README.rst
@@ -215,6 +215,7 @@ Credits
 Authors
 -------
 
+* Hunki Enterprises BV
 * Therp BV
 * Tecnativa
 * Camptocamp
@@ -224,7 +225,7 @@ Authors
 Contributors
 ------------
 
--  Holger Brunn <hbrunn@therp.nl>
+-  Holger Brunn <mail@hunki-enterprises.com>
 -  Pedro M. Baeza <pedro.baeza@tecnativa.com>
 -  Artem Kostyuk <a.kostyuk@mobilunity.com>
 -  Simone Orsi <simone.orsi@camptocamp.com>
@@ -256,10 +257,13 @@ promote its widespread use.
 .. |maintainer-JasminSForgeFlow| image:: https://github.com/JasminSForgeFlow.png?size=40px
     :target: https://github.com/JasminSForgeFlow
     :alt: JasminSForgeFlow
+.. |maintainer-hbrunn| image:: https://github.com/hbrunn.png?size=40px
+    :target: https://github.com/hbrunn
+    :alt: hbrunn
 
-Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-JasminSForgeFlow| 
+|maintainer-JasminSForgeFlow| |maintainer-hbrunn| 
 
 This module is part of the `OCA/web <https://github.com/OCA/web/tree/17.0/web_widget_x2many_2d_matrix>`_ project on GitHub.
 

--- a/web_widget_x2many_2d_matrix/README.rst
+++ b/web_widget_x2many_2d_matrix/README.rst
@@ -95,6 +95,23 @@ want to calculate row totals. True by default
 show_column_totals If field_value is a numeric field, it indicates if
 you want to calculate column totals. True by default
 
+For the value field, you can set any attributes you'd set in a normal
+list view, ie if your value field is a many2one field and you want to
+disable creating records via this field, you'd write
+
+.. code:: xml
+
+   <field name="my_field3" options="{'no_create': true}"/>
+
+or if you want to have a custom domain or context
+
+.. code:: xml
+
+   <field name="my_field3" domain="[('some_field', '=', my_field1)]" context="{'default_some_field': my_field1}" />
+
+Note that to be able to refer to other fields than the ones used as
+coordinates or value, you have to add them inside the ``list`` node.
+
 Example
 -------
 
@@ -153,18 +170,13 @@ Now in our wizard, we can use:
 Known issues / Roadmap
 ======================
 
-- Support extra attributes on each field cell via field_extra_attrs
-  param. We could set a cell as not editable, required or readonly for
-  instance. The readonly case will also give the ability to click on m2o
-  to open related records.
-- Support limit total records in the matrix. Ref:
-  https://github.com/OCA/web/issues/901
-- Support cell traversal through keyboard arrows.
-- Entering the widget from behind by pressing ``Shift+TAB`` in your
-  keyboard will enter into the 1st cell until
-  https://github.com/odoo/odoo/pull/26490 is merged.
-- Support extra invisible fields inside each cell.
-- Support kanban mode. Current behaviour forces list mode.
+-  Support limit total records in the matrix. Ref:
+   https://github.com/OCA/web/issues/901
+-  Support cell traversal through keyboard arrows.
+-  Entering the widget from behind by pressing ``Shift+TAB`` in your
+   keyboard will enter into the 1st cell until
+   https://github.com/odoo/odoo/pull/26490 is merged.
+-  Support kanban mode. Current behaviour forces list mode.
 
 Changelog
 =========
@@ -172,14 +184,14 @@ Changelog
 12.0.1.0.1 (2018-12-07)
 -----------------------
 
-- [FIX] Cells are unable to render property.
-  (`#1126 <https://github.com/OCA/web/issues/1126>`__)
+-  [FIX] Cells are unable to render property.
+   (`#1126 <https://github.com/OCA/web/issues/1126>`__)
 
 12.0.1.0.0 (2018-11-20)
 -----------------------
 
-- [12.0][MIG] web_widget_x2many_2d_matrix
-  (`#1101 <https://github.com/OCA/web/issues/1101>`__)
+-  [12.0][MIG] web_widget_x2many_2d_matrix
+   (`#1101 <https://github.com/OCA/web/issues/1101>`__)
 
 Bug Tracker
 ===========
@@ -206,21 +218,21 @@ Authors
 Contributors
 ------------
 
-- Holger Brunn <hbrunn@therp.nl>
-- Pedro M. Baeza <pedro.baeza@tecnativa.com>
-- Artem Kostyuk <a.kostyuk@mobilunity.com>
-- Simone Orsi <simone.orsi@camptocamp.com>
-- Timon Tschanz <timon.tschanz@camptocamp.com>
-- Jairo Llopis <jairo.llopis@tecnativa.com>
-- Dennis Sluijk <d.sluijk@onestein.nl>
-- `CorporateHub <https://corporatehub.eu/>`__
+-  Holger Brunn <hbrunn@therp.nl>
+-  Pedro M. Baeza <pedro.baeza@tecnativa.com>
+-  Artem Kostyuk <a.kostyuk@mobilunity.com>
+-  Simone Orsi <simone.orsi@camptocamp.com>
+-  Timon Tschanz <timon.tschanz@camptocamp.com>
+-  Jairo Llopis <jairo.llopis@tecnativa.com>
+-  Dennis Sluijk <d.sluijk@onestein.nl>
+-  `CorporateHub <https://corporatehub.eu/>`__
 
-  - Alexey Pelykh <alexey.pelykh@corphub.eu>
+   -  Alexey Pelykh <alexey.pelykh@corphub.eu>
 
-- Adrià Gil Sorribes <adria.gil@forgeflow.com>
-- Christopher Ormaza <chris.ormaza@forgeflow.com>
-- SodexisTeam <dev@sodexis.com>
-- Jasmin Solanki <jasmin.solanki@forgeflow.com>
+-  Adrià Gil Sorribes <adria.gil@forgeflow.com>
+-  Christopher Ormaza <chris.ormaza@forgeflow.com>
+-  SodexisTeam <dev@sodexis.com>
+-  Jasmin Solanki <jasmin.solanki@forgeflow.com>
 
 Maintainers
 -----------

--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -22,7 +22,9 @@
     "category": "Hidden/Dependency",
     "summary": "Show list fields as a matrix",
     "depends": ["web"],
-    "data": [],
+    "demo": [
+        "demo/res_groups_views.xml",
+    ],
     "installable": True,
     "assets": {
         "web.assets_backend": [

--- a/web_widget_x2many_2d_matrix/__manifest__.py
+++ b/web_widget_x2many_2d_matrix/__manifest__.py
@@ -6,9 +6,10 @@
 {
     "name": "2D matrix for x2many fields",
     "version": "17.0.1.1.2",
-    "maintainers": ["JasminSForgeFlow"],
+    "maintainers": ["JasminSForgeFlow", "hbrunn"],
     "development_status": "Production/Stable",
     "author": (
+        "Hunki Enterprises BV, "
         "Therp BV, "
         "Tecnativa, "
         "Camptocamp, "

--- a/web_widget_x2many_2d_matrix/demo/res_groups_views.xml
+++ b/web_widget_x2many_2d_matrix/demo/res_groups_views.xml
@@ -1,0 +1,106 @@
+<odoo>
+    <record id="view_groups_form" model="ir.ui.view">
+        <field name="model">res.groups</field>
+        <field name="inherit_id" ref="base.view_groups_form" />
+        <field name="arch" type="xml">
+            <notebook position="inside">
+                <page string="Matrix widget">
+                    <div
+                        class="o_form_label"
+                    >Many2one field as value and y axis, options and domain set on value field</div>
+                    <field
+                        name="users"
+                        widget="x2many_2d_matrix"
+                        field_x_axis="login"
+                        field_y_axis="partner_id"
+                        field_value="country_id"
+                    >
+                        <tree>[
+                            <field name="login" />
+                            <field name="partner_id" />
+                            <field
+                                name="country_id"
+                                domain="[('name', 'like', 'land')]"
+                                options="{'no_create': True}"
+                                readonly="login == 'demo'"
+                                required="login == 'admin'"
+                            />
+                        </tree>
+                    </field>
+                    <div class="o_form_label">Char field as value</div>
+                    <field
+                        name="users"
+                        widget="x2many_2d_matrix"
+                        field_x_axis="country_id"
+                        field_y_axis="partner_id"
+                        field_value="name"
+                    >
+                        <tree>[
+                            <field name="name" />
+                            <field name="partner_id" />
+                            <field
+                                name="country_id"
+                                domain="[('name', 'like', 'land')]"
+                                options="{'no_create': True}"
+                            />
+                        </tree>
+                    </field>
+                    <div class="o_form_label">Boolean field as value</div>
+                    <field
+                        name="users"
+                        widget="x2many_2d_matrix"
+                        field_x_axis="country_id"
+                        field_y_axis="partner_id"
+                        field_value="active"
+                    >
+                        <tree>[
+                            <field name="active" />
+                            <field name="partner_id" />
+                            <field
+                                name="country_id"
+                                domain="[('name', 'like', 'land')]"
+                                options="{'no_create': True}"
+                            />
+                        </tree>
+                    </field>
+                    <div class="o_form_label">Selection field as value</div>
+                    <field
+                        name="users"
+                        widget="x2many_2d_matrix"
+                        field_x_axis="country_id"
+                        field_y_axis="partner_id"
+                        field_value="lang"
+                    >
+                        <tree>[
+                            <field name="lang" />
+                            <field name="partner_id" />
+                            <field
+                                name="country_id"
+                                domain="[('name', 'like', 'land')]"
+                                options="{'no_create': True}"
+                            />
+                        </tree>
+                    </field>
+                    <div class="o_form_label">Float field as value</div>
+                    <field
+                        name="users"
+                        widget="x2many_2d_matrix"
+                        field_x_axis="country_id"
+                        field_y_axis="partner_id"
+                        field_value="partner_latitude"
+                    >
+                        <tree>[
+                            <field name="partner_latitude" />
+                            <field name="partner_id" />
+                            <field
+                                name="country_id"
+                                domain="[('name', 'like', 'land')]"
+                                options="{'no_create': True}"
+                            />
+                        </tree>
+                    </field>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>

--- a/web_widget_x2many_2d_matrix/readme/CONTRIBUTORS.md
+++ b/web_widget_x2many_2d_matrix/readme/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-- Holger Brunn \<<hbrunn@therp.nl>\>
+- Holger Brunn \<<mail@hunki-enterprises.com>\>
 - Pedro M. Baeza \<<pedro.baeza@tecnativa.com>\>
 - Artem Kostyuk \<<a.kostyuk@mobilunity.com>\>
 - Simone Orsi \<<simone.orsi@camptocamp.com>\>

--- a/web_widget_x2many_2d_matrix/readme/ROADMAP.md
+++ b/web_widget_x2many_2d_matrix/readme/ROADMAP.md
@@ -1,12 +1,7 @@
-- Support extra attributes on each field cell via field_extra_attrs
-  param. We could set a cell as not editable, required or readonly for
-  instance. The readonly case will also give the ability to click on m2o
-  to open related records.
 - Support limit total records in the matrix. Ref:
   <https://github.com/OCA/web/issues/901>
 - Support cell traversal through keyboard arrows.
 - Entering the widget from behind by pressing `Shift+TAB` in your
   keyboard will enter into the 1st cell until
   <https://github.com/odoo/odoo/pull/26490> is merged.
-- Support extra invisible fields inside each cell.
 - Support kanban mode. Current behaviour forces list mode.

--- a/web_widget_x2many_2d_matrix/readme/USAGE.md
+++ b/web_widget_x2many_2d_matrix/readme/USAGE.md
@@ -36,6 +36,12 @@ show_column_totals
 If field_value is a numeric field, it indicates if you want to calculate
 column totals. True by default
 
+x_axis_clickable
+If the x axis field is a many2one field, render the values as links to the record in question
+
+y_axis_clickable
+If the y axis field is a many2one field, render the values as links to the record in question
+
 For the value field, you can set any attributes you'd set in a normal list view, ie if your value field is a many2one field and you want to disable creating records via this field, you'd write
 
 ```xml

--- a/web_widget_x2many_2d_matrix/readme/USAGE.md
+++ b/web_widget_x2many_2d_matrix/readme/USAGE.md
@@ -36,6 +36,21 @@ show_column_totals
 If field_value is a numeric field, it indicates if you want to calculate
 column totals. True by default
 
+For the value field, you can set any attributes you'd set in a normal list view, ie if your value field is a many2one field and you want to disable creating records via this field, you'd write
+
+```xml
+<field name="my_field3" options="{'no_create': true}"/>
+```
+
+or if you want to have a custom domain or context
+
+```xml
+<field name="my_field3" domain="[('some_field', '=', my_field1)]" context="{'default_some_field': my_field1}" />
+```
+
+Note that to be able to refer to other fields than the ones used as coordinates or value, you have to add them inside the ``list`` node.
+
+
 ## Example
 
 You need a data structure already filled with values. Let's assume we

--- a/web_widget_x2many_2d_matrix/static/description/index.html
+++ b/web_widget_x2many_2d_matrix/static/description/index.html
@@ -452,6 +452,10 @@ attributes:</p>
 want to calculate row totals. True by default</p>
 <p>show_column_totals If field_value is a numeric field, it indicates if
 you want to calculate column totals. True by default</p>
+<p>x_axis_clickable If the x axis field is a many2one field, render the
+values as links to the record in question</p>
+<p>y_axis_clickable If the y axis field is a many2one field, render the
+values as links to the record in question</p>
 <p>For the value field, you can set any attributes you’d set in a normal
 list view, ie if your value field is a many2one field and you want to
 disable creating records via this field, you’d write</p>

--- a/web_widget_x2many_2d_matrix/static/description/index.html
+++ b/web_widget_x2many_2d_matrix/static/description/index.html
@@ -562,6 +562,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="authors">
 <h2><a class="toc-backref" href="#toc-entry-9">Authors</a></h2>
 <ul class="simple">
+<li>Hunki Enterprises BV</li>
 <li>Therp BV</li>
 <li>Tecnativa</li>
 <li>Camptocamp</li>
@@ -572,7 +573,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-10">Contributors</a></h2>
 <ul class="simple">
-<li>Holger Brunn &lt;<a class="reference external" href="mailto:hbrunn&#64;therp.nl">hbrunn&#64;therp.nl</a>&gt;</li>
+<li>Holger Brunn &lt;<a class="reference external" href="mailto:mail&#64;hunki-enterprises.com">mail&#64;hunki-enterprises.com</a>&gt;</li>
 <li>Pedro M. Baeza &lt;<a class="reference external" href="mailto:pedro.baeza&#64;tecnativa.com">pedro.baeza&#64;tecnativa.com</a>&gt;</li>
 <li>Artem Kostyuk &lt;<a class="reference external" href="mailto:a.kostyuk&#64;mobilunity.com">a.kostyuk&#64;mobilunity.com</a>&gt;</li>
 <li>Simone Orsi &lt;<a class="reference external" href="mailto:simone.orsi&#64;camptocamp.com">simone.orsi&#64;camptocamp.com</a>&gt;</li>
@@ -598,8 +599,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
-<p><a class="reference external image-reference" href="https://github.com/JasminSForgeFlow"><img alt="JasminSForgeFlow" src="https://github.com/JasminSForgeFlow.png?size=40px" /></a></p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/JasminSForgeFlow"><img alt="JasminSForgeFlow" src="https://github.com/JasminSForgeFlow.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/hbrunn"><img alt="hbrunn" src="https://github.com/hbrunn.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/web/tree/17.0/web_widget_x2many_2d_matrix">OCA/web</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/web_widget_x2many_2d_matrix/static/description/index.html
+++ b/web_widget_x2many_2d_matrix/static/description/index.html
@@ -452,6 +452,18 @@ attributes:</p>
 want to calculate row totals. True by default</p>
 <p>show_column_totals If field_value is a numeric field, it indicates if
 you want to calculate column totals. True by default</p>
+<p>For the value field, you can set any attributes you’d set in a normal
+list view, ie if your value field is a many2one field and you want to
+disable creating records via this field, you’d write</p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;my_field3&quot;</span><span class="w"> </span><span class="na">options=</span><span class="s">&quot;{'no_create': true}&quot;</span><span class="nt">/&gt;</span>
+</pre>
+<p>or if you want to have a custom domain or context</p>
+<pre class="code xml literal-block">
+<span class="nt">&lt;field</span><span class="w"> </span><span class="na">name=</span><span class="s">&quot;my_field3&quot;</span><span class="w"> </span><span class="na">domain=</span><span class="s">&quot;[('some_field', '=', my_field1)]&quot;</span><span class="w"> </span><span class="na">context=</span><span class="s">&quot;{'default_some_field': my_field1}&quot;</span><span class="w"> </span><span class="nt">/&gt;</span>
+</pre>
+<p>Note that to be able to refer to other fields than the ones used as
+coordinates or value, you have to add them inside the <tt class="docutils literal">list</tt> node.</p>
 <div class="section" id="example">
 <h2><a class="toc-backref" href="#toc-entry-2">Example</a></h2>
 <p>You need a data structure already filled with values. Let’s assume we
@@ -507,17 +519,12 @@ crucial part is that we fill the field in the default function:</p>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>Support extra attributes on each field cell via field_extra_attrs
-param. We could set a cell as not editable, required or readonly for
-instance. The readonly case will also give the ability to click on m2o
-to open related records.</li>
 <li>Support limit total records in the matrix. Ref:
 <a class="reference external" href="https://github.com/OCA/web/issues/901">https://github.com/OCA/web/issues/901</a></li>
 <li>Support cell traversal through keyboard arrows.</li>
 <li>Entering the widget from behind by pressing <tt class="docutils literal">Shift+TAB</tt> in your
 keyboard will enter into the 1st cell until
 <a class="reference external" href="https://github.com/odoo/odoo/pull/26490">https://github.com/odoo/odoo/pull/26490</a> is merged.</li>
-<li>Support extra invisible fields inside each cell.</li>
 <li>Support kanban mode. Current behaviour forces list mode.</li>
 </ul>
 </div>

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.esm.js
@@ -3,7 +3,6 @@
 import {Component} from "@odoo/owl";
 import {X2Many2DMatrixRenderer} from "@web_widget_x2many_2d_matrix/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm";
 import {archParseBoolean} from "@web/views/utils";
-import {evaluateBooleanExpr} from "@web/core/py_js/py";
 import {registry} from "@web/core/registry";
 import {standardFieldProps} from "@web/views/fields/standard_field_props";
 
@@ -19,36 +18,33 @@ export class X2Many2DMatrixField extends Component {
     get list() {
         return this.getList();
     }
+
+    getListView() {
+        return this.props.list_view;
+    }
+
+    get list_view() {
+        return this.getListView();
+    }
 }
 
 X2Many2DMatrixField.template = "web_widget_x2many_2d_matrix.X2Many2DMatrixField";
 X2Many2DMatrixField.props = {
     ...standardFieldProps,
-    list: {type: Object, optional: true},
-    matrixFields: {type: Object, optional: true},
+    list_view: {type: Object, optional: false},
+    matrixFields: {type: Object, optional: false},
     isXClickable: {type: Boolean, optional: true},
     isYClickable: {type: Boolean, optional: true},
     showRowTotals: {type: Boolean, optional: true},
     showColumnTotals: {type: Boolean, optional: true},
-    canOpen: {type: Boolean, optional: true},
-    canCreate: {type: Boolean, optional: true},
-    canWrite: {type: Boolean, optional: true},
-    canQuickCreate: {type: Boolean, optional: true},
-    canCreateEdit: {type: Boolean, optional: true},
 };
 
 X2Many2DMatrixField.components = {X2Many2DMatrixRenderer};
 export const x2Many2DMatrixField = {
     component: X2Many2DMatrixField,
-    extractProps({attrs, options}) {
-        const hasCreatePermission = attrs.can_create
-            ? evaluateBooleanExpr(attrs.can_create)
-            : true;
-        const hasWritePermission = attrs.can_write
-            ? evaluateBooleanExpr(attrs.can_write)
-            : true;
-        const canCreate = options.no_create ? false : hasCreatePermission;
+    extractProps({attrs, views}) {
         return {
+            list_view: views.list,
             matrixFields: {
                 value: attrs.field_value,
                 x: attrs.field_x_axis,
@@ -64,11 +60,6 @@ export const x2Many2DMatrixField = {
                 "show_column_totals" in attrs
                     ? archParseBoolean(attrs.show_column_totals)
                     : true,
-            canOpen: !options.no_open,
-            canCreate,
-            canWrite: hasWritePermission,
-            canQuickCreate: canCreate && !options.no_quick_create,
-            canCreateEdit: canCreate && !options.no_create_edit,
         };
     },
 };

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.xml
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.xml
@@ -9,6 +9,8 @@
                 showRowTotals="props.showRowTotals"
                 showColumnTotals="props.showColumnTotals"
                 readonly="props.readonly"
+                isXClickable="props.isXClickable"
+                isYClickable="props.isYClickable"
             />
         </div>
     </t>

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.xml
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.xml
@@ -4,16 +4,11 @@
         <div class="table-responsive">
             <X2Many2DMatrixRenderer
                 list="list"
+                list_view="list_view"
                 matrixFields="props.matrixFields"
                 showRowTotals="props.showRowTotals"
                 showColumnTotals="props.showColumnTotals"
                 readonly="props.readonly"
-                domain="props.domain"
-                canOpen="props.canOpen"
-                canCreate="props.canCreate"
-                canWrite="props.canWrite"
-                canQuickCreate="props.canQuickCreate"
-                canCreateEdit="props.canCreateEdit"
             />
         </div>
     </t>

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -173,6 +173,9 @@ export class X2Many2DMatrixRenderer extends Component {
         }
         value = record ? record.data[this.matrixFields.value] : value;
         this.matrix[y][x].value = value;
+        if (!record) {
+            return null;
+        }
         const fieldInfo =
             this.props.list_view.fieldNodes[this.matrixFields.value + "_0"];
         const dynamicInfo = {

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -111,6 +111,14 @@ export class X2Many2DMatrixRenderer extends Component {
         return field.type;
     }
 
+    _getXAxisField() {
+        return this.list.fields[this.matrixFields.x];
+    }
+
+    _getYAxisField() {
+        return this.list.fields[this.matrixFields.y];
+    }
+
     _aggregateRow(row) {
         const y = this.rows.findIndex((r) => r.value === row);
         const total = this.matrix[y].map((r) => r.value).reduce((aggr, x) => aggr + x);
@@ -216,4 +224,6 @@ X2Many2DMatrixRenderer.props = {
     domain: {type: [Array, Function], optional: true},
     showRowTotals: {type: Boolean, optional: true},
     showColumnTotals: {type: Boolean, optional: true},
+    isXClickable: {type: Boolean, optional: true},
+    isYClickable: {type: Boolean, optional: true},
 };

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -1,9 +1,10 @@
 /** @odoo-module **/
 
 import {Component, onWillUpdateProps} from "@odoo/owl";
-import {registry} from "@web/core/registry";
+import {evaluateBooleanExpr, evaluateExpr} from "@web/core/py_js/py";
 import {Domain} from "@web/core/domain";
-import {evaluateExpr} from "@web/core/py_js/py";
+import {getFieldContext} from "@web/model/relational_model/utils";
+import {registry} from "@web/core/registry";
 const fieldRegistry = registry.category("fields");
 
 export class X2Many2DMatrixRenderer extends Component {
@@ -93,12 +94,16 @@ export class X2Many2DMatrixRenderer extends Component {
         return this.props.matrixFields;
     }
 
-    _getValueFieldComponent() {
+    _getValueField() {
         const field = this.list.fields[this.matrixFields.value];
         if (!field.widget) {
-            return fieldRegistry.get(field.type).component;
+            return fieldRegistry.get(field.type);
         }
-        return fieldRegistry.get(field.widget).component;
+        return fieldRegistry.get(field.widget);
+    }
+
+    _getValueFieldComponent() {
+        return this._getValueField().component;
     }
 
     _getValueFieldType() {
@@ -119,6 +124,7 @@ export class X2Many2DMatrixRenderer extends Component {
         const x = this.columns.findIndex((c) => c.value === column);
 
         const total = this.matrix
+
             .map((r) => r[x])
             .map((r) => r.value)
             .reduce((aggr, y) => aggr + y);
@@ -144,11 +150,6 @@ export class X2Many2DMatrixRenderer extends Component {
         );
     }
 
-    // More options can be included in the future, here are only added the ones tested initially.
-    _canOptions() {
-        return ["many2one"].includes(this.list.fields[this.matrixFields.value].type);
-    }
-
     getValueFieldProps(column, row) {
         const x = this.columns.findIndex((c) => c.value === column);
         const y = this.rows.findIndex((r) => r.value === row);
@@ -164,24 +165,41 @@ export class X2Many2DMatrixRenderer extends Component {
         }
         value = record ? record.data[this.matrixFields.value] : value;
         this.matrix[y][x].value = value;
+        const fieldInfo =
+            this.props.list_view.fieldNodes[this.matrixFields.value + "_0"];
+        const dynamicInfo = {
+            get context() {
+                return getFieldContext(record, fieldInfo.name, fieldInfo.context);
+            },
+            domain() {
+                const evalContext = record.evalContext;
+                if (fieldInfo.domain) {
+                    return new Domain(
+                        evaluateExpr(fieldInfo.domain, evalContext)
+                    ).toList();
+                }
+            },
+            required: evaluateBooleanExpr(
+                fieldInfo.required,
+                record.evalContextWithVirtualIds
+            ),
+            readonly:
+                this.props.readonly ||
+                evaluateBooleanExpr(
+                    fieldInfo.readonly,
+                    record.evalContextWithVirtualIds
+                ),
+        };
+        const valueField = this._getValueField();
         const result = {
-            readonly: this.props.readonly,
+            readonly: dynamicInfo.readonly,
             record: record,
             name: this.matrixFields.value,
-            ...(this._canOptions() && {
-                canCreate: this.props.canCreate,
-                canOpen: this.props.canOpen,
-                canWrite: this.props.canWrite,
-                canQuickCreate: this.props.canQuickCreate,
-                canCreateEdit: this.props.canCreateEdit,
-            }),
+            ...(valueField.extractProps || (() => ({}))).apply(valueField, [
+                fieldInfo,
+                dynamicInfo,
+            ]),
         };
-        const domain = record.fields[this.matrixFields.value].domain;
-        if (domain) {
-            result.domain = new Domain(
-                evaluateExpr(domain, record.evalContext)
-            ).toList();
-        }
         if (value === null) {
             result.readonly = true;
         }
@@ -191,15 +209,11 @@ export class X2Many2DMatrixRenderer extends Component {
 
 X2Many2DMatrixRenderer.template = "web_widget_x2many_2d_matrix.X2Many2DMatrixRenderer";
 X2Many2DMatrixRenderer.props = {
-    list: {type: Object, optional: true},
-    matrixFields: {type: Object, optional: true},
+    list: {type: Object, optional: false},
+    list_view: {type: Object, optional: false},
+    matrixFields: {type: Object, optional: false},
     readonly: {type: Boolean, optional: true},
     domain: {type: [Array, Function], optional: true},
     showRowTotals: {type: Boolean, optional: true},
     showColumnTotals: {type: Boolean, optional: true},
-    canOpen: {type: Boolean, optional: true},
-    canCreate: {type: Boolean, optional: true},
-    canWrite: {type: Boolean, optional: true},
-    canQuickCreate: {type: Boolean, optional: true},
-    canCreateEdit: {type: Boolean, optional: true},
 };

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.xml
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.xml
@@ -42,9 +42,13 @@
                     </td>
                     <td t-foreach="columns" t-as="column" t-key="column.value">
                         <t
+                            t-set="value_field_props"
+                            t-value="getValueFieldProps(column.value, row.value)"
+                        />
+                        <t
+                            t-if="value_field_props"
                             t-component="ValueFieldComponent"
-                            t-props="getValueFieldProps(column.value, row.value)"
-                            record="getValueFieldProps(column.value, row.value).record"
+                            t-props="value_field_props"
                         />
                     </td>
                     <td

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.xml
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.xml
@@ -14,7 +14,15 @@
                         t-key="column.value"
                         class="text-center"
                     >
-                        <t t-esc="column.text" />
+                        <t t-if="props.isXClickable and _getXAxisField().relation">
+                            <a
+                                class="o_form_uri"
+                                t-attf-href="/odoo/{{_getXAxisField().relation}}/{{column.value}}"
+                            >
+                                <t t-esc="column.text" />
+                            </a>
+                        </t>
+                        <t t-else="" t-esc="column.text" />
                     </th>
                     <th t-if="props.showRowTotals" />
                 </tr>
@@ -22,7 +30,15 @@
             <tbody>
                 <tr t-foreach="rows" t-as="row" t-key="row.value">
                     <td>
-                        <t t-esc="row.text" />
+                        <t t-if="props.isYClickable and _getYAxisField().relation">
+                            <a
+                                class="o_form_uri"
+                                t-attf-href="/odoo/{{_getYAxisField().relation}}/{{row.value}}"
+                            >
+                                <t t-esc="row.text" />
+                            </a>
+                        </t>
+                        <t t-else="" t-esc="row.text" />
                     </td>
                     <td t-foreach="columns" t-as="column" t-key="column.value">
                         <t


### PR DESCRIPTION
see https://github.com/OCA/web/pull/3203

I didn't backport the tests because that would be a lot of work for just trying to make a better offer instead of butchering my baby even more in recent PRs. I did however add a tab to the group form in demo data where you can easily check on runbot that the different kinds of widgets work now in the matrix, and can be manipulated via attributes in the view definition.