### PR TITLE
[16.0][FIX] web_help: Check if search model exists

### DIFF
--- a/web_help/static/src/components/help_button/help_button.xml
+++ b/web_help/static/src/components/help_button/help_button.xml
@@ -13,7 +13,7 @@
     </t>
     <t t-inherit="web.ControlPanel.Regular" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o_cp_bottom_right')]" t-operation="inside">
-            <nav class="btn-group">
+            <nav class="btn-group" t-if="env.searchModel">
                 <HelpButton
                     resModel="env.searchModel.resModel"
                     viewType="env.config.viewType"
@@ -23,7 +23,7 @@
     </t>
     <t t-inherit="web.ControlPanel.Small" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o_cp_bottom_right')]" t-operation="inside">
-            <nav class="btn-group">
+            <nav class="btn-group" t-if="env.searchModel">
                 <HelpButton
                     resModel="env.searchModel.resModel"
                     viewType="env.config.viewType"


### PR DESCRIPTION
There are cases that the search is not there e.g. in the OCA accounting reports. If so it will throw an error, this PR fixes that error.

**Before:**

<img width="1005" height="710" alt="image" src="https://github.com/user-attachments/assets/dc4c6cee-8554-4f03-bee2-cdd7cb8547f9" />

**After (no error):**
<img width="2479" height="529" alt="image" src="https://github.com/user-attachments/assets/ecd0a04b-3acf-4ee3-afe2-25a8c0099aaa" />
