### PR TITLE
[17.0][FIX] web_m2x_options: Wrong function reference in conditional check

### DIFF
--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -179,7 +179,7 @@ patch(many2OneField, {
         // FIXME: field of type === "many2one_reference" does not support m2o_options_props.
         // This no-op prevents crashes, but proper option support is still missing.
         // See roadmap note in PR #3205
-        if (!this.m2m_options_props) {
+        if (!this.m2o_options_props) {
             return props;
         }
         const new_props = this.m2o_options_props(props, attrs, options);


### PR DESCRIPTION
ISSUE: https://github.com/OCA/web/issues/3227

without this patch,  if you try to restrict access to create from a many2one field using the parameters: web_m2x_options.create: False and web_m2x_options.create_edit: False, it still shows the options to create records.

## Before:
<img width="1045" height="448" alt="Captura desde 2025-07-22 21-16-46" src="https://github.com/user-attachments/assets/da494368-e60e-4921-a0bf-4f18034d61ea" />
Show "Create" and "Create and Edit" options

## After:
<img width="1045" height="448" alt="Captura desde 2025-07-22 21-18-11" src="https://github.com/user-attachments/assets/99789d1c-93bf-4118-8da3-3d1d22cc571d" />
Don' t show "Create" and "Create and Edit" options
