### PR TITLE
[18.0][FIX] web_widget_x2many_2d_matrix: adapt test invocation to upstream

### DIFF
--- a/web_widget_x2many_2d_matrix/static/tests/web_widget_x2many_2d_matrix.test.js
+++ b/web_widget_x2many_2d_matrix/static/tests/web_widget_x2many_2d_matrix.test.js
@@ -1,5 +1,7 @@
 import {defineModels, fields, models, mountView} from "@web/../tests/web_test_helpers";
-import {expect, test} from "@odoo/hoot";
+import {describe, expect, test} from "@odoo/hoot";
+
+describe.current.tags("desktop");
 
 class Main extends models.Model {
     line_ids = fields.One2many({

--- a/web_widget_x2many_2d_matrix/tests/test_web_widget_x2many_2d_matrix.py
+++ b/web_widget_x2many_2d_matrix/tests/test_web_widget_x2many_2d_matrix.py
@@ -5,11 +5,11 @@ from odoo.tests import HttpCase, tagged
 class TestWebWidgetX2Many2DMatrix(HttpCase):
     def test_js(self):
         self.browser_js(
-            "/web/tests?headless&loglevel=2&preset=desktop&timeout=15000&suite=e1a9aaa1",
+            "/web/tests?headless&loglevel=2&preset=desktop&timeout=15000&id=b42fa5f8",
             "",
             "",
             login="admin",
             timeout=1800,
-            success_signal="[HOOT] test suite succeeded",
+            success_signal="[HOOT] Test suite succeeded",
             error_checker=lambda x: "[HOOT]" not in x,
         )


### PR DESCRIPTION
since https://github.com/odoo/odoo/commit/494db33f5f0ad43a3ff459ac320597541d667e49, we need to call tests in a different way