### PR TITLE
[17.0][FIX] web_responsive: prevent error in tests when accessing an undefined variable

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.esm.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.esm.js
@@ -49,7 +49,7 @@ export class AppsMenu extends Component {
     setup() {
         super.setup();
         this.state = useState({open: false});
-        this.theme = session.apps_menu.theme || "milk";
+        this.theme = session.apps_menu?.theme || "milk";
         this.menuService = useService("menu");
         browser.localStorage.setItem("redirect_menuId", "");
         if (this.env.services.user.context.is_redirect_to_home) {


### PR DESCRIPTION
For an unknown reason, when running the tests, the `session` does not have all variables filled, so `apps_menu` is undefined. This causes an error in tours of other modules: `Cannot read properties of undefined (reading 'theme')`.
<img width="1434" height="474" alt="image" src="https://github.com/user-attachments/assets/0fb7a02a-efe7-4c52-94ab-2c495c69ebe7" />
<img width="1311" height="391" alt="image" src="https://github.com/user-attachments/assets/616f0c86-c7f4-4cab-b82a-6d20b931e008" />

The curious thing is that if you run the tests of this module alone, they pass.
But when running tests together with another module, or starting the test manually from the browser, tests from the other module fail.
For example, when running tests with the `voip_oca` module.

After this commit, the tests pass correctly:

<img width="1573" height="302" alt="image" src="https://github.com/user-attachments/assets/26e15418-e0df-4823-9022-b30f7243f94a" />


@Tecnativa @pedrobaeza @CarlosRoca13 could you please review this?