### PR TITLE
[17.0][FIX] web_widget_x2many_2d_matrix: restore pre-v17 functionality (axes)

### DIFF
--- a/web_widget_x2many_2d_matrix/demo/res_groups_views.xml
+++ b/web_widget_x2many_2d_matrix/demo/res_groups_views.xml
@@ -15,7 +15,7 @@
                         field_y_axis="partner_id"
                         field_value="country_id"
                     >
-                        <tree>[
+                        <tree>
                             <field name="login" />
                             <field name="partner_id" />
                             <field
@@ -27,22 +27,26 @@
                             />
                         </tree>
                     </field>
-                    <div class="o_form_label">Char field as value</div>
+                    <div
+                        class="o_form_label"
+                    >Char field as value, clickable X axis</div>
                     <field
                         name="users"
                         widget="x2many_2d_matrix"
                         field_x_axis="country_id"
                         field_y_axis="partner_id"
                         field_value="name"
+                        x_axis_clickable="True"
                     >
-                        <tree>[
-                            <field name="name" />
+                        <tree>
+                            <field name="name" required="login == 'admin'" />
                             <field name="partner_id" />
                             <field
                                 name="country_id"
                                 domain="[('name', 'like', 'land')]"
                                 options="{'no_create': True}"
                             />
+                            <field name="login" />
                         </tree>
                     </field>
                     <div class="o_form_label">Boolean field as value</div>
@@ -53,7 +57,7 @@
                         field_y_axis="partner_id"
                         field_value="active"
                     >
-                        <tree>[
+                        <tree>
                             <field name="active" />
                             <field name="partner_id" />
                             <field
@@ -71,7 +75,7 @@
                         field_y_axis="partner_id"
                         field_value="lang"
                     >
-                        <tree>[
+                        <tree>
                             <field name="lang" />
                             <field name="partner_id" />
                             <field
@@ -91,6 +95,26 @@
                     >
                         <tree>[
                             <field name="partner_latitude" />
+                            <field name="partner_id" />
+                            <field
+                                name="country_id"
+                                domain="[('name', 'like', 'land')]"
+                                options="{'no_create': True}"
+                            />
+                        </tree>
+                    </field>
+                    <div
+                        class="o_form_label"
+                    >Float field as value with float_time widget</div>
+                    <field
+                        name="users"
+                        widget="x2many_2d_matrix"
+                        field_x_axis="country_id"
+                        field_y_axis="partner_id"
+                        field_value="partner_latitude"
+                    >
+                        <tree>
+                            <field name="partner_latitude" widget="float_time" />
                             <field name="partner_id" />
                             <field
                                 name="country_id"

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.esm.js
@@ -3,17 +3,14 @@
 import {Component, onWillUpdateProps} from "@odoo/owl";
 import {evaluateBooleanExpr, evaluateExpr} from "@web/core/py_js/py";
 import {Domain} from "@web/core/domain";
+import {Record} from "@web/model/relational_model/record";
 import {getFieldContext} from "@web/model/relational_model/utils";
-import {registry} from "@web/core/registry";
-const fieldRegistry = registry.category("fields");
 
 export class X2Many2DMatrixRenderer extends Component {
     setup() {
-        this.ValueFieldComponent = this._getValueFieldComponent();
         this.columns = this._getColumns();
         this.rows = this._getRows();
         this.matrix = this._getMatrix();
-        this.ValueFieldType = this._getValueFieldType();
 
         onWillUpdateProps((newProps) => {
             this.columns = this._getColumns(newProps.list.records);
@@ -28,6 +25,7 @@ export class X2Many2DMatrixRenderer extends Component {
             const column = {
                 value: record.data[this.matrixFields.x],
                 text: record.data[this.matrixFields.x],
+                rawValue: record.data[this.matrixFields.x],
             };
             if (record.fields[this.matrixFields.x].type === "many2one") {
                 column.text = column.value[1];
@@ -45,6 +43,7 @@ export class X2Many2DMatrixRenderer extends Component {
             const row = {
                 value: record.data[this.matrixFields.y],
                 text: record.data[this.matrixFields.y],
+                rawValue: record.data[this.matrixFields.y],
             };
             if (record.fields[this.matrixFields.y].type === "many2one") {
                 row.text = row.value[1];
@@ -94,62 +93,41 @@ export class X2Many2DMatrixRenderer extends Component {
         return this.props.matrixFields;
     }
 
-    _getValueField() {
-        const field = this.list.fields[this.matrixFields.value];
-        if (!field.widget) {
-            return fieldRegistry.get(field.type);
-        }
-        return fieldRegistry.get(field.widget);
+    get valueFieldComponent() {
+        return this.props.list_view.fieldNodes[this.matrixFields.value + "_0"].field
+            .component;
     }
 
-    _getValueFieldComponent() {
-        return this._getValueField().component;
+    get xFieldComponent() {
+        return this.props.list_view.fieldNodes[this.matrixFields.x + "_0"].field
+            .component;
     }
 
-    _getValueFieldType() {
-        const field = this.list.fields[this.matrixFields.value];
-        return field.type;
-    }
-
-    _getXAxisField() {
-        return this.list.fields[this.matrixFields.x];
-    }
-
-    _getYAxisField() {
-        return this.list.fields[this.matrixFields.y];
+    get yFieldComponent() {
+        return this.props.list_view.fieldNodes[this.matrixFields.y + "_0"].field
+            .component;
     }
 
     _aggregateRow(row) {
         const y = this.rows.findIndex((r) => r.value === row);
         const total = this.matrix[y].map((r) => r.value).reduce((aggr, x) => aggr + x);
-        if (this.ValueFieldType === "integer") {
-            return total;
-        }
-        return Number(total).toFixed(2);
+        return total;
     }
 
     _aggregateColumn(column) {
         const x = this.columns.findIndex((c) => c.value === column);
-
         const total = this.matrix
-
             .map((r) => r[x])
             .map((r) => r.value)
             .reduce((aggr, y) => aggr + y);
-        if (this.ValueFieldType === "integer") {
-            return total;
-        }
-        return Number(total).toFixed(2);
+        return total;
     }
 
     _aggregateAll() {
         const total = this.matrix
             .map((r) => r.map((x) => x.value).reduce((aggr, x) => aggr + x))
             .reduce((aggr, y) => aggr + y);
-        if (this.ValueFieldType === "integer") {
-            return total;
-        }
-        return Number(total).toFixed(2);
+        return total;
     }
 
     _canAggregate() {
@@ -158,26 +136,43 @@ export class X2Many2DMatrixRenderer extends Component {
         );
     }
 
-    getValueFieldProps(column, row) {
+    _getValueFieldProps(column, row) {
         const x = this.columns.findIndex((c) => c.value === column);
         const y = this.rows.findIndex((r) => r.value === row);
-        let record = null;
-        let value = null;
-        if (
-            this.matrix[y] &&
-            this.matrix[y][x] &&
-            (record = this.matrix[y][x].records[0])
-        ) {
-            record = this.matrix[y][x].records[0];
-            value = this.matrix[y][x].value;
-        }
-        value = record ? record.data[this.matrixFields.value] : value;
-        this.matrix[y][x].value = value;
+        const record = this.matrix[y][x].records[0];
+
         if (!record) {
             return null;
         }
+        return this._getMatrixFieldProps(record, "value");
+    }
+
+    _getAxisFieldProps(value, axis) {
+        const fieldName = this.matrixFields[axis];
+        const record = new Record(this.list.model, this.list._config, {
+            [fieldName]: value,
+        });
+        const props = this._getMatrixFieldProps(record, axis);
+        if (this.list.fields[fieldName].type === "many2one") {
+            props.canOpen =
+                axis === "x" ? this.props.isXClickable : this.props.isYClickable;
+        }
+        props.readonly = true;
+        return props;
+    }
+
+    _getAggregateProps(value) {
+        const record = new Record(this.list.model, this.list._config, {
+            [this.matrixFields.value]: value,
+        });
+        const props = this._getMatrixFieldProps(record, "value");
+        props.readonly = true;
+        return props;
+    }
+
+    _getMatrixFieldProps(record, fieldName) {
         const fieldInfo =
-            this.props.list_view.fieldNodes[this.matrixFields.value + "_0"];
+            this.props.list_view.fieldNodes[this.matrixFields[fieldName] + "_0"];
         const dynamicInfo = {
             get context() {
                 return getFieldContext(record, fieldInfo.name, fieldInfo.context);
@@ -201,19 +196,15 @@ export class X2Many2DMatrixRenderer extends Component {
                     record.evalContextWithVirtualIds
                 ),
         };
-        const valueField = this._getValueField();
         const result = {
             readonly: dynamicInfo.readonly,
             record: record,
-            name: this.matrixFields.value,
-            ...(valueField.extractProps || (() => ({}))).apply(valueField, [
+            name: this.matrixFields[fieldName],
+            ...(fieldInfo.field.extractProps || (() => ({}))).apply(fieldInfo.field, [
                 fieldInfo,
                 dynamicInfo,
             ]),
         };
-        if (value === null) {
-            result.readonly = true;
-        }
         return result;
     }
 }

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.xml
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_renderer/x2many_2d_matrix_renderer.xml
@@ -14,15 +14,10 @@
                         t-key="column.value"
                         class="text-center"
                     >
-                        <t t-if="props.isXClickable and _getXAxisField().relation">
-                            <a
-                                class="o_form_uri"
-                                t-attf-href="/odoo/{{_getXAxisField().relation}}/{{column.value}}"
-                            >
-                                <t t-esc="column.text" />
-                            </a>
-                        </t>
-                        <t t-else="" t-esc="column.text" />
+                        <t
+                            t-component="xFieldComponent"
+                            t-props="_getAxisFieldProps(column.rawValue, 'x')"
+                        />
                     </th>
                     <th t-if="props.showRowTotals" />
                 </tr>
@@ -30,24 +25,19 @@
             <tbody>
                 <tr t-foreach="rows" t-as="row" t-key="row.value">
                     <td>
-                        <t t-if="props.isYClickable and _getYAxisField().relation">
-                            <a
-                                class="o_form_uri"
-                                t-attf-href="/odoo/{{_getYAxisField().relation}}/{{row.value}}"
-                            >
-                                <t t-esc="row.text" />
-                            </a>
-                        </t>
-                        <t t-else="" t-esc="row.text" />
+                        <t
+                            t-component="yFieldComponent"
+                            t-props="_getAxisFieldProps(row.rawValue, 'y')"
+                        />
                     </td>
                     <td t-foreach="columns" t-as="column" t-key="column.value">
                         <t
                             t-set="value_field_props"
-                            t-value="getValueFieldProps(column.value, row.value)"
+                            t-value="_getValueFieldProps(column.value, row.value)"
                         />
                         <t
                             t-if="value_field_props"
-                            t-component="ValueFieldComponent"
+                            t-component="valueFieldComponent"
                             t-props="value_field_props"
                         />
                     </td>
@@ -55,7 +45,10 @@
                         t-if="props.showRowTotals and _canAggregate()"
                         class="row-total"
                     >
-                        <span t-esc="_aggregateRow(row.value)" />
+                        <t
+                            t-component="valueFieldComponent"
+                            t-props="_getAggregateProps(_aggregateRow(row.value))"
+                        />
                     </td>
                 </tr>
             </tbody>
@@ -63,10 +56,16 @@
                 <tr t-if="props.showColumnTotals and _canAggregate()">
                     <th />
                     <th t-foreach="columns" t-as="column" t-key="column.value">
-                        <span t-esc="_aggregateColumn(column.value)" />
+                        <t
+                            t-component="valueFieldComponent"
+                            t-props="_getAggregateProps(_aggregateColumn(column.value))"
+                        />
                     </th>
                     <th t-if="props.showRowTotals" class="col-total">
-                        <span t-esc="_aggregateAll()" />
+                        <t
+                            t-component="valueFieldComponent"
+                            t-props="_getAggregateProps(_aggregateAll())"
+                        />
                     </th>
                 </tr>
             </tfoot>


### PR DESCRIPTION
use components to render axes and aggregates, allowing custom widgets there

see https://github.com/OCA/web/pull/3219#issuecomment-3155776072