### PR TITLE
[17.0][IMP] web_widget_product_label_section_and_note: force a width on the column

### DIFF
--- a/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.esm.js
+++ b/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.esm.js
@@ -298,3 +298,21 @@ export const productLabelSectionAndNoteField = {
 registry
     .category("fields")
     .add("product_label_section_and_note_field", productLabelSectionAndNoteField);
+
+// Patch HTMLElement to set a max width on the product and label field cells.
+// Odoo does not facilitate inheritance in the function computeColumnWidthsFromContent,
+// so we need to patch the getBoundingClientRect method to enforce a max width.
+const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+HTMLElement.prototype.getBoundingClientRect = function () {
+    const rect = originalGetBoundingClientRect.call(this);
+    if (
+        this.classList &&
+        this.classList.contains("o_product_label_section_and_note_field_cell")
+    ) {
+        return {
+            ...rect,
+            width: Math.min(rect.width, 400), // Set your desired max width here
+        };
+    }
+    return rect;
+};


### PR DESCRIPTION
Forward-port of https://github.com/OCA/web/pull/3247
Odoo does not facilitate inheritance in the function https://github.com/odoo/odoo/blob/3bc173a6b22f2e360ec363277800ee5efa12088f/addons/web/static/src/views/list/list_renderer.js#L406 so it is necessary to force a max width at this low level.

In v18, Odoo provides an attribute at the field level https://github.com/odoo/odoo/blob/1702cb44ab7692d70bfabfc25db9592dac85e7a2/addons/web/static/src/views/list/column_width_hook.js#L299  and in this widget Odoo uses a default value, which we also use here, see https://github.com/odoo/odoo/blob/1702cb44ab7692d70bfabfc25db9592dac85e7a2/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js#L249

TT57583

@Tecnativa @pedrobaeza @CarlosRoca13 could you please review this?