### PR TITLE
[16.0][FIX] web_systray_button_init_action: fix failed tour

### DIFF
--- a/web_systray_button_init_action/static/src/tours/tour.esm.js
+++ b/web_systray_button_init_action/static/src/tours/tour.esm.js
@@ -24,6 +24,7 @@ tour.register(
         test: true,
     },
     [
+        tour.stepUtils.showAppsMenuItem(),
         {
             trigger: ".o_navbar_apps_menu button",
             extra_trigger: ".init_action_div:has(a[name='init_action'])",


### PR DESCRIPTION
# Note
- Before this change, tour is failed although it passes locally

> odoo.addons.web_systray_button_init_action.tests.test_web_systray_button_init_action: FAIL: TestUI.test_ui
> Traceback (most recent call last):
>   File "/__w/web/web/web_systray_button_init_action/tests/test_web_systray_button_init_action.py", line 20, in test_ui
>     self.start_tour(
>   File "/opt/odoo/odoo/tests/common.py", line 2048, in start_tour
>     return self.browser_js(url_path=url_path, code=code, ready=ready, **kwargs)
>   File "/opt/odoo/odoo/tests/common.py", line 2024, in browser_js
>     self.fail('%s\n\n%s' % (message, error))
> AssertionError: The test code "odoo.startTour('web_systray_button_init_action_set_tour', 100)" failed
> 
> Tour web_systray_button_init_action_set_tour failed at step a[data-menu-xmlid='base.menu_administration']
>  

It's a temporary fix to unblock the runbot and will be investigated more in details.