### PR TITLE
[18.0][FIX] web_company_color: fix systray icon color

### DIFF
--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -115,7 +115,7 @@ class ResCompany(models.Model):
             background-color: %(color_navbar_bg_hover)s !important;
           }
         }
-        .o_menu_systray .o-dropdown .dropdown-toggle {
+        .o_menu_systray button{
             color: %(color_navbar_text)s !important;
             &:hover, &:focus, &:active, &:focus:active {
                 background-color: %(color_navbar_bg_hover)s !important;


### PR DESCRIPTION
In Odoo 17 the classes were nested, so the descendant selector worked, but in Odoo 18 both classes are on the same element.

Before:
<img width="1849" height="241" alt="image" src="https://github.com/user-attachments/assets/d59e8500-da79-4c64-99e4-58aafcc3e99a" />


After:
<img width="1846" height="288" alt="image" src="https://github.com/user-attachments/assets/2c13c57e-3b12-48d9-b3b8-e112726d5418" />
