### PR TITLE
[18][IMP] web_chatter_position: improve form and chatter layout styles

### DIFF
--- a/web_chatter_position/README.rst
+++ b/web_chatter_position/README.rst
@@ -32,6 +32,9 @@ Configurable chatter position from the user preferences.
 
 Supports Both Community & Enterprise Edition.
 
+Extends the functionality of the web client to get full width in the
+form view sheet.
+
 **Table of contents**
 
 .. contents::
@@ -66,19 +69,19 @@ Authors
 Contributors
 ------------
 
-- Hynsys Technologies <hynsystechnologies@gmail.com>
-- Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>
-- `Camptocamp <https://www.camptocamp.com>`__
+-  Hynsys Technologies <hynsystechnologies@gmail.com>
+-  Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>
+-  `Camptocamp <https://www.camptocamp.com>`__
 
-  - Iván Todorovich <ivan.todorovich@camptocamp.com>
+   -  Iván Todorovich <ivan.todorovich@camptocamp.com>
 
-- `Alitec Pte Ltd <http://www.alitec.sg>`__
+-  `Alitec Pte Ltd <http://www.alitec.sg>`__
 
-  - Jay Patel <jay@alitec.sg>
+   -  Jay Patel <jay@alitec.sg>
 
-- Trobz
+-  Trobz
 
-  - Tris Doan <tridm@trobz.com>
+   -  Tris Doan <tridm@trobz.com>
 
 Maintainers
 -----------

--- a/web_chatter_position/readme/DESCRIPTION.md
+++ b/web_chatter_position/readme/DESCRIPTION.md
@@ -1,3 +1,5 @@
 Configurable chatter position from the user preferences.
 
 Supports Both Community & Enterprise Edition.
+
+Extends the functionality of the web client to get full width in the form view sheet.

--- a/web_chatter_position/static/description/index.html
+++ b/web_chatter_position/static/description/index.html
@@ -372,6 +372,8 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/web/tree/18.0/web_chatter_position"><img alt="OCA/web" src="https://img.shields.io/badge/github-OCA%2Fweb-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/web-18-0/web-18-0-web_chatter_position"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/web&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>Configurable chatter position from the user preferences.</p>
 <p>Supports Both Community &amp; Enterprise Edition.</p>
+<p>Extends the functionality of the web client to get full width in the
+form view sheet.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/web_chatter_position/static/src/js/web_chatter_position.esm.js
+++ b/web_chatter_position/static/src/js/web_chatter_position.esm.js
@@ -46,12 +46,14 @@ patch(FormCompiler.prototype, {
                 isChatterAside: `__comp__.uiService.size >= ${SIZES.XXL}`,
             });
             setAttributes(chatterContainerHookXml, {
-                class: "o-aside",
+                class: "o-mail-ChatterContainer o-mail-Form-chatter o-aside w-print-100",
             });
             // For "bottom", we keep the chatter in the form sheet
             // (the one used for the attachment viewer case)
             // If it's not there, we create it.
         } else if (odoo.web_chatter_position === "bottom") {
+            // Force full width form view if chatter is set to bottom manually
+            formSheetBgXml.classList.add("o_fullwidth");
             if (webClientViewAttachmentViewHookXml) {
                 const sheetBgChatterContainerHookXml = res.querySelector(
                     ".o-mail-Form-chatter.o-isInFormSheetBg"

--- a/web_chatter_position/static/src/scss/form_controller.scss
+++ b/web_chatter_position/static/src/scss/form_controller.scss
@@ -2,16 +2,11 @@
     Copyright 2024 Alitec Pte Ltd (https://www.alitec.sg).
     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 */
-
-.o_form_view {
-    .o_form_sheet_bg {
-        max-width: none;
-    }
-    .o_form_sheet {
-        max-width: $o-form-view-sheet-max-width;
-        width: 100%;
-        @include media-breakpoint-up(md) {
-            margin: $o-sheet-vpadding * 0.2 auto;
-        }
+// Set sheet to full width when chatter is forced to bottom
+.o_form_view_container {
+    .o_form_sheet_bg.o_fullwidth,
+    .o_form_sheet_bg.o_fullwidth .o_form_sheet {
+        max-width: none !important;
+        width: auto !important;
     }
 }


### PR DESCRIPTION
Move functional elements of web_sheet_full_width into web_chatter_position, as it is otherwise deprecated.

Supersedes https://github.com/OCA/web/pull/3183 (after first having proposed the changes into that PR's branch in https://github.com/c4a8-odoo/module-oca-web/pull/17).
