### PR TITLE
[18.0][FIX] web_company_color: show company colors from active company

### DIFF
--- a/web_company_color/models/assetsbundle.py
+++ b/web_company_color/models/assetsbundle.py
@@ -10,7 +10,7 @@ class AssetsBundleCompanyColor(AssetsBundle):
         """Process the user active company scss and returns the node to inject"""
         try:
             active_company_id = int(
-                request.httprequest.cookies.get("cids", "").split(",")[0]
+                request.httprequest.cookies.get("cids", "").split("-")[0]
             )
         except Exception:
             active_company_id = False


### PR DESCRIPTION
When you have multiple active companies, changing the active company doesn’t update the company colors.