### PR TITLE
[18.0][REF] web_responsive: set as rebel module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo18.0:latest
+            exclude: "web_responsive"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb18.0:latest
+            exclude: "web_responsive"
             name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo18.0:latest
+            include: "web_responsive"
+            name: test with Odoo (rebel modules)
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb18.0:latest
+            include: "web_responsive"
+            name: test with OCB (rebel modules)
             makepot: "true"
     services:
       postgres:
@@ -50,6 +59,8 @@ jobs:
         ports:
           - 5432:5432
     env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
       OCA_ENABLE_CHECKLOG_ODOO: "1"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
web_tour's showAppsMenuItem does not work with web_responsive, causing
```
 2025-09-04 07:52:17,019 294 ERROR odoo odoo.addons.web_systray_button_init_action.tests.test_web_systray_button_init_action: FAIL: TestUI.test_ui
Traceback (most recent call last):
  File "/__w/web/web/web_systray_button_init_action/tests/test_web_systray_button_init_action.py", line 20, in test_ui
    self.start_tour(
  File "/opt/odoo/odoo/tests/common.py", line 2266, in start_tour
    return self.browser_js(url_path=url_path, code=code, ready=ready, timeout=timeout, success_signal="tour succeeded", **kwargs)
  File "/opt/odoo/odoo/tests/common.py", line 2240, in browser_js
    self.fail('%s\n\n%s' % (message, error))
AssertionError: The test code "odoo.startTour('web_systray_button_init_action_set_tour', {"stepDelay": 100, "keepWatchBrowser": false, "debug": false, "startUrl": "/web", "delayToCheckUndeterminisms": 0})" failed

FAILED: [3/5] Tour web_systray_button_init_action_set_tour → Step .o_app[data-menu-xmlid='base.menu_administration'].
Element (.o_app[data-menu-xmlid='base.menu_administration']) has not been found.
TIMEOUT step failed to complete within 10000 ms.
```