### PR TITLE
[18.0][FIX] web_systray_button_init_action + web_pivot_computed_measure: Add test: true to tours according to previous version

### DIFF
--- a/web_pivot_computed_measure/static/src/test/test.esm.js
+++ b/web_pivot_computed_measure/static/src/test/test.esm.js
@@ -5,6 +5,7 @@ import {registry} from "@web/core/registry";
 
 registry.category("web_tour.tours").add("web_pivot_computed_measure_tour", {
     url: "/odoo",
+    test: true,
     steps: () => [
         {
             trigger: ".o_navbar_apps_menu button",

--- a/web_systray_button_init_action/static/src/tours/tour.esm.js
+++ b/web_systray_button_init_action/static/src/tours/tour.esm.js
@@ -6,6 +6,7 @@ import {stepUtils} from "@web_tour/tour_service/tour_utils";
 
 registry.category("web_tour.tours").add("web_systray_button_init_action_not_set_tour", {
     url: "/web",
+    test: true,
     steps: () => [
         {
             trigger: ":not(:has(button[name='init_action']))",
@@ -14,6 +15,7 @@ registry.category("web_tour.tours").add("web_systray_button_init_action_not_set_
 });
 registry.category("web_tour.tours").add("web_systray_button_init_action_set_tour", {
     url: "/web",
+    test: true,
     steps: () => [
         {
             trigger: ".init_action_div:has(button[name='init_action'])",


### PR DESCRIPTION
Add test: true to tours according to previous version

https://github.com/OCA/web/commit/35729072ca4d2b683b40faddfb6f4bfcea7ba0ad#diff-d8c668fc0b4cbb274f0f6ad0a4faa7207f45bcaa66e15f43bc4f02c8c9c60ac2L5-L11 + https://github.com/OCA/web/commit/83c38fa2b1d02c11fb226bc19fc7d4f9c483ef09#diff-b4f10873d349a9b1d87d14f5159b8d72054411cf3d33bf1b0b4aef1989dc657eL9-L11

Please @pilarvargas-tecnativa and @CarlosRoca13 can you review it?

@Tecnativa