### PR TITLE
Fix CI in 14.0

### DIFF
--- a/web_edit_user_filter/tests/test_edit_user_filter.py
+++ b/web_edit_user_filter/tests/test_edit_user_filter.py
@@ -1,10 +1,11 @@
 # Copyright 2019 Onestein
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import SingleTransactionCase, post_install
+from odoo.tests import tagged
+from odoo.tests.common import SingleTransactionCase
 
 
-@post_install(True)
+@tagged("post_install", "-at_install")
 class TestEditUserFilter(SingleTransactionCase):
     def test_filter_facet_inclusion(self):
         self.env["ir.filters"].create(


### PR DESCRIPTION
We have noticed that the tests in `14.0` are failing, this is a known issue for (at least one of) @OCA/web-maintainers:
> old js tests are a mess, and I've given up trying to fix them

_Originally posted by @hbrunn in https://github.com/OCA/web/pull/2433#pullrequestreview-3186414249_

I have managed to fix one of the failures but can't reproduce the others, like:
```
2025-09-04 20:15:20,723 550 ERROR odoo odoo.addons.web_disable_export_group.tests.test_tour: FAIL: TestTour.test_user_not_export
Traceback (most recent call last):
  File "/__w/web/web/web_disable_export_group/tests/test_tour.py", line 30, in test_user_not_export
    self.start_tour("/web", "export_tour_xlsx_button_ko", login="user_not_export")
  File "/opt/odoo/odoo/tests/common.py", line 1563, in start_tour
    res = self.browser_js(url_path=url_path, code=code, ready=ready, **kwargs)
  File "/opt/odoo/odoo/tests/common.py", line 1535, in browser_js
    self.assertTrue(self.browser._wait_ready(ready), 'The ready "%s" code was always falsy' % ready)
AssertionError: False is not true : The ready "odoo.__DEBUG__.services['web_tour.tour'].tours['export_tour_xlsx_button_ko'].ready" code was always falsy
```
(from https://github.com/OCA/web/actions/runs/17475451661/job/49634125811#step:8:674)

Does anybody have a clue?
Looks like all the failing tests are from module `web_disable_export_group`, should we disable them?

Let me know what you think, thanks!
