### PR TITLE
[14.0][FIX] CI

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.29
+_commit: v1.33
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 convert_readme_fragments_to_markdown: false
@@ -18,6 +18,7 @@ org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups:
 - web_widget_model_viewer
+- web_disable_export_group
 repo_description: "This project aims to deal with modules related to the webclient\
     \ of Odoo. You'll find modules that:\n\n - Add facilities to the UI\n - Add widgets\n\
     \ - Ease the import/export features\n - Generally add clientside functionality"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,17 @@ jobs:
             name: test with OCB
             makepot: "true"
           - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
-            exclude: "web_widget_model_viewer"
+            include: "web_disable_export_group"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
-            exclude: "web_widget_model_viewer"
+            include: "web_disable_export_group"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.6-odoo14.0:latest
+            exclude: "web_widget_model_viewer,web_disable_export_group"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.6-ocb14.0:latest
+            exclude: "web_widget_model_viewer,web_disable_export_group"
             name: test with OCB
             makepot: "true"
     services:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
   - repo: https://github.com/oca/maintainer-tools
-    rev: d5fab7ee87fceee858a3d01048c78a548974d935
+    rev: f9b919b9868143135a9c9cb03021089cabba8223
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -104,6 +104,7 @@ repos:
         additional_dependencies:
           - "eslint@7.8.1"
           - "eslint-plugin-jsdoc@"
+          - "globals@"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:

--- a/web_edit_user_filter/tests/test_edit_user_filter.py
+++ b/web_edit_user_filter/tests/test_edit_user_filter.py
@@ -1,10 +1,11 @@
 # Copyright 2019 Onestein
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import SingleTransactionCase, post_install
+from odoo.tests import tagged
+from odoo.tests.common import SingleTransactionCase
 
 
-@post_install(True)
+@tagged("post_install", "-at_install")
 class TestEditUserFilter(SingleTransactionCase):
     def test_filter_facet_inclusion(self):
         self.env["ir.filters"].create(

--- a/web_field_required_invisible_manager/tests/test_web_field_required_invisible_manager.py
+++ b/web_field_required_invisible_manager/tests/test_web_field_required_invisible_manager.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests import Form, common
+from odoo.tools import mute_logger
 
 
 class TestFieldRequiredIvisibleManager(common.SavepointCase):
@@ -215,9 +216,10 @@ class TestFieldRequiredIvisibleManager(common.SavepointCase):
         self.env["res.partner.title"].default_get(["shortcut"])
         # onchange_field_id()
         self.assertFalse(self.invisible_title_rec_id.required)
-        self.invisible_title_rec_id.field_id = self.partner_title_name_field_id
-        self.invisible_title_rec_id.required_model_id = self.partner_model_id
-        self.invisible_title_rec_id._compute_model_name()
+        with mute_logger("odoo.modules.registry"):
+            self.invisible_title_rec_id.field_id = self.partner_title_name_field_id
+            self.invisible_title_rec_id.required_model_id = self.partner_model_id
+            self.invisible_title_rec_id._compute_model_name()
         self.assertTrue(self.invisible_title_rec_id.required)
         # unlink
         self.invisible_rec_id.unlink()


### PR DESCRIPTION
Include 3 actions:
- Applies https://github.com/OCA/web/pull/3281
- Removes a warning
- Puts the module web_disable_export_group to be executed independently, as there is some collisions with other modules.