### PR TITLE
[18.0][IMP] web_chatter_position: pre-commit fixes

### DIFF
--- a/web_chatter_position/models/res_users.py
+++ b/web_chatter_position/models/res_users.py
@@ -9,7 +9,7 @@ class ResUsers(models.Model):
 
     chatter_position = fields.Selection(
         [
-            ("auto", "Responsive"),
+            ("auto", "Automatic"),
             ("bottom", "Bottom"),
             ("sided", "Sided"),
         ],
@@ -22,4 +22,6 @@ class ResUsers(models.Model):
 
     @property
     def SELF_WRITEABLE_FIELDS(self):
-        return super().SELF_WRITEABLE_FIELDS + ["chatter_position"]
+        return super().SELF_WRITEABLE_FIELDS + [
+            "chatter_position",
+        ]

--- a/web_chatter_position/static/src/js/web_chatter_position.esm.js
+++ b/web_chatter_position/static/src/js/web_chatter_position.esm.js
@@ -3,10 +3,10 @@
     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 */
 
-import {FormCompiler} from "@web/views/form/form_compiler";
-import {patch} from "@web/core/utils/patch";
 import {append, setAttributes} from "@web/core/utils/xml";
+import {FormCompiler} from "@web/views/form/form_compiler";
 import {SIZES} from "@web/core/ui/ui_service";
+import {patch} from "@web/core/utils/patch";
 
 patch(FormCompiler.prototype, {
     /**


### PR DESCRIPTION
When using side mode, the chatter is by default responsive by addind the isChatterAside and o-aside class. This can cause some 'inconveniencies' if the chatter contains a long text, making the form view almost unreadable while helping reading the chatter. So this PR simply removes the responsive when used in side mode.

Chatter Responsive previous behavior:
<img width="1918" height="774" alt="image" src="https://github.com/user-attachments/assets/ccdd9354-bc08-4d75-8d29-f0e97a926463" />

Chatter Responsive disabled:
<img width="1918" height="776" alt="image" src="https://github.com/user-attachments/assets/c7645890-2c0a-4e5f-9438-a59f552d60ae" />