### PR TITLE
[16.0][FIX] web_dialog_size: fix dialog shrink issue

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -9,43 +9,42 @@ import {SelectCreateDialog} from "@web/views/view_dialogs/select_create_dialog";
 
 export class ExpandButton extends Component {
     setup() {
-        this.lastSize = this.currentSize = this.props.getsize();
-        this.sizeRestored = false;
+        this.lastSize = this.props.getsize();
+        this.currentSize = this.props.getsize();
         this.config = rpc.query({
             model: "ir.config_parameter",
             method: "get_web_dialog_size_config",
         });
 
         onWillRender(() => {
-            var self = this;
             // If the form lost its current state, we need to set it again
             if (this.props.getsize() !== this.currentSize) {
                 this.props.setsize(this.currentSize);
             }
-            // Check if we already are in full screen or if the form was restored.
-            // If so we don't need to check the default maximize
+            // Auto maximize once if config says so
             if (this.props.getsize() !== "dialog_full_screen" && !this.sizeRestored) {
-                this.config.then(function (r) {
-                    if (r.default_maximize && stop) {
-                        self.dialog_button_extend();
+                this.config.then((r) => {
+                    if (r.default_maximize) {
+                        this.toggleSize();
                     }
                 });
             }
         });
     }
 
-    dialog_button_extend() {
-        this.lastSize = this.props.getsize();
-        this.props.setsize("dialog_full_screen");
-        this.currentSize = "dialog_full_screen";
-        this.sizeRestored = false;
-        this.render();
-    }
-
-    dialog_button_restore() {
-        this.props.setsize(this.lastSize);
-        this.currentSize = this.lastSize;
-        this.sizeRestored = true;
+    toggleSize() {
+        if (this.currentSize === "dialog_full_screen") {
+            // Restore to previous remembered size
+            this.currentSize = "lg";
+            this.props.setsize(this.currentSize);
+            this.sizeRestored = true;
+        } else {
+            // Remember current size before maximizing
+            this.lastSize = this.currentSize;
+            this.currentSize = "dialog_full_screen";
+            this.props.setsize("dialog_full_screen");
+            this.sizeRestored = false;
+        }
         this.render();
     }
 }

--- a/web_dialog_size/static/src/xml/ExpandButton.xml
+++ b/web_dialog_size/static/src/xml/ExpandButton.xml
@@ -5,7 +5,7 @@
             t-if="props.getsize() == 'dialog_full_screen'"
             type="button"
             class="btn btn-secondary dialog_button_extend"
-            t-on-click="dialog_button_restore"
+            t-on-click="toggleSize"
         >
             <i class="fa fa-compress" />
         </button>
@@ -13,7 +13,7 @@
             t-if="props.getsize() != 'dialog_full_screen'"
             type="button"
             class="btn btn-secondary dialog_button_restore"
-            t-on-click="dialog_button_extend"
+            t-on-click="toggleSize"
         >
             <i class="fa fa-expand" />
         </button>


### PR DESCRIPTION
<img width="1160" height="327" alt="image" src="https://github.com/user-attachments/assets/200209f8-8843-478b-80a9-6ac02e7256e4" />

Whenever we set this system parameter to set size for the dialog default to True, some of the wizards can not be restore to it's original size by clicking on the below button.

<img width="113" height="73" alt="image" src="https://github.com/user-attachments/assets/501519b3-04f1-4eec-a9b9-dc40f505b7c0" />

One of the example for this issue is product selection wizard in any order line form view.

<img width="457" height="398" alt="image" src="https://github.com/user-attachments/assets/3fc17d67-b86e-4866-a305-83d577f63bb9" />
<img width="520" height="536" alt="image" src="https://github.com/user-attachments/assets/33dccdff-ded9-4e7a-a8c0-5ebaae6f5af4" />

When we click on "Search More..." it will open a wizard which can not be restored to it's original size.

It only happens when we set the system parameter "web_dialog_size.default_maximize" = "True"


https://github.com/user-attachments/assets/36095d06-eee8-4db4-93cf-5547d562aebb

