### PR TITLE
[17.0][FIX] web_environment_ribbon: fix configuration image in description

### DIFF
--- a/web_environment_ribbon/README.rst
+++ b/web_environment_ribbon/README.rst
@@ -39,19 +39,21 @@ every page
 Configuration
 =============
 
--  You can change the ribbon's name ("TEST") by editing the default
-   system parameter "ribbon.name" (in the menu Settings > Technical >
-   Parameters > System Parameters) To hide the ribbon, set this
-   parameter to "False" or delete it and refresh the page.
+- You can change the ribbon's name ("TEST") by editing the default
+  system parameter "ribbon.name" (in the menu Settings > Technical >
+  Parameters > System Parameters) To hide the ribbon, set this parameter
+  to "False" or delete it and refresh the page.
 
--  You can customize the ribbon color and background color through
-   system parameters: "ribbon.color", "ribbon.background.color". Fill
-   with valid CSS colors or just set to "False" to use default values.
+- You can customize the ribbon color and background color through system
+  parameters: "ribbon.color", "ribbon.background.color". Fill with valid
+  CSS colors or just set to "False" to use default values.
 
--  You can add the database name in the ribbon by adding "{db_name}" in
-   the system parameter "ribbon.name".
+- You can add the database name in the ribbon by adding "{db_name}" in
+  the system parameter "ribbon.name".
 
-   `configure_1 <../static/description/configure_1.png>`__
+  |configure_1|
+
+.. |configure_1| image:: https://raw.githubusercontent.com/OCA/web/17.0/web_environment_ribbon/static/description/configure_1.png
 
 Usage
 =====
@@ -81,13 +83,13 @@ Authors
 Contributors
 ------------
 
--  Francesco Apruzzese <cescoap@gmail.com>
--  Javi Melendez <javimelex@gmail.com>
--  Antonio Espinosa <antonio.espinosa@tecnativa.com>
--  Thomas Binsfeld <thomas.binsfeld@acsone.eu>
--  Xavier Jiménez <xavier.jimenez@qubiq.es>
--  Dennis Sluijk <d.sluijk@onestein.nl>
--  Eric Lembregts <eric@lembregts.eu>
+- Francesco Apruzzese <cescoap@gmail.com>
+- Javi Melendez <javimelex@gmail.com>
+- Antonio Espinosa <antonio.espinosa@tecnativa.com>
+- Thomas Binsfeld <thomas.binsfeld@acsone.eu>
+- Xavier Jiménez <xavier.jimenez@qubiq.es>
+- Dennis Sluijk <d.sluijk@onestein.nl>
+- Eric Lembregts <eric@lembregts.eu>
 
 Maintainers
 -----------

--- a/web_environment_ribbon/readme/CONFIGURE.md
+++ b/web_environment_ribbon/readme/CONFIGURE.md
@@ -1,5 +1,5 @@
 - You can change the ribbon's name ("TEST") by editing the default
-  system parameter "ribbon.name" (in the menu Settings \> Technical \> Parameters \> 
+  system parameter "ribbon.name" (in the menu Settings \> Technical \> Parameters \>
   System Parameters) To hide the ribbon, set this parameter to "False"
   or delete it and refresh the page.
 - You can customize the ribbon color and background color through system
@@ -8,4 +8,4 @@
 - You can add the database name in the ribbon by adding "{db_name}" in
   the system parameter "ribbon.name".
 
-  [configure_1](../static/description/configure_1.png)
+  ![configure_1](../static/description/configure_1.png)

--- a/web_environment_ribbon/static/description/index.html
+++ b/web_environment_ribbon/static/description/index.html
@@ -391,16 +391,16 @@ every page</p>
 <ul>
 <li><p class="first">You can change the ribbon’s name (“TEST”) by editing the default
 system parameter “ribbon.name” (in the menu Settings &gt; Technical &gt;
-Parameters &gt; System Parameters) To hide the ribbon, set this
-parameter to “False” or delete it and refresh the page.</p>
+Parameters &gt; System Parameters) To hide the ribbon, set this parameter
+to “False” or delete it and refresh the page.</p>
 </li>
-<li><p class="first">You can customize the ribbon color and background color through
-system parameters: “ribbon.color”, “ribbon.background.color”. Fill
-with valid CSS colors or just set to “False” to use default values.</p>
+<li><p class="first">You can customize the ribbon color and background color through system
+parameters: “ribbon.color”, “ribbon.background.color”. Fill with valid
+CSS colors or just set to “False” to use default values.</p>
 </li>
 <li><p class="first">You can add the database name in the ribbon by adding “{db_name}” in
 the system parameter “ribbon.name”.</p>
-<p><a class="reference external" href="../static/description/configure_1.png">configure_1</a></p>
+<p><img alt="configure_1" src="https://raw.githubusercontent.com/OCA/web/17.0/web_environment_ribbon/static/description/configure_1.png" /></p>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
While reviewing for 19.0 #3297 i discovered that:

The description inside Odoo's Module Info featured a broken image:
<img width="512" height="45" alt="image" src="https://github.com/user-attachments/assets/3b55884b-a79b-40f7-9459-7085d07405cc" />

With this change it is fixed:
<img width="854" height="142" alt="image" src="https://github.com/user-attachments/assets/551263e1-dff8-496d-8952-abe26713e7f6" />

If this is ok, i will forward port to 18.0 and 19.0 (17.0 seems to be the first version with the broken description)

Info @wt-io-it

