### PR TITLE
[17.0][IMP] web_company_color: mobile systray button

### DIFF
--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -115,7 +115,9 @@ class ResCompany(models.Model):
             background-color: %(color_navbar_bg_hover)s !important;
           }
         }
-        .o_menu_systray .o-dropdown .dropdown-toggle {
+        .o_menu_systray .o-dropdown .dropdown-toggle,
+        .o_menu_systray .o_mobile_menu_toggle,
+        .o_menu_toggle {
             color: %(color_navbar_text)s !important;
             &:hover, &:focus, &:active, &:focus:active {
                 background-color: %(color_navbar_bg_hover)s !important;


### PR DESCRIPTION
When used on mobile/tablet view, the button that opens the menu does not have the correct colors

Previous behavior: 
<img width="508" height="823" alt="image" src="https://github.com/user-attachments/assets/49acf290-c92d-4570-95ce-b1a15837fa5a" />

New behavior:
<img width="516" height="814" alt="image" src="https://github.com/user-attachments/assets/547683e9-cd66-4286-b8dd-111b716b94ba" />
