### PR TITLE
[16.0][FIX] web_dialog_size: prevent export wizard from shrinking when dialog maximize is enabled

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -56,9 +56,15 @@ patch(Dialog.prototype, "web_dialog_size.Dialog", {
         this._super(...arguments);
         this.setSize = this.setSize.bind(this);
         this.getSize = this.getSize.bind(this);
+        onWillRender(() => {
+            if (this._forcedSize && this.props.size !== this._forcedSize) {
+                this.props.size = this._forcedSize;
+            }
+        });
     },
 
     setSize(size) {
+        this._forcedSize = size;
         this.props.size = size;
         this.render();
     },


### PR DESCRIPTION
When i set system parameter web_dialog_size.default_maximize = True and open the export wizard i found this below bug where wizard is getting shrink automatically which is not a good user experience so i have fixed the issue and made the PR for it.


https://github.com/user-attachments/assets/28bdf815-35e3-42c4-8cb3-b2c08f931370

