### PR TITLE
[18.0][IMP] web_company_color: mobile systray button

### DIFF
--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -115,7 +115,10 @@ class ResCompany(models.Model):
             background-color: %(color_navbar_bg_hover)s !important;
           }
         }
-        .o_menu_systray button{
+        .o_menu_systray button,
+        .o_navbar_breadcrumbs,
+        .o_main_navbar button,
+        .o_menu_toggle {
             color: %(color_navbar_text)s !important;
             &:hover, &:focus, &:active, &:focus:active {
                 background-color: %(color_navbar_bg_hover)s !important;


### PR DESCRIPTION
When used on mobile/tablet view, the buttons and texts in the navbar do not match the company colors.

Forward port of #3314

This modify the previous commit to match the v18.0 requirements. To show exactly what I mean, here is the previous behavior in v18.0:
<img width="487" height="812" alt="image" src="https://github.com/user-attachments/assets/ea5bef71-6ec0-42db-806c-52f87007ca3c" />


An this how it looks like later:
<img width="491" height="801" alt="image" src="https://github.com/user-attachments/assets/d83ab7f2-b7b2-447c-974b-8acc977ffc06" />
