### PR TITLE
[18.0][FIX] web_dialog_size: prevent export wizard from shrinking when dialog maximize is enabled

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -1,4 +1,4 @@
-import {Component, onMounted} from "@odoo/owl";
+import {Component, onMounted, onWillRender} from "@odoo/owl";
 import {ActionDialog} from "@web/webclient/actions/action_dialog";
 import {Dialog} from "@web/core/dialog/dialog";
 import {SelectCreateDialog} from "@web/views/view_dialogs/select_create_dialog";
@@ -42,9 +42,15 @@ patch(Dialog.prototype, {
         super.setup();
         this.setSize = this.setSize.bind(this);
         this.getSize = this.getSize.bind(this);
+        onWillRender(() => {
+            if (this._forcedSize && this.props.size !== this._forcedSize) {
+                this.props.size = this._forcedSize;
+            }
+        });
     },
 
     setSize(size) {
+        this._forcedSize = size;
         this.props.size = size;
         this.render();
     },


### PR DESCRIPTION
Forward-port of #3315 