### PR TITLE
[17.0][IMP] web_responsive: adjust button styles and alignment in the chatter

### DIFF
--- a/web_responsive/static/src/components/chatter/chatter.xml
+++ b/web_responsive/static/src/components/chatter/chatter.xml
@@ -40,7 +40,7 @@
         <xpath expr="//button[hasclass('o-mail-Chatter-logNote')]" position="replace">
             <button
                 t-if="props.hasMessageList"
-                class="o-mail-Chatter-logNote btn text-nowrap me-2"
+                class="o-mail-Chatter-logNote btn text-nowrap me-1"
                 t-att-class="{
                     'btn-primary active': state.composerType === 'note',
                     'btn-secondary': state.composerType !== 'note',
@@ -64,6 +64,47 @@
             position="attributes"
         >
             <attribute name="class" add="d-none d-sm-inline" separator=" " />
+        </xpath>
+        <!-- remove extra padding between the activity separator and the search message -->
+        <xpath
+            expr="//span[hasclass('o-mail-Chatter-topbarGrow')]"
+            position="attributes"
+        >
+            <attribute name="class" remove="pe-2" add="px-0" separator=" " />
+        </xpath>
+        <!-- Align the "Follow" button and text to the left -->
+        <xpath
+            expr="//span[hasclass('o-mail-Chatter-follow')]/../.."
+            position="attributes"
+        >
+            <attribute name="class" add="text-start" separator=" " />
+        </xpath>
+        <xpath expr="//span[hasclass('o-mail-Chatter-follow')]" position="attributes">
+            <attribute name="class" remove="end-0" separator=" " />
+        </xpath>
+        <!-- Hide the icon that is invisible -->
+        <xpath
+            expr="//span[hasclass('o-mail-Chatter-follow')]/..//i"
+            position="attributes"
+        >
+            <attribute name="class" add="d-none" separator=" " />
+        </xpath>
+        <!-- Align the "Unfollow" button and text to the left -->
+        <xpath expr="//button[hasclass('o-mail-Chatter-follow')]" position="attributes">
+            <attribute name="class" add="text-start" separator=" " />
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o-mail-Chatter-follow')]//span[hasclass('end-0')]"
+            position="attributes"
+        >
+            <attribute name="class" remove="end-0" separator=" " />
+        </xpath>
+        <!-- Hide the icon that is invisible -->
+        <xpath
+            expr="//button[hasclass('o-mail-Chatter-follow')]//i"
+            position="attributes"
+        >
+            <attribute name="class" add="d-none" separator=" " />
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
The purpose is to reduce spacing so that all icons and buttons fit within the window without having to scroll.

Before
<img width="671" height="92" alt="image" src="https://github.com/user-attachments/assets/4d925eb8-520b-4363-b677-38eeaf84df54" />
With `mail_gateway` module installed
<img width="671" height="92" alt="image" src="https://github.com/user-attachments/assets/fee52957-141d-42dd-bff8-64d38e145de5" />


After
<img width="671" height="92" alt="image" src="https://github.com/user-attachments/assets/159bd47e-f094-405a-b89a-1975d4d01e67" />
With `mail_gateway` module installed
<img width="671" height="92" alt="image" src="https://github.com/user-attachments/assets/aeb3cb10-4862-4f3f-99a8-b80173bd8613" />

TT57968
@Tecnativa @pedrobaeza @pilarvargas-tecnativa @CarlosRoca13 could you please review this?