### PR TITLE
[18.0][IMP] web_responsive: adjust button styles and alignment in the chatter

### DIFF
--- a/web_responsive/static/src/components/chatter/chatter.xml
+++ b/web_responsive/static/src/components/chatter/chatter.xml
@@ -31,7 +31,7 @@
         </xpath>
         <xpath expr="//button[hasclass('o-mail-Chatter-logNote')]" position="replace">
             <button
-                class="o-mail-Chatter-logNote btn text-nowrap me-2"
+                class="o-mail-Chatter-logNote btn text-nowrap me-1"
                 t-att-class="{
                 'btn-primary active': state.composerType === 'note',
                 'btn-secondary': state.composerType !== 'note',
@@ -56,6 +56,33 @@
             position="attributes"
         >
             <attribute name="class" add="d-none d-sm-inline" separator=" " />
+        </xpath>
+        <!-- remove extra padding between the activity separator and the search message -->
+        <xpath
+            expr="//span[hasclass('o-mail-Chatter-topbarGrow')]"
+            position="attributes"
+        >
+            <attribute name="class" remove="pe-2" add="px-0" separator=" " />
+        </xpath>
+        <!-- Align the "Follow" button and text to the left -->
+        <xpath
+            expr="//span[hasclass('o-mail-Chatter-follow')]/../.."
+            position="attributes"
+        >
+            <attribute name="class" add="text-start" separator=" " />
+        </xpath>
+        <xpath expr="//span[hasclass('o-mail-Chatter-follow')]" position="attributes">
+            <attribute name="class" remove="end-0" separator=" " />
+        </xpath>
+        <!-- Align the "Unfollow" button and text to the left -->
+        <xpath expr="//button[hasclass('o-mail-Chatter-follow')]" position="attributes">
+            <attribute name="class" add="text-start" separator=" " />
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o-mail-Chatter-follow')]//span[hasclass('end-0')]"
+            position="attributes"
+        >
+            <attribute name="class" remove="end-0" separator=" " />
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
The purpose is to reduce spacing so that all icons and buttons fit within the window without having to scroll.

Before
<img width="663" height="76" alt="image" src="https://github.com/user-attachments/assets/677ee39b-5fe7-4ba2-8cba-cfb7a9d3d28c" />


After
<img width="663" height="76" alt="image" src="https://github.com/user-attachments/assets/857e21a3-abdf-426e-aee7-666227111c0c" />


Forward-port of https://github.com/OCA/web/pull/3321

TT57968
@Tecnativa @pedrobaeza @pilarvargas-tecnativa @CarlosRoca13 @legalsylvain could you please review this?