### PR TITLE
[18.0][IMP] web_widget_product_label_section_and_note_name_visibility: Remove the incompatibility with the sale_product_configurator module in the ROADMAP

### DIFF
--- a/web_widget_product_label_section_and_note_name_visibility/README.rst
+++ b/web_widget_product_label_section_and_note_name_visibility/README.rst
@@ -46,7 +46,6 @@ Usage
 Known issues / Roadmap
 ======================
 
-- Add compatibility with sale_product_configurator module
 - Add compatibility with purchase_product_matrix module
 
 Bug Tracker

--- a/web_widget_product_label_section_and_note_name_visibility/readme/ROADMAP.md
+++ b/web_widget_product_label_section_and_note_name_visibility/readme/ROADMAP.md
@@ -1,2 +1,1 @@
-- Add compatibility with sale_product_configurator module
 - Add compatibility with purchase_product_matrix module

--- a/web_widget_product_label_section_and_note_name_visibility/static/description/index.html
+++ b/web_widget_product_label_section_and_note_name_visibility/static/description/index.html
@@ -397,7 +397,6 @@ to decide whether to show or hide the product name in the description.</p>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>Add compatibility with sale_product_configurator module</li>
 <li>Add compatibility with purchase_product_matrix module</li>
 </ul>
 </div>


### PR DESCRIPTION
This module was merged into sale in the following commit: https://github.com/odoo/odoo/commit/fdcd3d5804cb86f3bda472e093739b7393c63659

@Tecnativa @pedrobaeza could you please review this?