### PR TITLE
[FIX] web_select_all_companies: avoid to add duplicated company ids in context

### DIFF
--- a/web_select_all_companies/static/src/js/switch_all_company_menu.esm.js
+++ b/web_select_all_companies/static/src/js/switch_all_company_menu.esm.js
@@ -31,7 +31,11 @@ patch(SwitchCompanyMenu.prototype, "SwitchAllCompanyMenu", {
             }, this.constructor.toggleDelay);
         } else {
             // Select all
-            this.state.companiesToToggle = [this.allCompanyIds];
+            this.state.companiesToToggle = [
+                this.allCompanyIds.filter(
+                    (x) => !this.companyService.allowedCompanyIds.includes(x)
+                ),
+            ];
             this.isAllCompaniesSelected = true;
             browser.clearTimeout(this.toggleTimer);
             this.toggleTimer = browser.setTimeout(() => {


### PR DESCRIPTION
The result of this bug was to add duplicate company ids in allowed_company_ids context. The side effect of this was to get duplicated lines in self.env['res.currency']._get_query_currency_table() and wrong results in currency_table of account.invoice.report.

```
...
            FROM account_move_line line
                LEFT JOIN res_partner partner ON partner.id = line.partner_id
                LEFT JOIN product_product product ON product.id = line.product_id
                LEFT JOIN account_account account ON account.id = line.account_id
                LEFT JOIN product_template template ON template.id = product.product_tmpl_id
                LEFT JOIN uom_uom uom_line ON uom_line.id = line.product_uom_id
                LEFT JOIN uom_uom uom_template ON uom_template.id = template.uom_id
                INNER JOIN account_move move ON move.id = line.move_id
                LEFT JOIN res_partner commercial_partner ON commercial_partner.id = move.commercial_partner_id
                JOIN (VALUES (1, 1.0, 2),(2, 1.0, 2),(4, 1.0, 2),(1, 1.0, 2),(2, 1.0, 2),(3, 1.0, 2),(4, 1.0, 2)) AS currency_table(company_id, rate, precision) ON currency_table.company_id = line.company_id
...
         
```