### PR TITLE
[IMP] web_timeline: Enhance date handling in TimelineModel to set dat…

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -140,6 +140,11 @@ export class TimelineModel extends Model {
                 this.fields[this.date_stop],
                 record[this.date_stop]
             );
+            // If date_stop is a date field (not datetime), set it to end of day
+            // This ensures the full day is included in the timeline
+            if (date_stop && this.fields[this.date_stop].type === "date") {
+                date_stop = date_stop.endOf("day");
+            }
         }
         if (!date_stop && date_delay) {
             date_stop = date_start.plus({hours: date_delay});


### PR DESCRIPTION
[IMP] web_timeline: Enhance date handling in TimelineModel to set date_stop to end of day for date fields, ensuring full day inclusion in the timeline.

Related to Issue: #3349 