### PR TITLE
[14.0][FIX] web_m2x_options_manager: fix m2o dialog

### DIFF
--- a/web_m2x_options_manager/models/m2x_create_edit_option.py
+++ b/web_m2x_options_manager/models/m2x_create_edit_option.py
@@ -148,10 +148,8 @@ class M2xCreateEditOption(models.Model):
             mode, val = opt.split("_")
             if mode == "force" or k not in options:
                 options[k] = val == "true"
+        options["m2o_dialog"] = self.option_create_edit_wizard
         node.set("options", str(options))
-        if not self.option_create_edit_wizard:
-            node.set("can_create", "false")
-            node.set("can_write", "true")
 
     @api.model
     def get(self, model_name, field_name):

--- a/web_m2x_options_manager/tests/test_m2x_create_edit_option.py
+++ b/web_m2x_options_manager/tests/test_m2x_create_edit_option.py
@@ -83,26 +83,12 @@ class TestM2xCreateEditOption(SavepointCase):
         title_node = form_doc.xpath("//field[@name='title']")[0]
         self.assertEqual(
             safe_eval(title_node.attrib.get("options"), nocopy=True),
-            {"create": True, "create_edit": True},
-        )
-        self.assertEqual(
-            (
-                title_node.attrib.get("can_create"),
-                title_node.attrib.get("can_write"),
-            ),
-            ("true", "true"),
+            {"create": True, "create_edit": True, "m2o_dialog": True},
         )
         categ_node = form_doc.xpath("//field[@name='category_id']")[0]
         self.assertEqual(
             safe_eval(categ_node.attrib.get("options"), nocopy=True),
-            {"create": False, "create_edit": True},
-        )
-        self.assertEqual(
-            (
-                categ_node.attrib.get("can_create"),
-                categ_node.attrib.get("can_write"),
-            ),
-            ("true", "true"),
+            {"create": False, "create_edit": True, "m2o_dialog": True},
         )
 
         # Check fields on res.users tree view (contained in ``user_ids`` field)
@@ -111,14 +97,7 @@ class TestM2xCreateEditOption(SavepointCase):
         company_node = tree_doc.xpath("//field[@name='company_id']")[0]
         self.assertEqual(
             safe_eval(company_node.attrib.get("options"), nocopy=True),
-            {"create": True, "create_edit": True},
-        )
-        self.assertEqual(
-            (
-                company_node.attrib.get("can_create"),
-                company_node.attrib.get("can_write"),
-            ),
-            ("false", "true"),
+            {"create": True, "create_edit": True, "m2o_dialog": False},
         )
 
         # Update options, check that node has been updated too
@@ -129,5 +108,5 @@ class TestM2xCreateEditOption(SavepointCase):
         title_node = form_doc.xpath("//field[@name='title']")[0]
         self.assertEqual(
             safe_eval(title_node.attrib.get("options"), nocopy=True),
-            {"create": True, "create_edit": False},
+            {"create": True, "create_edit": False, "m2o_dialog": True},
         )


### PR DESCRIPTION
Current implementation behind field ``option_create_edit_wizard`` was inconsistent with other options' values: if ``option_create_edit_wizard`` was unflagged, users could not access the "Create" and "Create & Edit" options even if ``option_create[_edit]`` were set to '[set|force]_true'. This commit fixes this issue.

To reproduce the issue:
- define an `m2x.create.edit.option` record where you set `option_create = 'force_true'`, `option_create_edit = 'force_true', `option_create_edit_wizard = False`
- go to any view displaying the field you chose
- write a name for a co-record that doesn't exist
- the pop-up wizard is not displayed :green_circle: 
- options "Create" and "Create & Edit" are not displayed either :red_circle: 