### PR TITLE
[18.0][FIX] web_favicon: use sanitized cids cookie

### DIFF
--- a/web_favicon/models/res_company.py
+++ b/web_favicon/models/res_company.py
@@ -72,9 +72,7 @@ class ResCompany(models.Model):
             website = self.env["website"].browse(self.env.context.get("website_id"))
             return website.image_url(website, "favicon")
         company_id = (
-            request.httprequest.cookies.get("cids")
-            if request.httprequest.cookies.get("cids")
-            else False
+            request.cookies.get("cids") if request.cookies.get("cids") else False
         )
         company = (
             self.browse(int(company_id.split("-")[0])).sudo()

--- a/web_favicon/tests/test_web_favicon.py
+++ b/web_favicon/tests/test_web_favicon.py
@@ -38,7 +38,7 @@ class TestWebFavicon(TransactionCase):
         self.assertEqual(image.size, (1920, 1080))
         self.assertEqual(image.getpixel((0, 0)), bg_color)
         with MockRequest(self.env) as mock_request:
-            mock_request.httprequest.cookies = {"cids": str(company.id)}
+            mock_request.cookies = {"cids": str(company.id)}
             self.assertTrue(Company._get_favicon())
 
     def test_02_default_favicon_creation(self):
@@ -83,10 +83,13 @@ class TestWebFavicon(TransactionCase):
         company_2 = Company.create(
             {"name": "Company 2", "favicon": Company._get_default_favicon()}
         )
+        company_3 = Company.create(
+            {"name": "Company 3", "favicon": Company._get_default_favicon()}
+        )
 
         with MockRequest(self.env) as mock_request:
-            mock_request.httprequest.cookies = {
-                "cids": f"{company_1.id}-{company_2.id}"
+            mock_request.cookies = {
+                "cids": f"{company_1.id}-{company_2.id}-{company_3.id}"
             }
             favicon_url = Company._get_favicon()
 


### PR DESCRIPTION
company ids separated by - is only available on sanitized request as per : https://github.com/odoo/odoo/blob/fcc5a90d2d5754923676b11031e37f52729402fd/addons/web/models/ir_http.py#L46

when using request.httprequest.cookies.get("cids"), you get a comma separated list instead and therefore the lines after the ones assigning company_id are failing when you get more than 2 companies active (because trying to cast to integer a string with potential multiple commas)