### PR TITLE
[17.0][FIX] web_m2x_options_manager: safe_eval() ValueError

### DIFF
--- a/web_m2x_options_manager/demo/res_partner_demo_view.xml
+++ b/web_m2x_options_manager/demo/res_partner_demo_view.xml
@@ -14,12 +14,12 @@
                         <!-- Many2one w/ options -->
                         <field
                             name="parent_id"
-                            options="{'create': False, 'create_edit': False}"
+                            options="{'create': false, 'create_edit': false}"
                         />
                         <!-- Many2many w/ options -->
                         <field
                             name="category_id"
-                            options="{'create': False, 'create_edit': False}"
+                            options="{'create': false, 'create_edit': false}"
                         />
                     </group>
                 </sheet>

--- a/web_m2x_options_manager/models/m2x_create_edit_option.py
+++ b/web_m2x_options_manager/models/m2x_create_edit_option.py
@@ -181,7 +181,7 @@ class M2xCreateEditOption(models.Model):
         """
         self.ensure_one()
         eval_ctx = dict(self.env.context or [])
-        eval_ctx.update({"context": dict(eval_ctx)})
+        eval_ctx.update({"context": dict(eval_ctx), "true": True, "false": False})
         return eval_ctx
 
     def _read_own_options(self):

--- a/web_m2x_options_manager/tests/common.py
+++ b/web_m2x_options_manager/tests/common.py
@@ -22,12 +22,18 @@ class Common(TransactionCase):
     def _get_model(cls, model_name):
         return cls.env["ir.model"]._get(model_name)
 
-    @staticmethod
-    def _eval_node_options(node):
-        opt = node.attrib.get("options")
-        if opt:
-            return safe_eval(opt, nocopy=True)
+    @classmethod
+    def _eval_node_options(cls, node):
+        opt = node.attrib.get("options") or {}
+        if isinstance(opt, str):
+            return safe_eval(opt, cls._get_node_options_eval_context(), nocopy=True)
         return {}
+
+    @classmethod
+    def _get_node_options_eval_context(cls):
+        eval_ctx = dict(cls.env.context or [])
+        eval_ctx.update({"context": dict(eval_ctx), "true": True, "false": False})
+        return eval_ctx
 
     @classmethod
     def _get_test_view(cls):


### PR DESCRIPTION
``safe_eval()`` raises a ``ValueError`` when evaluating ``node`` options containing boolean values written in lowercase (`true` or `false`).

Fixes
```
ValueError: <class 'NameError'>: "name 'true' is not defined" while evaluating
"{'<option_name>': [true|false}"
```