### PR TITLE
[16.0][FIX] web_group_by_percentage: Added exclusion of non-field columns

### DIFF
--- a/web_group_by_percentage/static/src/js/backend.esm.js
+++ b/web_group_by_percentage/static/src/js/backend.esm.js
@@ -18,7 +18,7 @@ patch(ListRenderer.prototype, "list_group_by_percentage", {
 
         if (list.isGrouped) {
             for (var column of columns) {
-                if (!this.isNumericColumn(column)) continue;
+                if (column.type != "field" || !this.isNumericColumn(column)) continue;
 
                 column.totalSum = 0;
                 for (var group of list.groups) {


### PR DESCRIPTION
In some list/tree views, there are non-field columns, for instance buttons to handle an action on a group of lines. Consequently, with this module installed, it's impossible to group lines in certain views, if the grouped view has a button, as using isNumericColumn, which tries to access the column in the view's fields, throws an Exception.

As such, we exclude non-field columns from the computation of grouped columns percentages.