### PR TITLE
[FIX] web_domain_field: Accept empty domain

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo_test_helper

--- a/web_domain_field/README.rst
+++ b/web_domain_field/README.rst
@@ -116,6 +116,9 @@ Contributors
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Denis Roussel <denis.roussel@acsone.eu>
 * Raf Ven <raf.ven@dynapps.be>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/web_domain_field/__manifest__.py
+++ b/web_domain_field/__manifest__.py
@@ -11,6 +11,8 @@
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",
     "depends": ["web"],
-    "data": ["views/web_domain_field.xml"],
+    "data": [
+        "views/web_domain_field.xml",
+    ],
     "installable": True,
 }

--- a/web_domain_field/readme/CONTRIBUTORS.rst
+++ b/web_domain_field/readme/CONTRIBUTORS.rst
@@ -1,3 +1,6 @@
 * Laurent Mignon <laurent.mignon@acsone.eu>
 * Denis Roussel <denis.roussel@acsone.eu>
 * Raf Ven <raf.ven@dynapps.be>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/web_domain_field/static/description/index.html
+++ b/web_domain_field/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -429,7 +429,7 @@ view.</p>
 </span><span class="p">)</span><span class="w">
 
 </span><span class="nd">&#64;api</span><span class="o">.</span><span class="n">depends</span><span class="p">(</span><span class="s1">'name'</span><span class="p">)</span><span class="w">
-</span><span class="k">def</span> <span class="nf">_compute_product_id_domain</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span><span class="w">
+</span><span class="k">def</span><span class="w"> </span><span class="nf">_compute_product_id_domain</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span><span class="w">
 </span>    <span class="k">for</span> <span class="n">rec</span> <span class="ow">in</span> <span class="bp">self</span><span class="p">:</span><span class="w">
 </span>        <span class="n">rec</span><span class="o">.</span><span class="n">product_id_domain</span> <span class="o">=</span> <span class="n">json</span><span class="o">.</span><span class="n">dumps</span><span class="p">(</span><span class="w">
 </span>            <span class="p">[(</span><span class="s1">'type'</span><span class="p">,</span> <span class="s1">'='</span><span class="p">,</span> <span class="s1">'product'</span><span class="p">),</span> <span class="p">(</span><span class="s1">'name'</span><span class="p">,</span> <span class="s1">'like'</span><span class="p">,</span> <span class="n">rec</span><span class="o">.</span><span class="n">name</span><span class="p">)]</span><span class="w">
@@ -458,12 +458,18 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</li>
 <li>Denis Roussel &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
 <li>Raf Ven &lt;<a class="reference external" href="mailto:raf.ven&#64;dynapps.be">raf.ven&#64;dynapps.be</a>&gt;</li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/web_domain_field/static/lib/js/pyeval.js
+++ b/web_domain_field/static/lib/js/pyeval.js
@@ -154,7 +154,7 @@ odoo.define('web.domain_field', function (require) {
                 // Modified part or the original method
                 if (domain in evaluation_context) {
                     result_domain.push.apply(
-                        result_domain, $.parseJSON(evaluation_context[domain]));
+                        result_domain, $.parseJSON(evaluation_context[domain]) || []);
                     return;
                 }
                 // End of modifications

--- a/web_domain_field/static/tests/tours/false_domain.js
+++ b/web_domain_field/static/tests/tours/false_domain.js
@@ -1,0 +1,31 @@
+odoo.define("web_domain_field.false_domain_tour", function (require) {
+    "use strict";
+
+    var tour = require("web_tour.tour");
+
+    tour.register(
+        "web_domain_field.false_domain_tour",
+        {
+            test: true,
+            url: "/web",
+        },
+        [
+            tour.stepUtils.showAppsMenuItem(),
+            {
+                content: "Go to Fake Model menu",
+                trigger: '.o_app[data-menu-xmlid="web_domain_field.fake_model_menu"]',
+                run: "click",
+            },
+            {
+                content: "Create a new record",
+                trigger: "button.o_list_button_add",
+                run: "click",
+            },
+            {
+                content: "Click on partner label (opens dropdown)",
+                trigger: "div.o_form_sheet label:contains('Partner')",
+                run: "click",
+            },
+        ]
+    );
+});

--- a/web_domain_field/tests/__init__.py
+++ b/web_domain_field/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_domain_field

--- a/web_domain_field/tests/fake_model_views.xml
+++ b/web_domain_field/tests/fake_model_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    ~ Copyright 2025 Simone Rubino - PyTech
+    ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="fake_model_form_view" model="ir.ui.view">
+        <field name="name">Form view for fake model</field>
+        <field name="model">web_domain_field.fake.model</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="partner_id_false_domain" invisible="True" />
+                        <field name="partner_id" domain="partner_id_false_domain" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="fake_model_action" model="ir.actions.act_window">
+        <field name="name">Fake Model action</field>
+        <field name="res_model">web_domain_field.fake.model</field>
+        <field name="view_mode">list,form</field>
+    </record>
+
+    <menuitem id="fake_model_menu" action="fake_model_action" />
+</odoo>

--- a/web_domain_field/tests/ir.model.access.csv
+++ b/web_domain_field/tests/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+full_access,Full Access,model_web_domain_field_fake_model,,1,1,1,1

--- a/web_domain_field/tests/models.py
+++ b/web_domain_field/tests/models.py
@@ -1,0 +1,22 @@
+# Copyright 2025 Simone Rubino - PyTech
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class FakeModel(models.Model):
+    _name = "web_domain_field.fake.model"
+    _description = "Fake model for testing web_domain_field"
+
+    partner_id_false_domain = fields.Char(
+        compute="_compute_partner_id_false_domain",
+        readonly=True,
+        store=False,
+    )
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+    )
+
+    def _compute_partner_id_false_domain(self):
+        for record in self:
+            record.partner_id_false_domain = False

--- a/web_domain_field/tests/test_domain_field.py
+++ b/web_domain_field/tests/test_domain_field.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Simone Rubino - PyTech
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo_test_helper import FakeModelLoader
+
+from odoo import tests, tools
+from odoo.modules.module import get_resource_path
+
+
+@tests.tagged("post_install", "-at_install")
+class TestDomainField(tests.HttpSavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+
+        from .models import FakeModel
+
+        cls.loader.update_registry((FakeModel,))
+        tools.convert_file(
+            cls.env.cr,
+            "web_domain_field",
+            get_resource_path("web_domain_field", "tests", "fake_model_views.xml"),
+            {},
+            kind="test",
+        )
+        tools.convert_file(
+            cls.env.cr,
+            "web_domain_field",
+            get_resource_path("web_domain_field", "tests", "ir.model.access.csv"),
+            {},
+            kind="test",
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()
+
+    def test_false_domain(self):
+        self.start_tour("/web", "web_domain_field.false_domain_tour", login="admin")

--- a/web_domain_field/views/web_domain_field.xml
+++ b/web_domain_field/views/web_domain_field.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
+<!--
+    ~ Copyright 2025 Simone Rubino - PyTech
+    ~ License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
 <odoo>
     <template
         id="assets_backend"
@@ -9,6 +13,15 @@
             <script
                 type="text/javascript"
                 src="/web_domain_field/static/lib/js/pyeval.js"
+            />
+        </xpath>
+    </template>
+
+    <template id="assets_tests" inherit_id="web.assets_tests">
+        <xpath expr="." position="inside">
+            <script
+                type="text/javascript"
+                src="/web_domain_field/static/tests/tours/false_domain.js"
             />
         </xpath>
     </template>


### PR DESCRIPTION
**Steps**:
1. Create a domain field that contains `False`
2. Associate the created field to a relational field
3. In a form view, open the dropdown of the filtered relational field

**Before this change**:
The following client error is raised:
> Error: second argument to Function.prototype.apply must be an array
eval_domains/<@https://domain.com/web_domain_field/static/lib/js/pyeval.js:156:40 [...]

**After this change**:
All the records can be selected

**Additional context**:
Fixes https://github.com/OCA/web/issues/882 that is closed because stale, not because it is fixed.

~~I struggled to add a test that fails without this change (as the UI does), but failed: the added test succeeds without this change too.
If anyone can help make the test fail without this change, it is much appreciated! Otherwise, at least we have added a test to the module.~~
The added test fails without this change.
For anyone who is interested: `click`ing on the dropdown does not open it, but `click`ing on the field label does.