### PR TITLE
[18.0][FIX] web_widget_x2many_2d_matrix: fix sticky header/column overlap

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.scss
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.scss
@@ -16,6 +16,7 @@ $x2many_2d_matrix_max_height: 450px;
             position: sticky;
             top: 0;
             z-index: 1;
+            background-color: $o-gray-100;
 
             &.total {
                 right: 0;
@@ -40,7 +41,9 @@ $x2many_2d_matrix_max_height: 450px;
                         border-right-width: 1px;
                         border-right-color: $gray-300;
                         border-right-style: solid;
+                        background-color: $o-view-background-color;
                     }
+
                     &.row-total {
                         padding: 0.5rem 0.75rem;
                         font-weight: bold;
@@ -49,6 +52,7 @@ $x2many_2d_matrix_max_height: 450px;
                         border-left-width: 1px;
                         border-left-color: $gray-300;
                         border-left-style: solid;
+                        background-color: $o-view-background-color;
                     }
                 }
             }
@@ -58,6 +62,7 @@ $x2many_2d_matrix_max_height: 450px;
             text-align: right;
             position: sticky;
             bottom: 0;
+            background-color: $o-gray-100;
 
             &.col-total {
                 padding: 0.75rem;


### PR DESCRIPTION
**Problem:**
When scrolling in the matrix widget, the content overlaps with the sticky headers (days), footers (totals), and the first column (names) because they are transparent by default.
<img width="1261" height="669" alt="image" src="https://github.com/user-attachments/assets/1218dea2-cf6d-4fd6-9c3d-2b5099708f5a" />
<img width="1213" height="689" alt="image" src="https://github.com/user-attachments/assets/73fca229-57bc-4417-b8fe-6d53b873c95d" />


**Solution:**
Added a background colour to all `position: sticky` elements in the `web_widget_x2many_2d_matrix` SCSS to ensure they properly hide the scrolling content behind them. Used standard Odoo colour variables (`$o-gray-100` and `$o-view-background-color`) for consistency.
<img width="1259" height="730" alt="image" src="https://github.com/user-attachments/assets/23d9fcee-9797-4605-be58-2a69a0e0b480" />

