### PR TITLE
DRAFT: Allow M2M items to appear multiple times in timeline

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -100,7 +100,6 @@ export class TimelineController extends Component {
      * @returns {Object}
      */
     _onUpdate(item) {
-
         const item_id =
             typeof item.evt.id === "string" && item.evt.id.indexOf("_") !== -1
                 ? Number(item.evt.id.split("_")[0]) || item.evt.id.split("_")[0]

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -80,15 +80,11 @@ export class TimelineController extends Component {
      * @returns {jQuery.Deferred}
      */
     _onItemDoubleClick(event) {
-        // Resume thought here tommorrow... Do we need to parse the id here?
-        console.log("Double click event", event);   
-
         const item_id = typeof event.item === 'string' && event.item.indexOf('_') !== -1
             ? Number(event.item.split('_')[0]) || event.item.split('_')[0]
             : Number(event.item) || event.item;
         
         event.item = item_id;  // Update event item to be just the ID
-        console.log("Parsed item_id:", event);
 
         return this.openItem(event.item, false);
     }

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -80,9 +80,10 @@ export class TimelineController extends Component {
      * @returns {jQuery.Deferred}
      */
     _onItemDoubleClick(event) {
-        const item_id = typeof event.item === 'string' && event.item.indexOf('_') !== -1
-            ? Number(event.item.split('_')[0]) || event.item.split('_')[0]
-            : Number(event.item) || event.item;
+        const item_id = 
+            typeof event.item === 'string' && event.item.indexOf('_') !== -1
+                ? Number(event.item.split('_')[0]) || event.item.split('_')[0]
+                : Number(event.item) || event.item;
 
         // Update event item to be just the ID
         event.item = item_id;  
@@ -100,9 +101,10 @@ export class TimelineController extends Component {
      */
     _onUpdate(item) {
 
-        const item_id = typeof item.evt.id === 'string' && item.evt.id.indexOf('_') !== -1
-            ? Number(item.evt.id.split('_')[0]) || item.evt.id.split('_')[0]
-            : Number(item.evt.id) || item.evt.id;
+        const item_id = 
+            typeof item.evt.id === 'string' && item.evt.id.indexOf('_') !== -1
+                ? Number(item.evt.id.split('_')[0]) || item.evt.id.split('_')[0]
+                : Number(item.evt.id) || item.evt.id;
         return this.openItem(item_id, true);
     }
 

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -87,7 +87,6 @@ export class TimelineController extends Component {
 
         // Update event item to be just the ID
         event.item = item_id;
-
         return this.openItem(event.item, false);
     }
 
@@ -112,6 +111,12 @@ export class TimelineController extends Component {
      * @param {Boolean} is_editable
      */
     openItem(item_id, is_editable) {
+        const _id =
+            typeof item_id === "string" && item_id.indexOf("_") !== -1
+                ? Number(item_id.split("_")[0]) || item_id.split("_")[0]
+                : Number(item_id) || item_id;
+        item_id = _id;
+
         if (this.open_popup_action) {
             const options = {
                 resModel: this.model.model_name,
@@ -254,7 +259,12 @@ export class TimelineController extends Component {
             context[`default_${this.date_delay}`] = diff.hours;
         }
         if (item.group > 0) {
-            context[`default_${this.model.last_group_bys[0]}`] = item.group;
+            if (this.model.fields[this.model.last_group_bys[0]].type !== "many2many") {
+                context[`default_${this.model.last_group_bys[0]}`] = item.group;
+            }
+            else {
+                context[`default_${this.model.last_group_bys[0]}`] = [item.group];
+            }
         }
         // Show popup
         this.dialogService.add(

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -80,13 +80,13 @@ export class TimelineController extends Component {
      * @returns {jQuery.Deferred}
      */
     _onItemDoubleClick(event) {
-        const item_id = 
+        const item_id =
             typeof event.item === 'string' && event.item.indexOf('_') !== -1
                 ? Number(event.item.split('_')[0]) || event.item.split('_')[0]
                 : Number(event.item) || event.item;
 
         // Update event item to be just the ID
-        event.item = item_id;  
+        event.item = item_id;
 
         return this.openItem(event.item, false);
     }
@@ -101,7 +101,7 @@ export class TimelineController extends Component {
      */
     _onUpdate(item) {
 
-        const item_id = 
+        const item_id =
             typeof item.evt.id === 'string' && item.evt.id.indexOf('_') !== -1
                 ? Number(item.evt.id.split('_')[0]) || item.evt.id.split('_')[0]
                 : Number(item.evt.id) || item.evt.id;

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -80,6 +80,16 @@ export class TimelineController extends Component {
      * @returns {jQuery.Deferred}
      */
     _onItemDoubleClick(event) {
+        // Resume thought here tommorrow... Do we need to parse the id here?
+        console.log("Double click event", event);   
+
+        const item_id = typeof event.item === 'string' && event.item.indexOf('_') !== -1
+            ? Number(event.item.split('_')[0]) || event.item.split('_')[0]
+            : Number(event.item) || event.item;
+        
+        event.item = item_id;  // Update event item to be just the ID
+        console.log("Parsed item_id:", event);
+
         return this.openItem(event.item, false);
     }
 
@@ -92,7 +102,13 @@ export class TimelineController extends Component {
      * @returns {Object}
      */
     _onUpdate(item) {
-        const item_id = Number(item.evt.id) || item.evt.id;
+
+        if (typeof item.evt.id === 'string' && item.evt.id.indexOf('_') !== -1) {
+            const item_id = item.evt.id.split('_')[0]
+        }
+        else {
+            const item_id = Number(item.evt.id) || item.evt.id;
+        }
         return this.openItem(item_id, true);
     }
 

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -83,8 +83,9 @@ export class TimelineController extends Component {
         const item_id = typeof event.item === 'string' && event.item.indexOf('_') !== -1
             ? Number(event.item.split('_')[0]) || event.item.split('_')[0]
             : Number(event.item) || event.item;
-        
-        event.item = item_id;  // Update event item to be just the ID
+
+        // Update event item to be just the ID
+        event.item = item_id;  
 
         return this.openItem(event.item, false);
     }
@@ -99,12 +100,9 @@ export class TimelineController extends Component {
      */
     _onUpdate(item) {
 
-        if (typeof item.evt.id === 'string' && item.evt.id.indexOf('_') !== -1) {
-            const item_id = item.evt.id.split('_')[0]
-        }
-        else {
-            const item_id = Number(item.evt.id) || item.evt.id;
-        }
+        const item_id = typeof item.evt.id === 'string' && item.evt.id.indexOf('_') !== -1
+            ? Number(item.evt.id.split('_')[0]) || item.evt.id.split('_')[0]
+            : Number(item.evt.id) || item.evt.id;
         return this.openItem(item_id, true);
     }
 

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -81,8 +81,8 @@ export class TimelineController extends Component {
      */
     _onItemDoubleClick(event) {
         const item_id =
-            typeof event.item === 'string' && event.item.indexOf('_') !== -1
-                ? Number(event.item.split('_')[0]) || event.item.split('_')[0]
+            typeof event.item === "string" && event.item.indexOf("_") !== -1
+                ? Number(event.item.split("_")[0]) || event.item.split("_")[0]
                 : Number(event.item) || event.item;
 
         // Update event item to be just the ID
@@ -102,8 +102,8 @@ export class TimelineController extends Component {
     _onUpdate(item) {
 
         const item_id =
-            typeof item.evt.id === 'string' && item.evt.id.indexOf('_') !== -1
-                ? Number(item.evt.id.split('_')[0]) || item.evt.id.split('_')[0]
+            typeof item.evt.id === "string" && item.evt.id.indexOf("_") !== -1
+                ? Number(item.evt.id.split("_")[0]) || item.evt.id.split("_")[0]
                 : Number(item.evt.id) || item.evt.id;
         return this.openItem(item_id, true);
     }

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -261,8 +261,7 @@ export class TimelineController extends Component {
         if (item.group > 0) {
             if (this.model.fields[this.model.last_group_bys[0]].type !== "many2many") {
                 context[`default_${this.model.last_group_bys[0]}`] = item.group;
-            }
-            else {
+            } else {
                 context[`default_${this.model.last_group_bys[0]}`] = [item.group];
             }
         }

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -33,18 +33,18 @@ export class TimelineModel extends Model {
         onWillStart(async () => {
             this.write_right = await this.orm.call(
                 this.model_name,
-                "check_access",
-                ["", 'write']
+                "check_access_rights",
+                ["write", false]
             );
             this.unlink_right = await this.orm.call(
                 this.model_name,
-                "check_access",
-                ["", 'unlink']
+                "check_access_rights",
+                ["unlink", false]
             );
             this.create_right = await this.orm.call(
                 this.model_name,
-                "check_access",
-                ["", 'create']
+                "check_access_rights",
+                ["create", false]
             );
         });
     }

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -90,10 +90,11 @@ export class TimelineModel extends Model {
         const [date_start, date_stop] = this._get_event_dates(record);
         const group = record[this.last_group_bys[0]];
         let groups = [];
-        if (group &&
+        if (
+            group &&
             Array.isArray(group) &&
             group.length === 2 &&
-            typeof group[1] === 'string'
+            typeof group[1] === "string"
         ) {
             // TODO: this breaks if m2m and only 2 items
             //  I guess detect if its a number/id or array of ids
@@ -105,10 +106,10 @@ export class TimelineModel extends Model {
             groups = [-1];
         }
         
-        // eslint-disable-next-line prefer-const
+        // eslint-disable-next-line prefer-constd
         let all_timeline_items = [];
 
-        for (const this_group of groups) {  
+        for (const this_group of groups) {
             let colorToApply = false;
             for (const color of this.colors) {
                 if (evaluate(color.ast, record)) {
@@ -217,8 +218,8 @@ export class TimelineModel extends Model {
     async remove_completed(event) {
 
         const item_id =
-            typeof event.evt.id === 'string' && event.evt.id.indexOf('_') !== -1
-                ? Number(event.evt.id.split('_')[0]) || event.evt.id.split('_')[0]
+            typeof event.evt.id === "string" && event.evt.id.indexOf("_") !== -1
+                ? Number(event.evt.id.split("_")[0]) || event.evt.id.split("_")[0]
                 : Number(event.evt.id) || event.evt.id;
 
         await this.orm.call(this.model_name, "unlink", [[item_id]]);

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -106,7 +106,7 @@ export class TimelineModel extends Model {
             groups = [-1];
         }
         
-        // eslint-disable-next-line prefer-constd
+        // eslint-disable-next-line prefer-const
         let all_timeline_items = [];
 
         for (const this_group of groups) {

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -64,7 +64,7 @@ export class TimelineModel extends Model {
         // because it is not supported by Odoo
         // In the module sale_timesheet_timeline, it is used
         // with default_group_by = task_user_ids
-        let field_to_order = this.params.default_group_by;
+        const field_to_order = this.params.default_group_by;
         // if (this.fields[field_to_order].type === "many2many") {
         //     field_to_order = undefined;
         // }
@@ -88,12 +88,13 @@ export class TimelineModel extends Model {
     _event_data_transform(record) {
 
         const [date_start, date_stop] = this._get_event_dates(record);
-        let group = record[this.last_group_bys[0]];
+        const group = record[this.last_group_bys[0]];
         let groups = [];
-        if (group && Array.isArray(group) && group.length === 2) {
+        if (group && Array.isArray(group) && group.length === 2 && typeof group[1] === 'string') {
+            // TODO: this breaks if m2m and only 2 items
+            //  I guess detect if its a number/id or array of ids
             groups.push(group[0]);
-        }
-        else{
+        } else{
             groups = group || -1;
         }
         if (groups.length === 0) {
@@ -118,7 +119,7 @@ export class TimelineModel extends Model {
             const timeline_item = {
                 start: date_start.toJSDate(),
                 content: content,
-                id: record.id + (this_group ? `_${this_group}` : ''),
+                id: record.id + (this_group ? `_${this_group}` : ""),
                 order: record.order,
                 group: this_group,
                 evt: record,
@@ -126,7 +127,10 @@ export class TimelineModel extends Model {
             };
             // Only specify range end when there actually is one.
             // ➔ Instantaneous events / those with inverted dates are displayed as points.
-            if (date_stop && DateTime.fromISO(date_start) < DateTime.fromISO(date_stop)) {
+            if (
+                date_stop && 
+                DateTime.fromISO(date_start) < DateTime.fromISO(date_stop)
+            ) {
                 timeline_item.end = date_stop.toJSDate();
             }
             all_timeline_items.push(timeline_item);
@@ -207,9 +211,10 @@ export class TimelineModel extends Model {
      */
     async remove_completed(event) {
 
-        const item_id = typeof event.evt.id === 'string' && event.evt.id.indexOf('_') !== -1
-            ? Number(event.evt.id.split('_')[0]) || event.evt.id.split('_')[0]
-            : Number(event.evt.id) || event.evt.id;
+        const item_id = 
+            typeof event.evt.id === 'string' && event.evt.id.indexOf('_') !== -1
+                ? Number(event.evt.id.split('_')[0]) || event.evt.id.split('_')[0]
+                : Number(event.evt.id) || event.evt.id;
 
         await this.orm.call(this.model_name, "unlink", [[item_id]]);
         const unlink_index = this.data.findIndex((item) => item.id === item_id);

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -65,9 +65,9 @@ export class TimelineModel extends Model {
         // In the module sale_timesheet_timeline, it is used
         // with default_group_by = task_user_ids
         let field_to_order = this.params.default_group_by;
-        if (this.fields[field_to_order].type === "many2many") {
-            field_to_order = undefined;
-        }
+        // if (this.fields[field_to_order].type === "many2many") {
+        //     field_to_order = undefined;
+        // }
         this.data = await this.keepLast.add(
             this.orm.call(this.model_name, "search_read", [], {
                 fields: fields,
@@ -86,40 +86,56 @@ export class TimelineModel extends Model {
      * @returns {Object}
      */
     _event_data_transform(record) {
+
+        console.log("Transforming event data:", record);
         const [date_start, date_stop] = this._get_event_dates(record);
         let group = record[this.last_group_bys[0]];
-        if (group && Array.isArray(group) && group.length > 0) {
-            group = group[0];
-        } else {
-            group = -1;
+        let groups = [];
+        if (group && Array.isArray(group) && group.length === 2) {
+            // Issue is right here for many to many. Need to return multiple timeline items.
+            groups.push(group[0]);
         }
-        let colorToApply = false;
-        for (const color of this.colors) {
-            if (evaluate(color.ast, record)) {
-                colorToApply = color.color;
+        else{
+            groups = group || -1;
+        }
+        if (groups.length === 0) {
+            groups = [-1];
+        }
+        
+        let all_timeline_items = [];
+        console.log("Determined groups for record:", groups);
+        for (const this_group of groups) {  
+            console.log("Processing group for record:", this_group);
+            let colorToApply = false;
+            for (const color of this.colors) {
+                if (evaluate(color.ast, record)) {
+                    colorToApply = color.color;
+                }
             }
-        }
 
-        let content = record.display_name;
-        if (this.recordTemplate) {
-            content = this._render_timeline_item(record);
-        }
+            let content = record.display_name;
+            if (this.recordTemplate) {
+                content = this._render_timeline_item(record);
+            }
 
-        const timeline_item = {
-            start: date_start.toJSDate(),
-            content: content,
-            id: record.id,
-            order: record.order,
-            group: group,
-            evt: record,
-            style: `background-color: ${colorToApply};`,
-        };
-        // Only specify range end when there actually is one.
-        // ➔ Instantaneous events / those with inverted dates are displayed as points.
-        if (date_stop && DateTime.fromISO(date_start) < DateTime.fromISO(date_stop)) {
-            timeline_item.end = date_stop.toJSDate();
+            const timeline_item = {
+                start: date_start.toJSDate(),
+                content: content,
+                id: record.id + (this_group ? `_${this_group}` : ''),
+                order: record.order,
+                group: this_group,
+                evt: record,
+                style: `background-color: ${colorToApply};`,
+            };
+            // Only specify range end when there actually is one.
+            // ➔ Instantaneous events / those with inverted dates are displayed as points.
+            if (date_stop && DateTime.fromISO(date_start) < DateTime.fromISO(date_stop)) {
+                timeline_item.end = date_stop.toJSDate();
+            }
+            all_timeline_items.push(timeline_item);
         }
-        return timeline_item;
+        console.log("Generated timeline items for record:", all_timeline_items);
+        return all_timeline_items;
     }
     /**
      * Get dates from given event

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -99,12 +99,13 @@ export class TimelineModel extends Model {
             //  I guess detect if its a number/id or array of ids
             groups.push(group[0]);
         } else {
-            groups = group || -1;
+            groups = group || [];
         }
         if (groups.length === 0) {
             groups = [-1];
         }
 
+        console.log("groups", groups);
         // eslint-disable-next-line prefer-const
         let all_timeline_items = [];
 

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -210,8 +210,16 @@ export class TimelineModel extends Model {
      * @returns {jQuery.Deferred}
      */
     async remove_completed(event) {
-        await this.orm.call(this.model_name, "unlink", [[event.evt.id]]);
-        const unlink_index = this.data.findIndex((item) => item.id === event.evt.id);
+
+        if (typeof event.evt.id === 'string' && event.evt.id.indexOf('_') !== -1) {
+            const item_id = event.evt.id.split('_')[0]
+        }
+        else {
+            const item_id = Number(event.evt.id) || event.evt.id;
+        }
+
+        await this.orm.call(this.model_name, "unlink", [[item_id]]);
+        const unlink_index = this.data.findIndex((item) => item.id === item_id);
         if (unlink_index !== -1) {
             this.data.splice(unlink_index, 1);
         }

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -207,12 +207,9 @@ export class TimelineModel extends Model {
      */
     async remove_completed(event) {
 
-        if (typeof event.evt.id === 'string' && event.evt.id.indexOf('_') !== -1) {
-            const item_id = event.evt.id.split('_')[0]
-        }
-        else {
-            const item_id = Number(event.evt.id) || event.evt.id;
-        }
+        const item_id = typeof event.evt.id === 'string' && event.evt.id.indexOf('_') !== -1
+            ? Number(event.evt.id.split('_')[0]) || event.evt.id.split('_')[0]
+            : Number(event.evt.id) || event.evt.id;
 
         await this.orm.call(this.model_name, "unlink", [[item_id]]);
         const unlink_index = this.data.findIndex((item) => item.id === item_id);

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -65,7 +65,7 @@ export class TimelineModel extends Model {
         // In the module sale_timesheet_timeline, it is used
         // with default_group_by = task_user_ids
         const field_to_order = this.params.default_group_by;
-        // if (this.fields[field_to_order].type === "many2many") {
+        // If (this.fields[field_to_order].type === "many2many") {
         //     field_to_order = undefined;
         // }
         this.data = await this.keepLast.add(
@@ -90,17 +90,22 @@ export class TimelineModel extends Model {
         const [date_start, date_stop] = this._get_event_dates(record);
         const group = record[this.last_group_bys[0]];
         let groups = [];
-        if (group && Array.isArray(group) && group.length === 2 && typeof group[1] === 'string') {
+        if (group &&
+            Array.isArray(group) &&
+            group.length === 2 &&
+            typeof group[1] === 'string'
+        ) {
             // TODO: this breaks if m2m and only 2 items
             //  I guess detect if its a number/id or array of ids
             groups.push(group[0]);
-        } else{
+        } else {
             groups = group || -1;
         }
         if (groups.length === 0) {
             groups = [-1];
         }
         
+        // eslint-disable-next-line prefer-const
         let all_timeline_items = [];
 
         for (const this_group of groups) {  
@@ -128,7 +133,7 @@ export class TimelineModel extends Model {
             // Only specify range end when there actually is one.
             // ➔ Instantaneous events / those with inverted dates are displayed as points.
             if (
-                date_stop && 
+                date_stop &&
                 DateTime.fromISO(date_start) < DateTime.fromISO(date_stop)
             ) {
                 timeline_item.end = date_stop.toJSDate();
@@ -211,7 +216,7 @@ export class TimelineModel extends Model {
      */
     async remove_completed(event) {
 
-        const item_id = 
+        const item_id =
             typeof event.evt.id === 'string' && event.evt.id.indexOf('_') !== -1
                 ? Number(event.evt.id.split('_')[0]) || event.evt.id.split('_')[0]
                 : Number(event.evt.id) || event.evt.id;

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -33,18 +33,18 @@ export class TimelineModel extends Model {
         onWillStart(async () => {
             this.write_right = await this.orm.call(
                 this.model_name,
-                "check_access_rights",
-                ["write", false]
+                "check_access",
+                ["", 'write']
             );
             this.unlink_right = await this.orm.call(
                 this.model_name,
-                "check_access_rights",
-                ["unlink", false]
+                "check_access",
+                ["", 'unlink']
             );
             this.create_right = await this.orm.call(
                 this.model_name,
-                "check_access_rights",
-                ["create", false]
+                "check_access",
+                ["", 'create']
             );
         });
     }

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -87,12 +87,10 @@ export class TimelineModel extends Model {
      */
     _event_data_transform(record) {
 
-        console.log("Transforming event data:", record);
         const [date_start, date_stop] = this._get_event_dates(record);
         let group = record[this.last_group_bys[0]];
         let groups = [];
         if (group && Array.isArray(group) && group.length === 2) {
-            // Issue is right here for many to many. Need to return multiple timeline items.
             groups.push(group[0]);
         }
         else{
@@ -103,9 +101,8 @@ export class TimelineModel extends Model {
         }
         
         let all_timeline_items = [];
-        console.log("Determined groups for record:", groups);
+
         for (const this_group of groups) {  
-            console.log("Processing group for record:", this_group);
             let colorToApply = false;
             for (const color of this.colors) {
                 if (evaluate(color.ast, record)) {
@@ -134,7 +131,6 @@ export class TimelineModel extends Model {
             }
             all_timeline_items.push(timeline_item);
         }
-        console.log("Generated timeline items for record:", all_timeline_items);
         return all_timeline_items;
     }
     /**

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -86,7 +86,6 @@ export class TimelineModel extends Model {
      * @returns {Object}
      */
     _event_data_transform(record) {
-
         const [date_start, date_stop] = this._get_event_dates(record);
         const group = record[this.last_group_bys[0]];
         let groups = [];
@@ -105,7 +104,7 @@ export class TimelineModel extends Model {
         if (groups.length === 0) {
             groups = [-1];
         }
-        
+
         // eslint-disable-next-line prefer-const
         let all_timeline_items = [];
 
@@ -216,7 +215,6 @@ export class TimelineModel extends Model {
      * @returns {jQuery.Deferred}
      */
     async remove_completed(event) {
-
         const item_id =
             typeof event.evt.id === "string" && event.evt.id.indexOf("_") !== -1
                 ? Number(event.evt.id.split("_")[0]) || event.evt.id.split("_")[0]

--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -336,7 +336,7 @@ export class TimelineRenderer extends Component {
             }
         }
 
-        const groups = await this.split_groups(records); // I don't like this functionality
+        const groups = await this.split_groups(records); 
         this.timeline.setGroups(groups);
         this.timeline.setItems(data);
         const mode = !this.mode.data || this.mode.data === "fit";

--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -336,7 +336,7 @@ export class TimelineRenderer extends Component {
             }
         }
 
-        const groups = await this.split_groups(records); 
+        const groups = await this.split_groups(records);
         this.timeline.setGroups(groups);
         this.timeline.setItems(data);
         const mode = !this.mode.data || this.mode.data === "fit";

--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -429,6 +429,8 @@ export class TimelineRenderer extends Component {
      * @private
      */
     on_timeline_double_click(e) {
+        // Fun Fact: this function never gets called.
+        // On_timeline_click fires twice but this never does.
         if (e.what === "item" && e.item !== -1) {
             this.props.onItemDoubleClick(e);
         }

--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -326,13 +326,17 @@ export class TimelineRenderer extends Component {
      * @private
      */
     async on_data_loaded(records, adjust_window) {
-        const data = [];
+        let data = []; // Changed to non const to allow concat
+
         for (const record of records) {
             if (record[this.date_start]) {
-                data.push(this.model._event_data_transform(record));
+                // Change here to allow multiple items per record
+                // Does this make the get_m2m_grouping_datas function obsolete?
+                data = data.concat(this.model._event_data_transform(record));
             }
         }
-        const groups = await this.split_groups(records);
+
+        const groups = await this.split_groups(records); // I don't like this functionality
         this.timeline.setGroups(groups);
         this.timeline.setItems(data);
         const mode = !this.mode.data || this.mode.data === "fit";


### PR DESCRIPTION
Allows events to appear multiple times in web timelines. Open to Conversation here, as I modify the ID to be <id>_<group_id> to allow unique item ids to keep the library happy, then on events parse it back down to <id>.

Going to keep testing, opening PR for conversation.

I believe this would close #3341

<img width="366" height="239" alt="image" src="https://github.com/user-attachments/assets/129374a7-2f14-4a8e-9cc0-ee21af652c05" />
