### PR TITLE
[18.0][FIX] web_notify_channel_message

### DIFF
--- a/web_notify_channel_message/models/res_users.py
+++ b/web_notify_channel_message/models/res_users.py
@@ -1,13 +1,15 @@
 from odoo import models
 
+from odoo.addons.web_notify.models.res_users import DEFAULT, DEFAULT_MESSAGE
+
 
 class ResUsers(models.Model):
     _inherit = "res.users"
 
     def _notify_channel(
         self,
-        type_message="default",
-        message="Default message",
+        type_message=DEFAULT,
+        message=DEFAULT_MESSAGE,
         title=None,
         sticky=False,
         target=None,


### PR DESCRIPTION
If other user than the admin is trying to send a message to a channel it will show an error message. Sending it as sudo solves the problem and makes sense that in this case you will always want to send the notification.