### PR TITLE
[18.0][IMP] web_tree_dynamic_colored_field: dynamic color based on other field's value in list view

### DIFF
--- a/web_tree_dynamic_colored_field/README.rst
+++ b/web_tree_dynamic_colored_field/README.rst
@@ -124,6 +124,24 @@ Example:
 the options doesn't follow the JSON format, the options string will be
 evaluated using py.eval()**
 
+- You can use another field's label referring to a color too... In the
+  tree view declaration, put
+  ``options="{'fg_color': 'my_other_color_field'}"`` attribute in the
+  ``field`` tag:
+
+  ::
+
+     ...
+     <field name="arch" type="xml">
+         <tree string="View name">
+             ...
+             <field name="my_other_color_field" column_invisible="True"/>
+             <field name="name" options="{'fg_color': 'my_other_color_field'}"/>
+             ...
+         </tree>
+     </field>
+     ...
+
 Known issues / Roadmap
 ======================
 

--- a/web_tree_dynamic_colored_field/readme/USAGE.md
+++ b/web_tree_dynamic_colored_field/readme/USAGE.md
@@ -68,3 +68,18 @@ Example:
 **Note that you can use single or normal quotes. If the declaration of
 the options doesn't follow the JSON format, the options string will be
 evaluated using py.eval()**
+
+- You can use another field's label referring to a color too... In the tree view declaration, put
+  `options="{'fg_color': 'my_other_color_field'}"`
+  attribute in the `field` tag:
+
+      ...
+      <field name="arch" type="xml">
+          <tree string="View name">
+              ...
+              <field name="my_other_color_field" column_invisible="True"/>
+              <field name="name" options="{'fg_color': 'my_other_color_field'}"/>
+              ...
+          </tree>
+      </field>
+      ...

--- a/web_tree_dynamic_colored_field/static/description/index.html
+++ b/web_tree_dynamic_colored_field/static/description/index.html
@@ -465,6 +465,25 @@ attribute in the <tt class="docutils literal">field</tt> tag:</p>
 <p><strong>Note that you can use single or normal quotes. If the declaration of
 the options doesn’t follow the JSON format, the options string will be
 evaluated using py.eval()</strong></p>
+<ul>
+<li><p class="first">You can use another field’s label referring to a color too… In the
+tree view declaration, put
+<tt class="docutils literal"><span class="pre">options=&quot;{'fg_color':</span> <span class="pre">'my_other_color_field'}&quot;</span></tt> attribute in the
+<tt class="docutils literal">field</tt> tag:</p>
+<pre class="literal-block">
+...
+&lt;field name=&quot;arch&quot; type=&quot;xml&quot;&gt;
+    &lt;tree string=&quot;View name&quot;&gt;
+        ...
+        &lt;field name=&quot;my_other_color_field&quot; column_invisible=&quot;True&quot;/&gt;
+        &lt;field name=&quot;name&quot; options=&quot;{'fg_color': 'my_other_color_field'}&quot;/&gt;
+        ...
+    &lt;/tree&gt;
+&lt;/field&gt;
+...
+</pre>
+</li>
+</ul>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h2><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h2>

--- a/web_tree_dynamic_colored_field/static/src/js/list_renderer.esm.js
+++ b/web_tree_dynamic_colored_field/static/src/js/list_renderer.esm.js
@@ -54,6 +54,11 @@ patch(ListRenderer.prototype, {
                     }
                 }
             }
+            // 'definition' can be a field's label referring to a color
+            if (definition in record.data && record.data[definition]) {
+                result = record.data[definition];
+            }
+
             return result || undefined;
         }
     },


### PR DESCRIPTION
Small improvement to be able to colorized a cell in a list view based on another record's field referring to a color, like : 
`options="{'fg_color': 'my_other_color_field'}"`

cc @Kimkhoi3010 @xaviedoanhduy 