### PR TITLE
[18.0][IMP] web_widget_one2many_tree_line_duplicate: duplicate icon hideable

### DIFF
--- a/web_widget_one2many_tree_line_duplicate/static/src/list/list_renderer.esm.js
+++ b/web_widget_one2many_tree_line_duplicate/static/src/list/list_renderer.esm.js
@@ -3,19 +3,47 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
 import {ListRenderer} from "@web/views/list/list_renderer";
+import {onWillRender} from "@odoo/owl";
 import {patch} from "@web/core/utils/patch";
 import {serializeDate, serializeDateTime} from "@web/core/l10n/dates";
+import {exprToBoolean} from "@web/core/utils/strings";
+import {browser} from "@web/core/browser/browser";
 
 patch(ListRenderer.prototype, {
     setup() {
         super.setup(...arguments);
         const parent = this.__owl__.parent.parent;
-        this.displayDuplicateLine =
+        const key = this.createViewKey();
+        this.keyDuplicateLineColumn = `duplicate_line_column,${key}`;
+        this.duplicateLineAllowed =
             parent &&
             parent.props &&
             parent.props.fieldInfo &&
             parent.props.fieldInfo.options &&
             parent.props.fieldInfo.options.allow_clone;
+        this.displayDuplicateLine =
+            this.duplicateLineAllowed && this.duplicateLineColumn;
+        onWillRender(() => {
+            this.duplicateLineColumn = exprToBoolean(
+                browser.localStorage.getItem(this.keyDuplicateLineColumn),
+                false
+            );
+            this.displayDuplicateLine =
+                this.duplicateLineAllowed && this.duplicateLineColumn;
+        });
+    },
+    toggleDuplicateLineColumn() {
+        this.duplicateLineColumn = !this.duplicateLineColumn;
+        browser.localStorage.setItem(
+            this.keyDuplicateLineColumn,
+            this.duplicateLineColumn
+        );
+        this.displayDuplicateLine =
+            this.duplicateLineAllowed && this.duplicateLineColumn;
+        this.render();
+    },
+    get hasActionsColumn() {
+        return super.hasActionsColumn || Boolean(this.duplicateLineAllowed);
     },
     async onCloneIconClick(record) {
         const toSkip = this.getFieldsToSkip();

--- a/web_widget_one2many_tree_line_duplicate/static/src/list/list_renderer.xml
+++ b/web_widget_one2many_tree_line_duplicate/static/src/list/list_renderer.xml
@@ -16,6 +16,33 @@
                 style="width: 32px; min-width: 32px"
             />
         </xpath>
+        <xpath
+            expr="//div[contains(@class, 'o_optional_columns_dropdown')]//t[@t-set-slot='content']"
+            position="inside"
+        >
+            <t t-set="hasX2ManyAction" t-value="isX2Many and activeActions.create" />
+            <t t-if="hasX2ManyAction and duplicateLineAllowed">
+                <div
+                    t-if="!hasOptionalOpenFormViewColumn"
+                    role="separator"
+                    class="dropdown-divider"
+                />
+                <DropdownItem
+                    closingMode="'none'"
+                    onSelected="() => this.toggleDuplicateLineColumn()"
+                >
+                    <CheckBox
+                        onChange="() => this.toggleDuplicateLineColumn()"
+                        value="this.duplicateLineColumn"
+                        name="'Duplicate Line'"
+                    >
+                        <span class="d-flex align-items-center">
+                            <span class="text-truncate">Duplicate Line Button</span>
+                        </span>
+                    </CheckBox>
+                </DropdownItem>
+            </t>
+        </xpath>
     </t>
     <t
         t-name="web_widget_one2many_tree_line_duplicate.ListRenderer.RecordRow"
@@ -39,5 +66,4 @@
             </td>
         </xpath>
     </t>
-
 </templates>


### PR DESCRIPTION
With this improvement, users can show / hide the duplicate button when not needed, preventing accidental clicks and reducing visual clutter. Of course, the button's visibility can only be toggled if the records (lines) themselves can be duplicated. The duplication logic remains the same.

<img width="1211" height="637" alt="image" src="https://github.com/user-attachments/assets/4f7cb952-0748-4ce3-b912-0819fc2fcfc2" />
