### PR TITLE
[FIX] web_notify: Use Odoo 17 translation API

### DIFF
--- a/web_notify/static/src/js/services/notification_services.esm.js
+++ b/web_notify/static/src/js/services/notification_services.esm.js
@@ -2,12 +2,13 @@
 
 import {markup} from "@odoo/owl";
 import {browser} from "@web/core/browser/browser";
+import {_t} from "@web/core/l10n/translation";
 import {registry} from "@web/core/registry";
 
 export const webNotificationService = {
     dependencies: ["bus_service", "notification", "action"],
 
-    start(env, {bus_service, notification, action}) {
+    start(_env, {bus_service, notification, action}) {
         let webNotifTimeouts = {};
         /**
          * Displays the web notification on user's screen
@@ -26,7 +27,7 @@ export const webNotificationService = {
                             (notif.action.context && notif.action.context.params) || {};
                         buttons = [
                             {
-                                name: params.button_name || env._t("Open"),
+                                name: params.button_name || _t("Open"),
                                 primary: true,
                                 onClick: async () => {
                                     await action.doAction(notif.action);


### PR DESCRIPTION
In Odoo 17, the translation function is no longer available through env._t() but must be imported directly from @web/core/l10n/translation.

This change:
- Imports _t from @web/core/l10n/translation
- Replaces env._t("Open") with _t("Open")
- Prefixes unused env parameter with underscore