### PR TITLE
[18.0][FIX] web_timeline: Render the SVG correctly to draw dependencies properly

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_canvas.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_canvas.esm.js
@@ -10,20 +10,14 @@ export class TimelineCanvas {
     constructor(canvas_ref) {
         this.canvas_ref = canvas_ref;
     }
+
     /**
      * Clears all drawings (svg elements) from the canvas.
      */
     clear() {
-        if (this.canvas_ref) {
-            const tempElement = document.createElement("div");
-            tempElement.innerHTML = this.canvas_ref;
-            Array.from(tempElement.children).forEach((child) => {
-                if (child.tagName.toLowerCase() !== "defs") {
-                    child.remove();
-                }
-            });
-            this.canvas_ref = tempElement.innerHTML;
-        }
+        Array.from(this.canvas_ref.children)
+            .filter((el) => el.tagName.toLowerCase() !== "defs")
+            .forEach((el) => el.remove());
     }
 
     /**
@@ -158,9 +152,7 @@ export class TimelineCanvas {
         if (markerStart) {
             line.setAttribute("marker-start", `url(${markerStart})`);
         }
-        if (this.canvas_ref instanceof HTMLElement) {
-            this.canvas_ref.appendChild(line);
-        }
+        this.canvas_ref.appendChild(line);
         return line;
     }
 }

--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -34,7 +34,10 @@ export class TimelineRenderer extends Component {
         this.fields = this.params.fields;
         this.timeline = false;
         this.initial_data_loaded = false;
-        this.canvas_ref = renderToString("TimelineView.Canvas", {});
+        const canvas_str = renderToString("TimelineView.Canvas", {});
+        const parser = new DOMParser();
+        const svgDoc = parser.parseFromString(canvas_str, "image/svg+xml");
+        this.canvas_ref = svgDoc.documentElement;
         onWillUpdateProps(async (props) => {
             this.on_data_loaded(props.model.data);
         });
@@ -220,8 +223,8 @@ export class TimelineRenderer extends Component {
         }
         this.$centerContainer = this.timeline.dom.centerContainer;
         this.canvas = new TimelineCanvas(this.canvas_ref);
-        if (this.$centerContainer.el) {
-            this.$centerContainer.el.appendChild(this.canvas_ref);
+        if (this.$centerContainer) {
+            this.$centerContainer.appendChild(this.canvas_ref);
         }
         this.timeline.on("changed", () => {
             this.draw_canvas();


### PR DESCRIPTION
This issue was introduced during the migration to v18 when converting old jQuery code to native JavaScript in this commit: https://github.com/OCA/web/commit/258a5a92dc85fa5cc6dd9181ca444e3b4b290d0f

Fixes https://github.com/OCA/web/issues/3420

@Tecnativa @CarlosRoca13 @pedrobaeza @cvinh could you please review this?


<img width="1284" height="1093" alt="image" src="https://github.com/user-attachments/assets/3a0649e4-2c0e-4795-97c9-378cf0db42c4" />
