### PR TITLE
[FIX] web_widget_numeric_step: Added migration script for migration to 16.0.

### DIFF
--- a/web_widget_numeric_step/migrations/16.0.1.0.0/pre-migration.py
+++ b/web_widget_numeric_step/migrations/16.0.1.0.0/pre-migration.py
@@ -1,0 +1,16 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Remove the obsolete demo view from v13/v14/v15 that references non-existing
+    credit_limit on res.users. In v16, web_widget_numeric_step no longer has this demo,
+    and credit_limit is on res.partner.
+    """
+    # Remove by xmlid if it exists
+    openupgrade.delete_records_safely_by_xml_id(
+        env, ["web_widget_numeric_step.view_users_form"], delete_childs=True
+    )


### PR DESCRIPTION
In version before odoo 16.0 there have been demo data in web_widget_numeric_step. This demo data contained a view for res users. Before odoo 16.0, the field credit_limit was defined in res.users model. In odoo 16.0 it was moved to res.partner.

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<!-- Copyright 2020 Tecnativa - Alexandre Díaz
     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
<odoo>
    <record id="view_users_form" model="ir.ui.view">
        <field name="model">res.users</field>
        <field name="inherit_id" ref="base.view_users_form" />
        <field name="arch" type="xml">
            <xpath expr="//div[hasclass('oe_title')]" position="after">
                <group>
                    <field
                        name="credit_limit"
                        widget="numeric_step"
                        options="{'step': 3, 'min': -10, 'max': 130}"
                    />
                </group>
            </xpath>
        </field>
    </record>
</odoo>
```

Demo data was removed when the module was migrated, but the view was never actively dropped in a migration script. This causes issues when migrating databases, which have been initialized with demo data.

