### PR TITLE
[18.0][FIX] web_widget_x2many_2d_matrix: monetary field display

### DIFF
--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.scss
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.scss
@@ -34,6 +34,10 @@ $x2many_2d_matrix_max_height: 450px;
                         text-align: left;
                     }
 
+                    .o_monetary_ghost_value {
+                        width: 100%;
+                    }
+
                     &:first-child {
                         position: sticky;
                         left: 0;

--- a/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.scss
+++ b/web_widget_x2many_2d_matrix/static/src/components/x2many_2d_matrix_field/x2many_2d_matrix_field.scss
@@ -6,6 +6,11 @@ $x2many_2d_matrix_max_height: 450px;
         overflow-y: auto;
     }
 
+    /* Prevent having double border for monetary fields (for instance if you use web_theme_classic) */
+    span.o_input:has(span.o_monetary_ghost_value) + input.o_input {
+        border-color: transparent;
+    }
+
     .o_input {
         padding: 1px 0px;
     }


### PR DESCRIPTION
As reported in #3431 display of monetary fields was incorrect on web_widget_x2many_2d_matrix.
The issue was related to the fact that the span with o_monetary_ghost_value class would not overlap the input but would be placed on the left instead.

Adding a CSS for width: 100% solves the issue and should not impact the other type of fields.

Closes #3431 
