### PR TITLE
[18.0][FIX] web_responsive: Fix menu icon rendering by delegating to Odoo's built-in functionality

### DIFF
--- a/web_responsive/static/src/components/apps_menu_tools.esm.js
+++ b/web_responsive/static/src/components/apps_menu_tools.esm.js
@@ -15,10 +15,13 @@ export function getWebIconData(menu) {
 }
 
 /**
- * @param {Object} menu
+ * Ensures menu has webIconData property set
+ * @param {Object} menu - Menu object to update (typically a shallow copy)
  */
 export function updateMenuWebIconData(menu) {
-    // Use getWebIconData which now delegates to Odoo's built-in handling
+    // GetWebIconData returns menu.webIconData if it exists (from Odoo),
+    // otherwise returns the default icon. This ensures the menu copy
+    // always has a valid icon reference.
     menu.webIconData = getWebIconData(menu);
 }
 

--- a/web_responsive/static/src/components/apps_menu_tools.esm.js
+++ b/web_responsive/static/src/components/apps_menu_tools.esm.js
@@ -5,30 +5,21 @@
  * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
 
 export function getWebIconData(menu) {
-    const result = "/web_responsive/static/img/default_icon_app.png";
-    const webIcon = menu.webIcon;
-    if (webIcon && webIcon.split(",").length === 2) {
-        const path = webIcon.replace(",", "/");
-        return path.startsWith("/") ? path : "/" + path;
+    // Delegate to Odoo's built-in webIconData if available
+    // This properly handles base64 images, file paths, and all icon formats
+    if (menu.webIconData) {
+        return menu.webIconData;
     }
-    const iconData = menu.webIconData;
-    if (!menu.webIcon) {
-        return result;
-    }
-    const prefix = iconData.startsWith("P")
-        ? "data:image/svg+xml;base64,"
-        : "data:image/png;base64,";
-    if (iconData.startsWith("data:image")) {
-        return iconData;
-    }
-    return prefix + iconData.replace(/\s/g, "");
+    // Fallback to default icon if no icon data is provided
+    return "/web_responsive/static/img/default_icon_app.png";
 }
 
 /**
  * @param {Object} menu
  */
 export function updateMenuWebIconData(menu) {
-    menu.webIconData = menu.webIconData ? getWebIconData(menu) : "";
+    // Use getWebIconData which now delegates to Odoo's built-in handling
+    menu.webIconData = getWebIconData(menu);
 }
 
 export function updateMenuDisplayName(menu) {


### PR DESCRIPTION
The previous implementation failed to render menu icons when only base64
image data was present without a file on disk. This happened because the
logic checked for `menu.webIcon` but ignored `menu.webIconData` when
webIcon was missing.

The fix simplifies the logic by delegating icon handling to Odoo's
built-in webIconData, which already properly handles all icon formats:
- Base64 encoded images (PNG and SVG)
- File paths (module,filename format)
- Direct data URIs

This approach follows the standards and trusts 
Odoo's menu service to provide correctly formatted icon data.