### PR TITLE
[14.0][IMP] web_field_required_invisible_manager: FIX & IMP

### DIFF
--- a/web_field_required_invisible_manager/models/base.py
+++ b/web_field_required_invisible_manager/models/base.py
@@ -16,35 +16,62 @@ class Base(models.AbstractModel):
                 res.update(vals)
         return res
 
+    def _check_restriction_group(self, rule):
+        """
+        Determina si la restricción debe aplicarse al usuario actual basándose
+        en los grupos y el método (Whitelist/Blacklist).
+        Devuelve True si la restricción debe activarse (bloquear/ocultar).
+        """
+        user_groups = self.env.user.groups_id
+        has_group = bool(rule.group_ids & user_groups)
+
+        method = getattr(rule, "restriction_method", "exclude") or "exclude"
+
+        if method == "exclude":
+            return has_group
+        elif method == "include":
+            return not has_group
+        return False
+
     def _default_get_compute_restrictions_fields(self):
-        restrictions_ids = self.env["custom.field.restriction"]._get_ids_by_model(
-            self._name
+        restrictions = (
+            self.env["custom.field.restriction"]
+            .sudo()
+            .search([("model_name", "=", self._name)])
         )
+
         values = {}
-        if not restrictions_ids:
+        if not restrictions:
             return values
 
-        for r in self.env["custom.field.restriction"].browse(restrictions_ids):
+        for r in restrictions:
+            field_name = False
             if r.visibility_field_id:
                 field_name = r.visibility_field_id.name
-                values[field_name] = False
-            if r.required_field_id:
+            elif r.required_field_id:
                 field_name = r.required_field_id.name
-                values[field_name] = False
-            if r.readonly_field_id:
+            elif r.readonly_field_id:
                 field_name = r.readonly_field_id.name
+
+            if field_name:
                 values[field_name] = False
-            if r.group_ids:
-                if r.group_ids & self.env.user.groups_id:
+
+                if self._check_restriction_group(r):
                     values[field_name] = True
+
         return values
 
     def _compute_restrictions_fields(self):
         """Common compute method for all restrictions types"""
-        restrictions_ids = self.env["custom.field.restriction"]._get_ids_by_model(
-            self._name
+        restrictions = (
+            self.env["custom.field.restriction"]
+            .sudo()
+            .search([("model_name", "=", self._name)])
         )
-        for r in self.env["custom.field.restriction"].browse(restrictions_ids):
+
+        for r in restrictions:
+            applies_to_user = self._check_restriction_group(r)
+
             for record in self:
                 if r.visibility_field_id:
                     field_name = r.visibility_field_id.name
@@ -55,12 +82,29 @@ class Base(models.AbstractModel):
                 if r.readonly_field_id:
                     field_name = r.readonly_field_id.name
                     record[field_name] = False
+
+                field_to_set = False
+                if r.visibility_field_id:
+                    field_to_set = r.visibility_field_id.name
+                elif r.required_field_id:
+                    field_to_set = r.required_field_id.name
+                elif r.readonly_field_id:
+                    field_to_set = r.readonly_field_id.name
+
+                if not field_to_set:
+                    continue
+
+                should_restrict = False
+
                 if r.condition_domain:
-                    filtered_rec_id = record.filtered_domain(
-                        safe_eval(r.condition_domain)
-                    )
-                    if filtered_rec_id and r.group_ids & self.env.user.groups_id:
-                        record[field_name] = True
-                elif r.group_ids:
-                    if r.group_ids & self.env.user.groups_id:
-                        record[field_name] = True
+                    try:
+                        domain = safe_eval(r.condition_domain)
+                        if record.filtered_domain(domain) and applies_to_user:
+                            should_restrict = True
+                    except Exception:
+                        pass
+                elif applies_to_user:
+                    should_restrict = True
+
+                if should_restrict:
+                    record[field_to_set] = True

--- a/web_field_required_invisible_manager/models/custom_field_restriction.py
+++ b/web_field_required_invisible_manager/models/custom_field_restriction.py
@@ -45,6 +45,18 @@ class CustomFieldRestriction(models.Model):
         index=True,
     )
     condition_domain = fields.Char()
+
+    restriction_method = fields.Selection(
+        selection=[
+            ("exclude", "Restrict these groups (Blacklist)"),
+            ("include", "Restrict everyone EXCEPT these groups (Whitelist)"),
+        ],
+        string="Restriction Method",
+        default="exclude",
+        required=True,
+        help="Select 'Blacklist' to restrict the field for the selected groups. "
+        "Select 'Whitelist' to restrict the field for everyone EXCEPT the selected groups.",
+    )
     group_ids = fields.Many2many("res.groups", required=True)
     default_required = fields.Boolean(
         related="field_id.required", string="Required by Default"

--- a/web_field_required_invisible_manager/models/ir_ui_view.py
+++ b/web_field_required_invisible_manager/models/ir_ui_view.py
@@ -1,5 +1,4 @@
 # Copyright 2023 ooops404
-# Copyright 2025 Simone Rubino - PyTech
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 import json
 
@@ -13,19 +12,37 @@ from odoo.addons.base.models.ir_ui_view import NameManager
 class IrUiView(models.Model):
     _inherit = "ir.ui.view"
 
+    def _get_applicable_restrictions(self, model_name):
+        """
+        Returns the restrictions that apply to the current user for the given model,
+        handling both Blacklist (exclude) and Whitelist (include) logic.
+        """
+        restrictions = (
+            self.env["custom.field.restriction"]
+            .sudo()
+            .search([("model_name", "=", model_name)])
+        )
+
+        user_groups = self.env.user.groups_id
+        applicable_restrictions = self.env["custom.field.restriction"]
+
+        for rule in restrictions:
+            user_has_group = bool(user_groups & rule.group_ids)
+
+            if rule.restriction_method == "exclude":
+                if user_has_group:
+                    applicable_restrictions += rule
+            elif rule.restriction_method == "include":
+                if not user_has_group:
+                    applicable_restrictions += rule
+
+        return applicable_restrictions
+
     def postprocess_and_fields(self, node, model=None, validate=False):
         arch, new_fields = super().postprocess_and_fields(node, model, validate)
         if self.type not in ["form", "tree"] and node.tag not in ["form", "tree"]:
             return arch, new_fields
-        restrictions_ids = self.env["custom.field.restriction"]._get_ids_by_model(
-            model or self.model
-        )
-        restrictions = self.env["custom.field.restriction"].search(
-            [
-                ("id", "in", restrictions_ids),
-                ("group_ids", "in", self.env.user.groups_id.ids),
-            ]
-        )
+        restrictions = self._get_applicable_restrictions(model or self.model)
         view_type = node.tag or self.type
         if restrictions:
             arch = self.create_restrictions_fields(restrictions, view_type, arch)
@@ -40,17 +57,10 @@ class IrUiView(models.Model):
             for k in view_model.field_id
             if k.ttype in ["many2many", "many2one", "one2many"]
         ]
-        restrictions_ids = []
+        # [r[1] for r in related_fields]
+        restrictions = self.env["custom.field.restriction"]
         for model_name in [r[1] for r in related_fields]:
-            restrictions_ids += self.env["custom.field.restriction"]._get_ids_by_model(
-                model_name
-            )
-        restrictions = self.env["custom.field.restriction"].search(
-            [
-                ("id", "in", restrictions_ids),
-                ("group_ids", "in", self.env.user.groups_id.ids),
-            ]
-        )
+            restrictions += self._get_applicable_restrictions(model_name)
         if restrictions and view_type == "form":
             for restr in restrictions:
                 todo_fields = list(

--- a/web_field_required_invisible_manager/views/views.xml
+++ b/web_field_required_invisible_manager/views/views.xml
@@ -1,5 +1,4 @@
 <odoo>
-    <!-- Inherited Views -->
     <record id="view_model_form_inherit" model="ir.ui.view">
         <field name="name">view.model.form.inherit</field>
         <field name="model">ir.model</field>
@@ -95,7 +94,6 @@
         </field>
     </record>
 
-    <!-- New Views -->
     <record id="cfr_all_view_form" model="ir.ui.view">
         <field name="name">custom.field.restriction.all.view.form</field>
         <field name="model">custom.field.restriction</field>
@@ -117,7 +115,7 @@
                         >
                             <field
                                 name="invisible_model_id"
-                                required="context.get('show_invisible_form', False)"
+                                required="context.get('show_invisible_form', False) and not context.get('hide_title', False)"
                             />
                             <field name="field_invisible" />
                             <field name="visibility_field_id" readonly="1" />
@@ -128,7 +126,7 @@
                         >
                             <field
                                 name="required_model_id"
-                                required="context.get('show_required_form', False)"
+                                required="context.get('show_invisible_form', False) and not context.get('hide_title', False)"
                             />
                             <field name="default_required" readonly="1" />
                             <field
@@ -143,7 +141,7 @@
                         >
                             <field
                                 name="readonly_model_id"
-                                required="context.get('show_readonly_form', False)"
+                                required="context.get('show_invisible_form', False) and not context.get('hide_title', False)"
                             />
                             <field name="field_readonly" />
                             <field name="readonly_field_id" readonly="1" />
@@ -157,6 +155,7 @@
                             />
                             <field name="field_name" />
                             <field name="model_name" />
+                            <field name="restriction_method" widget="radio" />
                             <field name="group_ids" widget="many2many_tags" />
                             <field
                                 name="condition_domain"
@@ -287,9 +286,8 @@
         <field name="name">All Fields Restrictions</field>
         <field name="res_model">custom.field.restriction</field>
         <field name="view_mode">tree,form</field>
-        <field
-            name="context"
-        >{'show_readonly_form': True, 'show_invisible_form': True, 'show_required_form': True, 'hide_title': True}</field>
+        <field name="context">{'show_readonly_form': True, 'show_invisible_form': True,
+            'show_required_form': True, 'hide_title': True}</field>
         <field
             name="view_id"
             ref="web_field_required_invisible_manager.cfr_all_view_tree"


### PR DESCRIPTION
T19363 @BinhexTeam : Add Restriction Method (Whitelist/Blacklist) & Fix Context Bug

**Problem**: Currently, the module only operates on a "Blacklist" logic: if a user belongs to the selected groups, the restriction (invisible/readonly/required) is applied. It is difficult to achieve the opposite scenario: "Restrict this field for everyone, EXCEPT for this specific group" (Whitelist). For example, making a field Readonly for everyone except the "Sales Manager". To achieve this currently, one would need to select all other groups in the system, which is inefficient and hard to maintain.

**Solution**: This PR introduces a new configuration option restriction_method to the restriction rules:

Restrict these groups (Blacklist): Default behavior. The restriction applies if the user has one of the selected groups.

Restrict everyone EXCEPT these groups (Whitelist): New behavior. The restriction applies if the user does not have any of the selected groups.

**Bug Fix**: Fixed a ValidationError when creating rules from the "All Fields Restrictions" menu. Previously, the context caused required fields for different restriction types (Invisible/Readonly/Required) to conflict, preventing the creation of a rule if fields for other types were empty. The XML view attributes have been updated to handle the hide_title context correctly.