### PR TITLE
[17.0][FIX] web_company_color: avoid overriding navbar dropdown items

### DIFF
--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -123,9 +123,9 @@ class ResCompany(models.Model):
                 background-color: %(color_navbar_bg_hover)s !important;
             }
         }
-        .dropdown-item{
-            color: %(color_submenu_text)s !important;
-        }
+        .o_main_navbar .dropdown-menu .dropdown-item:not(.o_menu_brand, .o_nav_entry) {
+    color: %(color_submenu_text)s !important;
+}
     """
 
     company_colors = fields.Serialized()


### PR DESCRIPTION
This PR fixes an overly broad dropdown styling generated by web_company_color.

Problem
- The generated SCSS applies a global dropdown-item text color, which can override
  navbar dropdown entries such as the “Settings” entry (o_menu_brand) and other
  navbar items (e.g. o_nav_entry), causing inconsistent/incorrect text colors
  depending on the configured company colors.

Solution
- Scope the submenu text color to navbar dropdown menus only.
- Exclude o_menu_brand and o_nav_entry from the rule to avoid impacting the
  brand entry and navbar top-level items.

How to test
1) Install web_company_color
2) Settings → Companies → (your company) → Company Styles
3) Set a Navbar Background / Hover color, save, then hard refresh (Ctrl+F5)
4) Open the navbar dropdown that contains the “Settings” entry
5) Verify dropdown items keep the expected color and the “Settings” entry is not incorrectly recolored

Fixes #3362