### PR TITLE
[FIX] web_responsive: fix minichat opening when app menu is active

### DIFF
--- a/web_calendar_slot_duration/README.rst
+++ b/web_calendar_slot_duration/README.rst
@@ -72,8 +72,7 @@ have slots of 10 minutes as feature demonstration.
 Known issues / Roadmap
 ======================
 
--  Drop module if/when https://github.com/odoo/odoo/pull/66739 is
-   merged.
+- Drop module if/when https://github.com/odoo/odoo/pull/66739 is merged.
 
 Bug Tracker
 ===========
@@ -96,10 +95,10 @@ Authors
 Contributors
 ------------
 
--  `Tecnativa <https://www.tecnativa.com>`__:
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-   -  Jairo Llopis
-   -  Stefan Ungureanu
+  - Jairo Llopis
+  - Stefan Ungureanu
 
 Maintainers
 -----------

--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -53,6 +53,9 @@
         "web.assets_tests": [
             "/web_responsive/static/tests/test_patch.js",
         ],
+        "web.assets_web": [
+            "/web_responsive/static/src/scss/mail_chatwindow.scss",
+        ],
         "web.qunit_suite_tests": [
             "/web_responsive/static/tests/apps_menu_tests.esm.js",
             "/web_responsive/static/tests/apps_menu_search_tests.esm.js",

--- a/web_responsive/static/src/scss/mail_chatwindow.scss
+++ b/web_responsive/static/src/scss/mail_chatwindow.scss
@@ -1,0 +1,3 @@
+.o-mail-ChatWindow {
+    z-index: 3000 !important;
+}


### PR DESCRIPTION
Fixes #3313

### Issue
Minichat cannot be opened when the app menu is active because
the chat window is rendered below the app menu overlay.

### Cause
`.o-mail-ChatWindow` z-index is lower than the app menu overlay.

### Solution
Override chat window z-index through web_responsive assets.

### Result
Minichat opens correctly even when the app menu is open.