### PR TITLE
[18.0] web_company_color: Add button to reset colors to default

### DIFF
--- a/web_company_color/i18n/ca.po
+++ b/web_company_color/i18n/ca.po
@@ -26,6 +26,11 @@ msgid ""
 msgstr ""
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "Esteu segur que voleu restablir tots els colors als valors predeterminats d'Odoo?"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr ""
@@ -99,6 +104,11 @@ msgstr ""
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr ""
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Restableix els colors"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/i18n/de.po
+++ b/web_company_color/i18n/de.po
@@ -30,6 +30,11 @@ msgstr ""
 "                        die Seite."
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "Sind Sie sicher, dass Sie alle Farben auf die Odoo-Standardwerte zurücksetzen möchten?"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr ""
@@ -103,6 +108,11 @@ msgstr "Navbar Textfarbe"
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr "Qweb"
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Farben zurücksetzen"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/i18n/es.po
+++ b/web_company_color/i18n/es.po
@@ -30,6 +30,11 @@ msgstr ""
 "                        la página."
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "¿Está seguro de que desea restablecer todos los colores a los valores predeterminados de Odoo?"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr "Color de Fondo del Botón"
@@ -103,6 +108,11 @@ msgstr "Color de texto de la barra de navegación"
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr "Qweb"
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Restablecer colores"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/i18n/fr.po
+++ b/web_company_color/i18n/fr.po
@@ -30,6 +30,11 @@ msgstr ""
 "                        la page."
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "Êtes-vous sûr de vouloir réinitialiser toutes les couleurs aux valeurs par défaut d'Odoo ?"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr "Couleur d'arrière-plan de bouton"
@@ -103,6 +108,11 @@ msgstr "Couleur du texte de la barre de navigation"
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr "Qweb"
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Réinitialiser les couleurs"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/i18n/hr.po
+++ b/web_company_color/i18n/hr.po
@@ -27,6 +27,11 @@ msgid ""
 msgstr ""
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "Jeste li sigurni da želite poništiti sve boje na Odoo zadane vrijednosti?"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr ""
@@ -100,6 +105,11 @@ msgstr "Boja teksta navigacijske trake"
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr ""
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Poništi boje"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/i18n/it.po
+++ b/web_company_color/i18n/it.po
@@ -29,6 +29,11 @@ msgstr ""
 "                        la pagina."
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "Si è sicuri di voler reimpostare tutti i colori ai valori predefiniti di Odoo?"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr "Colore sfondo pulsante"
@@ -102,6 +107,11 @@ msgstr "Colori Testo Barra Navigazione"
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr "Qweb"
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Reimposta colori"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/i18n/nl.po
+++ b/web_company_color/i18n/nl.po
@@ -30,6 +30,11 @@ msgstr ""
 "                        de pagina."
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "Weet u zeker dat u alle kleuren wilt terugzetten naar de Odoo-standaardwaarden?"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr ""
@@ -103,6 +108,11 @@ msgstr "Navigatiebalk Tekstkleuren"
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr "Qweb"
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Kleuren herstellen"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/i18n/pt.po
+++ b/web_company_color/i18n/pt.po
@@ -29,6 +29,11 @@ msgstr ""
 "                        a página."
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "Tem a certeza de que pretende repor todas as cores para os valores predefinidos do Odoo?"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr "Cor de Fundo dos Botões"
@@ -102,6 +107,11 @@ msgstr "Cor do Texto da Barra de Navegação"
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr "QWeb"
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Repor cores"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/i18n/web_company_color.pot
+++ b/web_company_color/i18n/web_company_color.pot
@@ -22,6 +22,11 @@ msgid ""
 msgstr ""
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr ""
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr ""
@@ -94,6 +99,11 @@ msgstr ""
 #. module: web_company_color
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
+msgstr ""
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
 msgstr ""
 
 #. module: web_company_color

--- a/web_company_color/i18n/zh_CN.po
+++ b/web_company_color/i18n/zh_CN.po
@@ -26,6 +26,11 @@ msgid ""
 msgstr ""
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Are you sure you want to reset all colors to Odoo defaults?"
+msgstr "您确定要将所有颜色重置为Odoo默认值吗？"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_button_bg
 msgid "Button Background Color"
 msgstr ""
@@ -99,6 +104,11 @@ msgstr "导航栏文字颜色"
 #: model:ir.model,name:web_company_color.model_ir_qweb
 msgid "Qweb"
 msgstr "Qweb"
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "重置颜色"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp

--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -182,6 +182,9 @@ class ResCompany(models.Model):
                 self.scss_create_or_update_attachment()
         return result
 
+    def button_reset_colors(self):
+        self.write({"company_colors": {}})
+
     def button_compute_color(self):
         self.ensure_one()
         values = self.default_get(

--- a/web_company_color/tests/test_res_company.py
+++ b/web_company_color/tests/test_res_company.py
@@ -79,6 +79,44 @@ class TestResCompany(common.TransactionCase):
             "Invalid Navbar Background Color",
         )
 
+    def test_reset_colors(self):
+        company = self.env["res.company"].search([], limit=1)
+        company.sudo().write(
+            {
+                "color_navbar_bg": "#111111",
+                "color_navbar_bg_hover": "#222222",
+                "color_navbar_text": "#333333",
+                "color_button_bg": "#444444",
+                "color_button_bg_hover": "#555555",
+                "color_button_text": "#666666",
+                "color_link_text": "#777777",
+                "color_link_text_hover": "#888888",
+                "color_submenu_text": "#999999",
+            }
+        )
+        company.button_reset_colors()
+        company.invalidate_recordset()
+        self.assertFalse(company.color_navbar_bg, "color_navbar_bg should be reset")
+        self.assertFalse(
+            company.color_navbar_bg_hover, "color_navbar_bg_hover should be reset"
+        )
+        self.assertFalse(company.color_navbar_text, "color_navbar_text should be reset")
+        self.assertFalse(company.color_button_bg, "color_button_bg should be reset")
+        self.assertFalse(
+            company.color_button_bg_hover, "color_button_bg_hover should be reset"
+        )
+        self.assertFalse(company.color_button_text, "color_button_text should be reset")
+        self.assertFalse(company.color_link_text, "color_link_text should be reset")
+        self.assertFalse(
+            company.color_link_text_hover, "color_link_text_hover should be reset"
+        )
+        self.assertFalse(
+            company.color_submenu_text, "color_submenu_text should be reset"
+        )
+        self.assertFalse(
+            company.company_colors, "company_colors should be empty after reset"
+        )
+
     def test_compiled_scss(self):
         """The SCSS is compiled before being sent to the client."""
         # Arrange

--- a/web_company_color/view/res_company.xml
+++ b/web_company_color/view/res_company.xml
@@ -32,6 +32,13 @@
                         type="object"
                         string="Compute colors from logo"
                     />
+                    <button
+                        class="btn-secondary ms-2"
+                        name="button_reset_colors"
+                        type="object"
+                        string="Reset colors"
+                        confirm="Are you sure you want to reset all colors to Odoo defaults?"
+                    />
                     <div
                         class="alert alert-info info_icon mt-2 d-flex align-items-center"
                         role="alert"


### PR DESCRIPTION
Implements a reset to default button for web_company_color, as once a color is set, the UI does not let you reset it in order to keep using the original Odoo colors.