### PR TITLE
[18.0] [IMP] web_timeline: Add multi group_by support

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_arch_parser.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_arch_parser.esm.js
@@ -33,7 +33,7 @@ export class TimelineArchParser {
                 zoomKey: "ctrlKey",
             },
         };
-        const fieldNames = fields.display_name ? ["display_name"] : [];
+        const fieldNames = new Set(fields.display_name ? ["display_name"] : []);
         visitXML(arch, (node) => {
             switch (node.tagName) {
                 case "timeline": {
@@ -122,9 +122,7 @@ export class TimelineArchParser {
                 }
                 case "field": {
                     const fieldName = node.getAttribute("name");
-                    if (!fieldNames.includes(fieldName)) {
-                        fieldNames.push(fieldName);
-                    }
+                    fieldNames.add(fieldName);
                     break;
                 }
                 case "t": {
@@ -142,27 +140,26 @@ export class TimelineArchParser {
             "default_group_by",
             "progress",
             "date_delay",
-            archInfo.default_group_by,
+            ...archInfo.default_group_by.split(","),
         ];
+        fieldsToGather
+            .map((field) =>
+                field === "default_group_by"
+                    ? archInfo[field].split(",")
+                    : archInfo[field]
+            )
+            .flat()
+            .filter(Boolean)
+            .forEach((field) => fieldNames.add(field));
 
-        for (const field of fieldsToGather) {
-            if (archInfo[field] && !fieldNames.includes(archInfo[field])) {
-                fieldNames.push(archInfo[field]);
-            }
-        }
-        for (const color of archInfo.colors) {
-            if (!fieldNames.includes(color.field)) {
-                fieldNames.push(color.field);
-            }
-        }
+        archInfo.colors
+            .map((color) => color.field)
+            .forEach((field) => fieldNames.add(field));
 
-        if (
-            archInfo.dependency_arrow &&
-            !fieldNames.includes(archInfo.dependency_arrow)
-        ) {
-            fieldNames.push(archInfo.dependency_arrow);
+        if (archInfo.dependency_arrow) {
+            fieldNames.add(archInfo.dependency_arrow);
         }
-        archInfo.fieldNames = fieldNames;
+        archInfo.fieldNames = [...fieldNames];
         return archInfo;
     }
     /**

--- a/web_timeline/static/src/views/timeline/timeline_controller.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_controller.esm.js
@@ -61,10 +61,9 @@ export class TimelineController extends Component {
      * @param {EventObject} item
      */
     _onGroupClick(item) {
-        const groupField = this.model.last_group_bys[0];
         this.actionService.doAction({
             type: "ir.actions.act_window",
-            res_model: this.model.fields[groupField].relation,
+            res_model: this.model.fields[item.groupField].relation,
             res_id: item.group,
             views: [[false, "form"]],
             view_mode: "form",

--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -65,7 +65,7 @@ export class TimelineModel extends Model {
         // In the module sale_timesheet_timeline, it is used
         // with default_group_by = task_user_ids
         let field_to_order = this.params.default_group_by;
-        if (this.fields[field_to_order].type === "many2many") {
+        if (this.fields[field_to_order]?.type === "many2many") {
             field_to_order = undefined;
         }
         this.data = await this.keepLast.add(
@@ -87,12 +87,14 @@ export class TimelineModel extends Model {
      */
     _event_data_transform(record) {
         const [date_start, date_stop] = this._get_event_dates(record);
-        let group = record[this.last_group_bys[0]];
-        if (group && Array.isArray(group) && group.length > 0) {
-            group = group[0];
-        } else {
-            group = -1;
-        }
+        const group = this.last_group_bys
+            .reduce((acc, group_by) => {
+                const value = record[group_by];
+                const groupId =
+                    value && value instanceof Array && value.length > 0 ? value[0] : -1;
+                return acc.concat(groupId);
+            }, [])
+            .toString();
         let colorToApply = false;
         for (const color of this.colors) {
             if (evaluate(color.ast, record)) {

--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -217,10 +217,8 @@ export class TimelineRenderer extends Component {
         };
         this.timeline = new vis.Timeline(this.canvasRef.el, {}, this.options);
         this.timeline.on("click", this.on_timeline_click.bind(this));
-        if (!this.options.onUpdate) {
-            // In read-only mode, catch double-clicks this way.
-            this.timeline.on("doubleClick", this.on_timeline_double_click.bind(this));
-        }
+        this.timeline.on("doubleClick", this.on_timeline_double_click.bind(this));
+
         this.$centerContainer = this.timeline.dom.centerContainer;
         this.canvas = new TimelineCanvas(this.canvas_ref);
         if (this.$centerContainer) {
@@ -356,42 +354,53 @@ export class TimelineRenderer extends Component {
         if (this.model.last_group_bys.length === 0) {
             return records;
         }
+        const group_bys = this.model.last_group_bys;
         const groups = [];
-        groups.push({id: -1, content: _t("<b>UNASSIGNED</b>"), order: -1});
         var seq = 1;
         for (const evt of records) {
-            const grouped_field = this.model.last_group_bys[0];
-            const group_name = evt[grouped_field];
-            if (group_name && group_name instanceof Array) {
-                const group = groups.find(
-                    (existing_group) => existing_group.id === group_name[0]
-                );
-                if (group) {
-                    continue;
-                }
-                // Check if group is m2m in this case add id -> value of all
-                // found entries.
-                if (this.fields[grouped_field].type === "many2many") {
-                    const list_values = await this.get_m2m_grouping_datas(
-                        this.fields[grouped_field].relation,
-                        group_name
-                    );
-                    for (const vals of list_values) {
-                        const is_inside = groups.some((gr) => gr.id === vals.id);
-                        if (!is_inside) {
-                            vals.order = seq;
-                            seq += 1;
-                            groups.push(vals);
+            const parents = [];
+            for (let treeLevel = 0; treeLevel < group_bys.length; treeLevel++) {
+                const grouped_field = group_bys[treeLevel];
+                const [groupId, groupName] =
+                    evt[grouped_field] instanceof Array
+                        ? evt[grouped_field]
+                        : [-1, _t("<b>UNASSIGNED</b>")];
+                const id = parents.concat(groupId).toString();
+                const group = groups.find((existing_group) => existing_group.id === id);
+                if (!group) {
+                    if (this.fields[grouped_field].type === "many2many") {
+                        const list_values = await this.get_m2m_grouping_datas(
+                            this.fields[grouped_field].relation,
+                            groupName
+                        );
+                        for (const vals of list_values) {
+                            const is_inside = groups.some((gr) => gr.id === vals.id);
+                            if (!is_inside) {
+                                vals.order = seq;
+                                seq += 1;
+                                groups.push(vals);
+                            }
                         }
+                    } else {
+                        groups.push({
+                            id,
+                            treeLevel,
+                            content: groupName,
+                            order: groupId !== -1 ? seq : -1,
+                        });
                     }
-                } else {
-                    groups.push({
-                        id: group_name[0],
-                        content: group_name[1],
-                        order: seq,
-                    });
+                    if (parents.length) {
+                        const parent_group = groups.find(
+                            (existing_group) => existing_group.id === parents.toString()
+                        );
+                        if (!parent_group.nestedGroups) {
+                            parent_group.nestedGroups = [];
+                        }
+                        parent_group.nestedGroups.push(id);
+                    }
                     seq += 1;
                 }
+                parents.push(groupId);
             }
         }
         return groups;
@@ -415,10 +424,8 @@ export class TimelineRenderer extends Component {
      * @param {Object} e
      * @private
      */
-    on_timeline_click(e) {
-        if (e.what === "group-label" && e.group !== -1) {
-            this.props.onGroupClick(e);
-        }
+    on_timeline_click() {
+        return;
     }
 
     /**
@@ -428,8 +435,16 @@ export class TimelineRenderer extends Component {
      * @private
      */
     on_timeline_double_click(e) {
-        if (e.what === "item" && e.item !== -1) {
+        if (!this.options.onUpdate && e.what === "item" && e.item !== -1) {
+            // In read-only mode, catch double-clicks this way.
             this.props.onItemDoubleClick(e);
+        } else if (e.what === "group-label") {
+            const group = this.timeline.groupsData.get(e.group);
+            e.group = parseInt(e.group.split(",")[group.treeLevel]);
+            e.groupField = this.model.last_group_bys[group.treeLevel];
+            if (e.group !== -1) {
+                this.props.onGroupClick(e);
+            }
         }
     }
 


### PR DESCRIPTION
Adds to the web_timeline the ability  to handle multiple group_by with `nestedGroups`:

<img width="626" height="240" alt="image" src="https://github.com/user-attachments/assets/46f70727-3a55-4403-b1dc-286c7604c5aa" />

This changes the group record view action from single click to double click to avoid conflict with group expand/collapse.