### PR TITLE
[18.0] [IMP] web_timeline: Add date picker to jump at given date

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.esm.js
@@ -130,6 +130,23 @@ export class TimelineRenderer extends Component {
     }
 
     /**
+     * Set the timeline window to given day.
+     *
+     * @private
+     */
+    _onDateInputChanged(ev) {
+        const date = luxon.DateTime.fromISO(ev.target.value);
+        this.current_window = {
+            start: date.toJSDate(),
+            end: date.plus({hours: 24}).toJSDate(),
+        };
+
+        if (this.timeline) {
+            this.timeline.setWindow(this.current_window);
+        }
+    }
+
+    /**
      * Scales the timeline window based on the current window.
      *
      * @param {Function} getHoursFromStart Function which returns the timespan
@@ -230,6 +247,7 @@ export class TimelineRenderer extends Component {
             this.draw_canvas();
             this.load_initial_data();
         });
+        this.timeline.on("rangechanged", this.on_range_changed.bind(this));
     }
     /**
      * Returns the XSS whitelist for the timeline library.
@@ -407,6 +425,22 @@ export class TimelineRenderer extends Component {
             groups.push({id: record_info[0].id, content: record_info[0].display_name});
         }
         return groups;
+    }
+
+    /**
+     * Handle a change in the timeline range.
+     *
+     * @param {RangeEvent} e
+     * @private
+     */
+    on_range_changed(e) {
+        const start = luxon.DateTime.fromJSDate(e.start);
+        const end = luxon.DateTime.fromJSDate(e.end);
+        const centerDate = start.plus({seconds: end.diff(start).as("seconds") / 2});
+        if (this.rootRef.el) {
+            this.rootRef.el.querySelector(".oe_timeline_date_input").value =
+                centerDate.toFormat("yyyy-MM-dd");
+        }
     }
 
     /**

--- a/web_timeline/static/src/views/timeline/timeline_renderer.xml
+++ b/web_timeline/static/src/views/timeline/timeline_renderer.xml
@@ -24,6 +24,12 @@
                         t-att-class="'oe_timeline_button_scale_year btn ' + (mode.data == 'year' ? ' btn-primary' : 'btn-default')"
                         t-on-click="_onScaleYearClicked"
                     >Year</button>
+                    <input
+                        name="date-input"
+                        type="date"
+                        class="form-control oe_timeline_date_input"
+                        t-on-change="_onDateInputChanged"
+                    />
                 </div>
             </div>
             <div class="oe_timeline_widget" t-ref="canvas" />


### PR DESCRIPTION
Add a synchronized date picker to add the ability to go to the given date: 
<img width="601" height="352" alt="image" src="https://github.com/user-attachments/assets/790f373e-a7e7-47b2-b350-327985a44a60" />
