### PR TITLE
[FIX] web_dark_mode: always use dark mode on new tabs

### DIFF
--- a/web_dark_mode/models/ir_http.py
+++ b/web_dark_mode/models/ir_http.py
@@ -9,15 +9,13 @@ class IrHttp(models.AbstractModel):
     _inherit = "ir.http"
 
     @classmethod
-    def _set_color_scheme(cls, response):
-        scheme = request.httprequest.cookies.get("color_scheme")
+    def _sanitize_cookies(cls, cookies):
+        """Set the color_scheme cookie before template rendering."""
+        super()._sanitize_cookies(cookies)
         user = request.env.user
+        if getattr(user, "dark_mode_device_dependent", None):
+            return
         user_scheme = "dark" if getattr(user, "dark_mode", None) else "light"
-        device_dependent = getattr(user, "dark_mode_device_dependent", None)
-        if (not device_dependent) and scheme != user_scheme:
-            response.set_cookie("color_scheme", user_scheme)
-
-    @classmethod
-    def _post_dispatch(cls, response):
-        cls._set_color_scheme(response)
-        return super()._post_dispatch(response)
+        if cookies.get("color_scheme") != user_scheme:
+            cookies["color_scheme"] = user_scheme
+            request.future_response.set_cookie("color_scheme", user_scheme)


### PR DESCRIPTION
Suppose you have your Odoo running at http://localhost:8069 (or https://domain.tld, doesn't matter)
Set your scheme to dark mode. Odoo switches to dark mode.
Open a new tab http://localhost:8069, it uses the light theme. Refresh the tab, it now uses the dark mode.
If you open your tab at http://localhost:8069/odoo (or any non-empty backend path) it would properly use dark mode. However, browser auto-complete defaults to the root address.