### PR TITLE
[18.0] [FIX] web_timeline: Migrate check_access_rights to has_access following deprecation

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -31,21 +31,18 @@ export class TimelineModel extends Model {
 
         this.keepLast = new KeepLast();
         onWillStart(async () => {
-            this.write_right = await this.orm.call(
-                this.model_name,
-                "check_access_rights",
-                ["write", false]
-            );
-            this.unlink_right = await this.orm.call(
-                this.model_name,
-                "check_access_rights",
-                ["unlink", false]
-            );
-            this.create_right = await this.orm.call(
-                this.model_name,
-                "check_access_rights",
-                ["create", false]
-            );
+            this.write_right = await this.orm.call(this.model_name, "has_access", [
+                [],
+                "write",
+            ]);
+            this.unlink_right = await this.orm.call(this.model_name, "has_access", [
+                [],
+                "unlink",
+            ]);
+            this.create_right = await this.orm.call(this.model_name, "has_access", [
+                [],
+                "create",
+            ]);
         });
     }
     /**

--- a/web_timeline/static/tests/web_timeline_view_tests.esm.js
+++ b/web_timeline/static/tests/web_timeline_view_tests.esm.js
@@ -54,7 +54,7 @@ QUnit.module("Views", (hooks) => {
                         },
                     ],
                     methods: {
-                        check_access_rights() {
+                        has_access() {
                             return Promise.resolve(true);
                         },
                     },


### PR DESCRIPTION
`check_access_rights` is deprecated in 18.0, replace it with `has_access`