### PR TITLE
[18.0][FIX] web_timeline: set date_stop to end of day for Date fields

### DIFF
--- a/web_timeline/static/src/views/timeline/timeline_model.esm.js
+++ b/web_timeline/static/src/views/timeline/timeline_model.esm.js
@@ -140,6 +140,9 @@ export class TimelineModel extends Model {
                 this.fields[this.date_stop],
                 record[this.date_stop]
             );
+            if (this.fields[this.date_stop].type === "date") {
+                date_stop = date_stop.endOf("day");
+            }
         }
         if (!date_stop && date_delay) {
             date_stop = date_start.plus({hours: date_delay});


### PR DESCRIPTION
When using Date fields (not DateTime) for `date_stop` in a timeline view, items end one day before the expected end date. The `date_stop` is parsed as `00:00:00` of that day, so the timeline item ends at the start of the day instead of including the full day.

The fix checks if the `date_stop` field type is `date` and sets it to end of day using Luxon's `.endOf("day")`, so the item correctly spans through `23:59:59` of the last day.

**Steps to reproduce:**
1. Create a model with `Date` fields for start and end dates
2. Create a timeline view using those fields
3. Create a record with `date_start = 2026-03-10` and `date_stop = 2026-03-14`
4. The timeline item ends on `2026-03-13` instead of `2026-03-14`

Fixes https://github.com/OCA/web/issues/3349