### PR TITLE
[17.0][FIX] web_m2x_options: Add section_one2many compatibility

### DIFF
--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -382,6 +382,9 @@ patch(FormController.prototype, {
             viewType = viewType.replace("tree", "list");
             if (viewType.includes(",")) {
                 viewType = isSmall ? "kanban" : "list";
+                if (field.widget && field.widget === "section_one2many") {
+                    viewType = "list";
+                }
             }
             field.viewMode = viewType;
             if (field.views && field.views[viewType] && limit) {


### PR DESCRIPTION
Add section_one2many compatibility

**Before**
<img width="1606" height="491" alt="antes" src="https://github.com/user-attachments/assets/2c95669f-57e7-400e-a91d-e68a9de3e143" />

**After**
<img width="1603" height="445" alt="despues" src="https://github.com/user-attachments/assets/36960d75-ee98-495a-ba4b-f040aafd0450" />


@Tecnativa TT61508