### PR TITLE
[18.0][IMP] web_company_color: allow to set bottom border color of navbar

### DIFF
--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -165,22 +165,15 @@ class ResCompany(models.Model):
         return super().unlink()
 
     def write(self, values):
-        if not self.env.context.get("ignore_company_color", False):
-            fields_to_check = (
-                "color_navbar_bg",
-                "color_navbar_bg_hover",
-                "color_navbar_text",
-                "color_button_bg",
-                "color_button_bg_hover",
-                "color_button_text",
-                "color_link_text",
-                "color_link_text_hover",
-            )
-            result = super().write(values)
-            if any([field in values for field in fields_to_check]):
+        result = super().write(values)
+        if not self.env.context.get("ignore_company_color"):
+            fields_to_check = ["company_colors"] + [
+                field_name
+                for field_name, field in self._fields.items()
+                if field.sparse == "company_colors"
+            ]
+            if any(field in values for field in fields_to_check):
                 self.scss_create_or_update_attachment()
-        else:
-            result = super().write(values)
         return result
 
     def button_compute_color(self):

--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -21,6 +21,7 @@ class ResCompany(models.Model):
         .o_main_navbar {
           background: %(color_navbar_bg)s !important;
           background-color: %(color_navbar_bg)s !important;
+          border-bottom: 1px solid %(color_navbar_border_bottom)s !important;
           color: %(color_navbar_text)s !important;
 
           .show {
@@ -109,6 +110,7 @@ class ResCompany(models.Model):
           &:hover, &:focus, &:active, &:focus:active {
             background-color: %(color_navbar_bg_hover)s !important;
           }
+          border-bottom: 1px solid %(color_navbar_border_bottom)s !important;
         }
         .o_menu_sections .dropdown-toggle {
           background: %(color_navbar_bg)s !important;
@@ -117,6 +119,7 @@ class ResCompany(models.Model):
           &:hover, &:focus, &:active, &:focus:active {
             background-color: %(color_navbar_bg_hover)s !important;
           }
+          border-bottom: 1px solid %(color_navbar_border_bottom)s !important;
         }
         .o_menu_systray button,
         .o_navbar_breadcrumbs,
@@ -136,6 +139,9 @@ class ResCompany(models.Model):
     color_navbar_bg = fields.Char("Navbar Background Color", sparse="company_colors")
     color_navbar_bg_hover = fields.Char(
         "Navbar Background Color Hover", sparse="company_colors"
+    )
+    color_navbar_border_bottom = fields.Char(
+        "Navbar Bottom Border Color", sparse="company_colors"
     )
     color_navbar_text = fields.Char("Navbar Text Color", sparse="company_colors")
     color_button_text = fields.Char("Button Text Color", sparse="company_colors")
@@ -194,10 +200,11 @@ class ResCompany(models.Model):
                 {
                     "color_navbar_bg": n_rgb_to_hex(_r, _g, _b),
                     "color_navbar_bg_hover": n_rgb_to_hex(_rd, _gd, _bd),
+                    "color_navbar_border_bottom": n_rgb_to_hex(_rd, _gd, _bd),
                     "color_navbar_text": "#000" if _a < 0.5 else "#fff",
                 }
             )
-        self.write(values)
+        self.update(values)
 
     def _scss_get_sanitized_values(self):
         self.ensure_one()
@@ -209,6 +216,8 @@ class ResCompany(models.Model):
             {
                 "color_navbar_bg": (values.get("color_navbar_bg") or "$o-brand-odoo"),
                 "color_navbar_bg_hover": (values.get("color_navbar_bg_hover")),
+                "color_navbar_border_bottom": values.get("color_navbar_border_bottom")
+                or f"darken({values.get('color_navbar_bg') or '$o-brand-odoo'}, 10%)",
                 "color_navbar_text": (values.get("color_navbar_text") or "#FFF"),
                 "color_button_bg": values.get("color_button_bg") or "#71639e",
                 "color_button_bg_hover": values.get("color_button_bg_hover")

--- a/web_company_color/tests/test_res_company.py
+++ b/web_company_color/tests/test_res_company.py
@@ -98,3 +98,26 @@ class TestResCompany(common.TransactionCase):
         self.assertNotIn("desaturate", css)
         self.assertNotIn(color, css)
         self.assertIn(desaturated_color, css)
+
+    def test_ignore_company_color(self):
+        """
+        Test that we can turn off regenerating css attachment via context key
+        """
+        company = self.env.company
+        attachment = self.env["ir.attachment"].search(
+            [("url", "=", company.scss_get_url())]
+        )
+        attachment.unlink()
+
+        company.company_colors = {}
+        attachment = self.env["ir.attachment"].search(
+            [("url", "=", company.scss_get_url())]
+        )
+        self.assertTrue(attachment, "attachment should have been regenerated")
+
+        attachment.unlink()
+        company.with_context(ignore_company_color=True).company_colors = {}
+        attachment = self.env["ir.attachment"].search(
+            [("url", "=", company.scss_get_url())]
+        )
+        self.assertFalse(attachment, "attachment should not have been regenerated")

--- a/web_company_color/view/res_company.xml
+++ b/web_company_color/view/res_company.xml
@@ -18,6 +18,7 @@
                     <group string="Colors" name="navbar_colors">
                         <field name="color_navbar_bg" widget="color" />
                         <field name="color_navbar_bg_hover" widget="color" />
+                        <field name="color_navbar_border_bottom" widget="color" />
                         <field name="color_navbar_text" widget="color" />
                         <field name="color_button_bg" widget="color" />
                         <field name="color_button_bg_hover" widget="color" />


### PR DESCRIPTION
Odoo adds a 1px border below the nav bar, which is not visible below navbar buttons. Usually it's hard to notice because the colors are darkish, but when using web_company_color to set a bright color, it looks like this on current runbot:

<img width="396" height="80" alt="image" src="https://github.com/user-attachments/assets/921140b6-6531-4ab0-bb6d-824c3f2daba9" />

but with this patch and setting the border color, it looks like this:

<img width="396" height="80" alt="image" src="https://github.com/user-attachments/assets/3452b359-6802-40ce-9bfa-da9d8a55ab63" />

I took the liberty to simplify the code I had to touch anyways