### PR TITLE
[18.0][FIX] web_m2x_options_manager: fix create edit options

### DIFF
--- a/web_m2x_options_manager/demo/res_partner_demo_view.xml
+++ b/web_m2x_options_manager/demo/res_partner_demo_view.xml
@@ -13,12 +13,12 @@
                         <!-- Many2one w/ options -->
                         <field
                             name="parent_id"
-                            options="{'create': False, 'create_edit': False}"
+                            options="{'no_quick_create': True, 'no_create_edit': True}"
                         />
                         <!-- Many2many w/ options -->
                         <field
                             name="category_id"
-                            options="{'create': False, 'create_edit': False}"
+                            options="{'no_quick_create': True, 'no_create_edit': True}"
                         />
                     </group>
                 </sheet>

--- a/web_m2x_options_manager/models/m2x_create_edit_option.py
+++ b/web_m2x_options_manager/models/m2x_create_edit_option.py
@@ -184,11 +184,19 @@ class M2xCreateEditOption(models.Model):
         eval_ctx.update({"context": dict(eval_ctx)})
         return eval_ctx
 
+    # Odoo 18 renamed the field-level option keys and inverted their boolean sense:
+    # old: create=False  → new: no_quick_create=True
+    # old: create_edit=False → new: no_create_edit=True
+    _OPTION_KEY_MAP = {
+        "create": "no_quick_create",
+        "create_edit": "no_create_edit",
+    }
+
     def _read_own_options(self):
         """Helper method to retrieve M2X options from ``self``
 
         :return: a dictionary mapping each M2X option to its mode and value, eg:
-            {'create': ('force', 'true'), 'create_edit': ('set', 'false')}
+            {'no_quick_create': ('force', True), 'no_create_edit': ('set', True)}
         :rtype: dict[str, tuple[str, Any]]
         """
         self.ensure_one()
@@ -196,7 +204,13 @@ class M2xCreateEditOption(models.Model):
         for fname, fvalue in self.read(self._get_option_fields())[0].items():
             if fname != "id" and fvalue != "none":
                 mode, value = tuple(fvalue.split("_"))
-                res[fname.replace("option_", "")] = (mode, value == "true")
+                old_key = fname.replace("option_", "")
+                new_key = self._OPTION_KEY_MAP.get(old_key, old_key)
+                # Value is inverted: create=False means no_quick_create=True
+                bool_value = value == "true"
+                if new_key != old_key:
+                    bool_value = not bool_value
+                res[new_key] = (mode, bool_value)
         return res
 
     def _get_option_fields(self):

--- a/web_m2x_options_manager/tests/test_m2x_create_edit_option.py
+++ b/web_m2x_options_manager/tests/test_m2x_create_edit_option.py
@@ -20,11 +20,11 @@ class TestM2xCreateEditOption(Common):
         )
         self.assertEqual(
             self._eval_node_options(form_doc.xpath("//field[@name='parent_id']")[0]),
-            {"create": False, "create_edit": False},
+            {"no_quick_create": True, "no_create_edit": True},
         )
         self.assertEqual(
             self._eval_node_options(form_doc.xpath("//field[@name='category_id']")[0]),
-            {"create": False, "create_edit": False},
+            {"no_quick_create": True, "no_create_edit": True},
         )
 
         # Create options, check view has been updated
@@ -55,19 +55,19 @@ class TestM2xCreateEditOption(Common):
         form_doc = self._get_test_view_parsed()
         self.assertEqual(
             self._eval_node_options(form_doc.xpath("//field[@name='title']")[0]),
-            {"create": True, "create_edit": True},
+            {"no_quick_create": False, "no_create_edit": False},
         )
         self.assertEqual(
             self._eval_node_options(form_doc.xpath("//field[@name='parent_id']")[0]),
             # These remain the same because the options are defined w/ 'set_true':
             # but the node already contains them, so no override is applied
-            {"create": False, "create_edit": False},
+            {"no_quick_create": True, "no_create_edit": True},
         )
         self.assertEqual(
             self._eval_node_options(form_doc.xpath("//field[@name='category_id']")[0]),
             # These change values because the options are defined w/ 'force_true':
             # options' values are overridden even if the node already contains them
-            {"create": True, "create_edit": True},
+            {"no_quick_create": False, "no_create_edit": False},
         )
 
         # Update options on ``res.partner.parent_id``, check its node has been updated
@@ -77,7 +77,7 @@ class TestM2xCreateEditOption(Common):
         form_doc = self._get_test_view_parsed()
         self.assertEqual(
             self._eval_node_options(form_doc.xpath("//field[@name='parent_id']")[0]),
-            {"create": True, "create_edit": True},
+            {"no_quick_create": False, "no_create_edit": False},
         )
 
     def test_m2x_option_name(self):


### PR DESCRIPTION
Odoo 18 renamed the field-level option keys and inverted their boolean sense:
- old: create=False  → new: no_quick_create=True
- old: create_edit=False → new: no_create_edit=True