### PR TITLE
[18.0][web_widget_dropdown_dynamic][FIX]: value dissappearing afetr losing …

### DIFF
--- a/web_widget_dropdown_dynamic/static/src/js/field_dynamic_dropdown.esm.js
+++ b/web_widget_dropdown_dynamic/static/src/js/field_dynamic_dropdown.esm.js
@@ -36,6 +36,19 @@ export class FieldDynamicDropdown extends Component {
         }
         return specialDataCaches[key];
     }
+    get string() {
+        const value = this.props.record.data[this.props.name];
+        if (value === false || value === null || value === undefined) {
+            return "";
+        }
+        if (!this.specialData) {
+            return "";
+        }
+        const option = this.specialData.find(
+            (o) => o[0] === value || String(o[0]) === String(value)
+        );
+        return option ? String(option[1]) : String(value);
+    }
     get options() {
         const fieldType = this.type || "";
         if (["char", "integer", "selection"].includes(fieldType)) {

--- a/web_widget_dropdown_dynamic/static/tests/web_widget_dropdown_dynamic_tests.esm.js
+++ b/web_widget_dropdown_dynamic/static/tests/web_widget_dropdown_dynamic_tests.esm.js
@@ -146,6 +146,48 @@ QUnit.module("web_widget_dropdown_dynamic", (hooks) => {
         assert.containsOnce(field_target, 'option[value="\\"10\\""]');
     });
 
+    QUnit.test("displays label for selected value in readonly mode", async (assert) => {
+        // Bug: FieldDynamicDropdown extended Component directly instead of SelectionField,
+        // so it never inherited get string(). The web.SelectionField template uses `this.string`
+        // in its readonly branch (<span t-esc="string">). Without the getter, this.string is
+        // undefined and the span renders empty — the selected value visually "disappears"
+        // whenever the field switches to readonly display (e.g. row loses focus in a list).
+        serverData.models["sale.order"].records[0].content_string = "value a";
+
+        await makeView({
+            type: "form",
+            resModel: "sale.order",
+            serverData,
+            arch: `
+                <form>
+                    <field
+                        name="content_string"
+                        widget="dynamic_dropdown"
+                        options="{'values': 'method_name'}"
+                        context="{'depending_on': id}"
+                        readonly="1"
+                    />
+                </form>`,
+            resId: 1,
+            mockRPC(route, args) {
+                if (args.method === "method_name") {
+                    return [["value a", "Value A"]];
+                }
+            },
+        });
+
+        const fieldEl = target.querySelector(".o_field_widget[name='content_string']");
+        assert.ok(
+            fieldEl.querySelector("span"),
+            "field renders a <span> element in readonly mode"
+        );
+        assert.strictEqual(
+            fieldEl.querySelector("span").textContent.trim(),
+            "Value A",
+            "the option label is shown in readonly mode, not blank"
+        );
+    });
+
     QUnit.test("values are fetched w/o context (selection)", async (assert) => {
         assert.expect(6);
         await makeView({


### PR DESCRIPTION
…focus when used in list view

I was using a list view of one2many inside a form with selection field using `web_widget_dropdown_dynamic` widget noticing strange behavior: selecting an option works fine but when the field loses focus, the value dissappears. However it is saved into the database. When loading the form the value is not there either, onl;y when clicking the field.

The web.SelectionField template has two rendering paths:
- Edit mode: uses options + value → \<select\> renders correctly with the chosen option
- Readonly mode: uses this.string → \<span t-esc="string"\>

`FieldDynamicDropdown` extends `Component` directly (not `SelectionField`), so `get string()` was never inherited. When an editable list row loses focus and switches back to readonly display, `this.string` is undefined — OWL renders an empty span. The value is still in the record (hence "saved into database later"), but the readonly display renders blank.

**Fix:** Added `get string()` to `FieldDynamicDropdown` that looks up the label for the current value from `this.specialData`, matching the same logic as `SelectionField.string` but working with the dynamically-fetched options. With the help of Claude added a test for this as well.
