### PR TITLE
[14.0][FIX] web_button_visibility: address same label warning

### DIFF
--- a/web_button_visibility/models/hide_button_rule.py
+++ b/web_button_visibility/models/hide_button_rule.py
@@ -17,7 +17,7 @@ class ModelButtonRule(models.Model):
         ondelete="cascade",
         index=True,
     )
-    model_name = fields.Char(related="model_id.model")
+    model_name = fields.Char(related="model_id.model", string="Model Name")
     condition_domain = fields.Char()
     group_ids = fields.Many2many("res.groups", required=True)
     # generated technical fields used in form attrs:


### PR DESCRIPTION
Fixes the following warning

```
2026-03-31 12:12:35,208 1 WARNING devel odoo.addons.base.models.ir_model: Two fields (model_name, model_id) of model.button.rule() have the same label: Model. 
```