### PR TITLE
[18.0][FIX] web_company_color: adjust navbar link color inheritance

### DIFF
--- a/web_company_color/__manifest__.py
+++ b/web_company_color/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Web Company Color",
     "category": "web",
-    "version": "18.0.1.0.7",
+    "version": "18.0.1.0.8",
     "author": "Alexandre Díaz, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/web",
     "depends": ["web", "base_sparse_field"],

--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -24,6 +24,10 @@ class ResCompany(models.Model):
           border-bottom: 1px solid %(color_navbar_border_bottom)s !important;
           color: %(color_navbar_text)s !important;
 
+          a {
+            color: inherit !important;
+          }
+
           .show {
             .dropdown-toggle {
               background-color: %(color_navbar_bg_hover)s !important;
@@ -54,16 +58,10 @@ class ResCompany(models.Model):
           .btn-link,
           .o_external_button {
             color: %(color_link_text)s;
-            .o_main_navbar {
-            color: none;
-            }
           }
         a:hover,
         .btn-link:hover {
           color: %(color_link_text_hover)s;
-          .o_main_navbar {
-            color: none;
-          }
         }
         .btn-primary:not(.disabled),
         .ui-autocomplete .ui-menu-item > a.ui-state-active {

--- a/web_company_color/view/assets.xml
+++ b/web_company_color/view/assets.xml
@@ -12,7 +12,7 @@
         name="web_company_color assets"
         inherit_id="web.webclient_bootstrap"
     >
-        <xpath expr="//t[@t-set='head_web']">
+        <xpath expr="//t[@t-set='head_web']" position="inside">
             <t t-call-assets="web_company_color.company_color_assets" />
         </xpath>
     </template>


### PR DESCRIPTION
Fixed an issue where links in the navbar (like breadcrumbs or module titles) inherited the corporate link color instead of the navbar text color. Corrected invalid CSS property (color: none). Adjusted asset injection point to use position='inside' to avoid potential inheritance issues.