### PR TITLE
[18.0][FIX] web_form_banner:  use record_id in help text

### DIFF
--- a/web_form_banner/views/web_form_banner_rule_views.xml
+++ b/web_form_banner/views/web_form_banner_rule_views.xml
@@ -113,7 +113,7 @@
                                     (one2many/reference, etc).
                                 </li>
                                 <li><code
-                                >current_id</code>: Integer id of the record being edited, or <code
+                                >record_id</code>: Integer id of the record being edited, or <code
                                 >False</code> if the form
                                     is creating a new record.
                                 </li>


### PR DESCRIPTION
The help text for web_form_banner incorrectly referred to current_id, while the eval context actually provides record_id.

@qrtl
QT6568