### PR TITLE
[18.0][FIX] checklog-odoo.cfg: ignore Killing chrome descendants-or-self warning

### DIFF
--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,4 +1,5 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING .* Killing chrome descendants-or-self .*
     Missing widget: res_partner_many2one for field of type many2one


### PR DESCRIPTION
Warning introduced in https://github.com/odoo/odoo/commit/d22e0b4e181de0940810b0f0a760bcfe288042a7. The previous warning apparently did not occur, as it was not featured in checklog-odoo.cfg.

```
2026-04-13 03:20:41,702 367 WARNING odoo odoo.addons.web_disable_export_group.tests.test_tour.TestTour.test_admin: Killing chrome descendants-or-self of 382: 6 remaining
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
- chrome (zombie)
```