### PR TITLE
[18.0][web_widget_dropdown_dynamic][FIX]: propagate required prop and value dissappearing after losing focus when used in list view

### DIFF
--- a/web_widget_dropdown_dynamic/README.rst
+++ b/web_widget_dropdown_dynamic/README.rst
@@ -123,6 +123,10 @@ Contributors
 
 - ``Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>``\ \_
 
+- `Data Dance s.r.o. <https://www.datadance.eu/>`__
+
+  - Radovan Skolnik <radovan@skolnik.info>
+
 Other credits
 -------------
 

--- a/web_widget_dropdown_dynamic/readme/CONTRIBUTORS.md
+++ b/web_widget_dropdown_dynamic/readme/CONTRIBUTORS.md
@@ -15,3 +15,7 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Carlos Roca
 - `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`_
+
+- [Data Dance s.r.o.](https://www.datadance.eu/)
+
+  - Radovan Skolnik \<<radovan@skolnik.info>\>

--- a/web_widget_dropdown_dynamic/static/src/js/field_dynamic_dropdown.esm.js
+++ b/web_widget_dropdown_dynamic/static/src/js/field_dynamic_dropdown.esm.js
@@ -11,6 +11,7 @@ export class FieldDynamicDropdown extends Component {
         ...standardFieldProps,
         method: {type: String},
         context: {type: Object},
+        required: {type: Boolean, optional: true},
     };
     setup() {
         super.setup();
@@ -35,6 +36,19 @@ export class FieldDynamicDropdown extends Component {
             });
         }
         return specialDataCaches[key];
+    }
+    get string() {
+        const value = this.props.record.data[this.props.name];
+        if (!value || !this.specialData) {
+            return "";
+        }
+        if (!this.specialData) {
+            return "";
+        }
+        const option = this.specialData.find(
+            (o) => o[0] === value || String(o[0]) === String(value)
+        );
+        return option ? String(option[1]) : String(value);
     }
     get options() {
         const fieldType = this.type || "";
@@ -84,9 +98,10 @@ export const dynamicDropdownField = {
     component: FieldDynamicDropdown,
     displayName: _t("Dynamic Dropdown"),
     supportedTypes: ["char", "integer", "selection"],
-    extractProps: ({options}, {context}) => ({
+    extractProps: ({options}, {context, required}) => ({
         method: options?.values,
         context,
+        required,
     }),
 };
 registry.category("fields").add("dynamic_dropdown", dynamicDropdownField);

--- a/web_widget_dropdown_dynamic/static/tests/web_widget_dropdown_dynamic_tests.esm.js
+++ b/web_widget_dropdown_dynamic/static/tests/web_widget_dropdown_dynamic_tests.esm.js
@@ -146,6 +146,48 @@ QUnit.module("web_widget_dropdown_dynamic", (hooks) => {
         assert.containsOnce(field_target, 'option[value="\\"10\\""]');
     });
 
+    QUnit.test("displays label for selected value in readonly mode", async (assert) => {
+        // Bug: FieldDynamicDropdown extended Component directly instead of SelectionField,
+        // so it never inherited get string(). The web.SelectionField template uses `this.string`
+        // in its readonly branch (<span t-esc="string">). Without the getter, this.string is
+        // undefined and the span renders empty — the selected value visually "disappears"
+        // whenever the field switches to readonly display (e.g. row loses focus in a list).
+        serverData.models["sale.order"].records[0].content_string = "value a";
+
+        await makeView({
+            type: "form",
+            resModel: "sale.order",
+            serverData,
+            arch: `
+                <form>
+                    <field
+                        name="content_string"
+                        widget="dynamic_dropdown"
+                        options="{'values': 'method_name'}"
+                        context="{'depending_on': id}"
+                        readonly="1"
+                    />
+                </form>`,
+            resId: 1,
+            mockRPC(route, args) {
+                if (args.method === "method_name") {
+                    return [["value a", "Value A"]];
+                }
+            },
+        });
+
+        const fieldEl = target.querySelector(".o_field_widget[name='content_string']");
+        assert.ok(
+            fieldEl.querySelector("span"),
+            "field renders a <span> element in readonly mode"
+        );
+        assert.strictEqual(
+            fieldEl.querySelector("span").textContent.trim(),
+            "Value A",
+            "the option label is shown in readonly mode, not blank"
+        );
+    });
+
     QUnit.test("values are fetched w/o context (selection)", async (assert) => {
         assert.expect(6);
         await makeView({


### PR DESCRIPTION
I noticed inconsistent rendering behavior between this module and standard Selection field when using `required="True"`

The standard Selection field when `required="True"` renders the options without any blank line in the list:
<img width="727" height="476" alt="image" src="https://github.com/user-attachments/assets/d1aabefb-f83a-4498-a394-494151301337" />
<img width="616" height="201" alt="image" src="https://github.com/user-attachments/assets/3903f1ae-c0cd-48f8-b5e7-68cb5c48ff99" />
When `required="False"` the Selection provides empty value as well:
<img width="769" height="563" alt="image" src="https://github.com/user-attachments/assets/a795abef-901e-42db-8afb-a6dd6faea44b" />
<img width="669" height="323" alt="image" src="https://github.com/user-attachments/assets/80096284-bac0-4e8a-a3cf-891ba5c3e8b4" />


However `web_widget_dropdown_dynamic` always adds blank line to the list even when there is no value selected even if `required="True"`:
<img width="939" height="480" alt="image" src="https://github.com/user-attachments/assets/69734830-1625-4a02-9c2e-fc74e92eabf9" />
<img width="626" height="205" alt="image" src="https://github.com/user-attachments/assets/aee69ffc-5c5d-4243-acf1-d0ace242d1ec" />

This comes down to propagating required property which this fix addresses and thus brings `web_widget_dropdown_dynamic` to be visually aligned with standard Selection widget.


I was also using a list view of one2many inside a form with selection field using `web_widget_dropdown_dynamic` widget noticing strange behavior: selecting an option works fine but when the field loses focus, the value dissappears. However it is saved into the database. When loading the form the value is not there either, onl;y when clicking the field.

The web.SelectionField template has two rendering paths:
- Edit mode: uses options + value → \<select\> renders correctly with the chosen option
- Readonly mode: uses this.string → \<span t-esc="string"\>

`FieldDynamicDropdown` extends `Component` directly (not `SelectionField`), so `get string()` was never inherited. When an editable list row loses focus and switches back to readonly display, `this.string` is undefined — OWL renders an empty span. The value is still in the record (hence "saved into database later"), but the readonly display renders blank.

**Fix:** Added `get string()` to `FieldDynamicDropdown` that looks up the label for the current value from `this.specialData`, matching the same logic as `SelectionField.string` but working with the dynamically-fetched options. With the help of Claude added a test for this as well.