### PR TITLE
[18.0][FIX] web_responsive: fix breadcrumb Unnamed on search navigation

### DIFF
--- a/web_responsive/static/src/components/menu_canonical_searchbar/searchbar.esm.js
+++ b/web_responsive/static/src/components/menu_canonical_searchbar/searchbar.esm.js
@@ -199,6 +199,15 @@ export class AppsMenuCanonicalSearchBar extends Component {
         }
     }
 
+    /**
+     * @param {MouseEvent} ev
+     * @param {Object} menu
+     */
+    _onSearchItemClick(ev, menu) {
+        ev.preventDefault();
+        this.menuService.selectMenu(menu);
+    }
+
     _splitName(name) {
         if (!name) {
             return [];

--- a/web_responsive/static/src/components/menu_canonical_searchbar/searchbar.xml
+++ b/web_responsive/static/src/components/menu_canonical_searchbar/searchbar.xml
@@ -32,6 +32,7 @@
                             t-att-href="menu.path"
                             t-att-data-menu-id="menu.id"
                             t-att-data-action-id="menu.actionID"
+                            t-on-click="(ev) => this._onSearchItemClick(ev, menu)"
                             draggable="false"
                             tabindex="-1"
                         >
@@ -66,6 +67,7 @@
                             t-att-href="menu.path"
                             t-att-data-menu-id="menu.id"
                             t-att-data-action-id="menu.actionID"
+                            t-on-click="(ev) => this._onSearchItemClick(ev, menu)"
                             draggable="false"
                             tabindex="-1"
                         >


### PR DESCRIPTION
## Summary

- Fix breadcrumb displaying "Unnamed" when navigating to Settings/Technical menus via the apps menu global search
- Search result links now use `menuService.selectMenu()` instead of plain URL navigation, ensuring the action name is correctly passed to the breadcrumb component
- Applies to both canonical and fuse search modes (fuse inherits the canonical template)

## Root cause

The search results in `AppsMenuCanonicalSearchBar` rendered as plain `<a href="/odoo/action-{id}">` links. Clicking these caused the browser to navigate via URL, bypassing the menu service. When loading an action from URL alone, Odoo 18's breadcrumb component does not receive the action name from the menu context, resulting in "Unnamed".

Standard app menu items use `onNavBarDropdownItemSelection` which calls `menuService.selectMenu()` — this properly sets the menu context and action name for the breadcrumb.

## Fix

Added a `_onSearchItemClick(ev, menu)` handler to `AppsMenuCanonicalSearchBar` that:
1. Prevents default link navigation
2. Calls `this.menuService.selectMenu(menu)` to navigate through the menu service

The `href` attribute is preserved for accessibility and fallback.

## Module
- **Name**: `web_responsive`
- **Development status**: Production/Stable
- **Odoo version**: 18.0

## Test plan
- [ ] Install `web_responsive` on Odoo 18.0 Community
- [ ] Enable Developer Mode
- [ ] Open the App Drawer / Global Search
- [ ] Search for "Sequences" or any Settings/Technical menu
- [ ] Click on the search result
- [ ] Verify breadcrumb shows the actual action name (e.g., "Sequences"), not "Unnamed"
- [ ] Verify standard app navigation (clicking app icons) still works correctly
- [ ] Verify keyboard navigation (Enter on highlighted result) still works
- [ ] Test with fuse search mode (if configured) to confirm inherited fix

Closes #3510