### PR TITLE
[18.0][FIX] web_m2x_options: prevent Owl crash when evaluateFieldBool…

### DIFF
--- a/web_m2x_options/static/src/components/form.esm.js
+++ b/web_m2x_options/static/src/components/form.esm.js
@@ -32,7 +32,13 @@ function evaluateHasCreatePermission(attrs) {
 }
 
 function evaluateFieldBooleanOption(option) {
-    return typeof option === "boolean" ? option : evaluateBooleanExpr(option);
+    if (typeof option === "boolean") {
+        return option;
+    }
+    if (typeof option === "string") {
+        return evaluateBooleanExpr(option);
+    }
+    return true;
 }
 
 patch(many2OneField, {


### PR DESCRIPTION
### Describe the Bug
An `UncaughtPromiseError > OwlError` is triggered when opening standard views that contain `m2m` or `m2o` fields with domain-based creation rules, such as the `stock.picking` form view (Deliveries/Receipts) in Odoo 18.

### Root Cause
The standard Odoo view defines the `lot_ids` field with the following option:
`<field name="lot_ids" ... options="{'create': [('parent.use_create_lots', '=', True)]}" />`

In JS, this domain is evaluated as an `Array`. The `web_m2x_options` module intercepts this through the `evaluateFieldBooleanOption` function in `form.esm.js`. 
Currently, the function assumes the input is either a `boolean` or a `string`. When the Array is passed directly to Odoo's native `evaluateBooleanExpr(option)`, JavaScript converts the array to a string ungracefully, generating an invalid python expression with commas instead of standard operators (`bool(parent.use_create_lots,=,true)`). This causes the Owl expression parser to fail and halt the entire rendering lifecycle.

### Solution
Modified `evaluateFieldBooleanOption` to explicitly check the type of the `option` argument. 
If the option is a `boolean` or a `string`, it evaluates it normally. If it receives an `Array` (an Odoo domain), it now returns `true` as a fallback. This prevents the module from sending malformed strings to the Owl evaluator and allows the view to load without crashing.

Error: 
<img width="1034" height="529" alt="image" src="https://github.com/user-attachments/assets/8fc687f5-0e06-4630-a88b-665a5b32abd5" />
