### PR TITLE
[17.0][IMP] web_widget_product_label_section_and_note: Use useInputField to handle keyboard interactions

### DIFF
--- a/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.esm.js
+++ b/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.esm.js
@@ -5,6 +5,7 @@
 
 import {Component, useEffect, useRef, useState} from "@odoo/owl";
 import {AutoComplete} from "@web/core/autocomplete/autocomplete";
+import {useInputField} from "@web/views/fields/input_field_hook";
 import {Many2OneField, many2OneField} from "@web/views/fields/many2one/many2one_field";
 import {Many2XAutocomplete} from "@web/views/fields/relational_utils";
 import {
@@ -135,6 +136,11 @@ export class ProductLabel extends Component {
         this.labelNode = useAutofocus({refName: "labelNodeRef"});
         useProductAndLabelAutoresize(this.labelNode, {
             targetParentName: this.props.field_name,
+        });
+        useInputField({
+            getValue: () => this.label,
+            refName: "labelNodeRef",
+            fieldName: "name",
         });
     }
     get sectionAndNoteClasses() {

--- a/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -8,7 +8,6 @@
             rows="1"
             type="text"
             t-att-class="sectionAndNoteClasses"
-            t-att-value="label"
             t-on-change="(ev) => this.updateLabel(ev.target.value)"
             t-ref="labelNodeRef"
         />


### PR DESCRIPTION
Before this commit, when a user added a section or note and pressed the TAB key to save and add a new line, these changes were not saved because keyboard events were not handled. After this commit, the keyboard events are handled.

TT62088

@Tecnativa @pedrobaeza @CarlosRoca13 @victoralmau could you please review this?