### PR TITLE
[17.0][FIX] web_dialog_size: fix infinite RPC retry loop

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -18,11 +18,15 @@ export class ExpandButton extends Component {
 
         onMounted(() => {
             var self = this;
-            this.config.then(function (r) {
-                if (r.default_maximize && stop) {
-                    self.dialog_button_extend();
-                }
-            });
+            this.config
+                .then(function (r) {
+                    if (r.default_maximize && stop) {
+                        self.dialog_button_extend();
+                    }
+                })
+                .catch(() => {
+                    // Session likely expired → ignore
+                });
         });
     }
 


### PR DESCRIPTION
Summary:
This PR fixes an issue where the frontend could enter an infinite loop of failing RPC calls when the user session expires (e.g., logging in from another browser). This behavior could generate excessive requests and effectively self-DDoS the Odoo instance.

Steps to reproduce:

1. Log in to an account in browser 1
2. Log in to the same account in browser 2
3. In browser 2, change the password of the user (this invalidates other sessions)
4. Go back to browser 1 and click anywhere in the UI
5. Observe continuous failing requests being triggered

Root cause:
The module performs an RPC call (orm.call) during component setup and consumes the resulting promise in onMounted() without handling rejection. When the session is no longer valid, the RPC call fails and returns a rejected promise. Because no .catch() was defined, this resulted in unhandled promise rejections that could repeatedly trigger component lifecycle behavior and re-execute the RPC call.

Fix:
Added a .catch() handler to the promise chain to gracefully handle RPC failures (such as session expiration) and prevent retry loops.

Impact:
Prevents excessive repeated RPC calls when the session is invalid
Avoids unnecessary load on the server
Improves frontend stability in session edge cases

Notes:
This change is minimal and does not alter intended functionality. It only ensures safe handling of failed RPC calls.