### PR TITLE
[18.0][FIX] web_favicon: guard template _get_favicon call during DB restore

### DIFF
--- a/web_favicon/views/templates.xml
+++ b/web_favicon/views/templates.xml
@@ -6,7 +6,7 @@
         <xpath expr="//head/link[@rel='shortcut icon']" position="attributes">
             <attribute
                 name="t-att-href"
-            >env['res.company'].sudo()._get_favicon() or '/web/static/img/favicon.ico'</attribute>
+            >getattr(env['res.company'].sudo(), '_get_favicon', lambda: False)() or '/web/static/img/favicon.ico'</attribute>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Fix for: #3289

**Problem:**
When restoring a database backup, the web.layout template renders before web_favicon has fully loaded its models. The template calls env['res.company'].sudo()._get_favicon(), but since the method doesn't exist yet during this transient state, it causes an AttributeError and a 500 error on every page.

**Fix:**
Use getattr() in the QWeb template so it safely falls back to the default favicon when _get_favicon is not yet available, instead of hard-calling a method that may not exist.

<attribute name="t-att-href">getattr(env['res.company'].sudo(), '_get_favicon', lambda: False)() or '/web/static/img/favicon.ico'</attribute>

This only adds a getattr wrapper around the existing call. When the module is loaded normally, it behaves identically. During module loading/DB restore, it returns False and the existing or clause falls back to the default favicon.
