### PR TITLE
[16.0][FIX] web_widget_product_label_section_and_note: Define the appropriate styles for the o_group div (similar to web)

### DIFF
--- a/web_systray_button_init_action/static/src/tours/tour.esm.js
+++ b/web_systray_button_init_action/static/src/tours/tour.esm.js
@@ -20,17 +20,13 @@ tour.register(
 tour.register(
     "web_systray_button_init_action_set_tour",
     {
-        url: "/web",
+        url: "/web#action=base.action_res_users",
         test: true,
     },
     [
-        tour.stepUtils.showAppsMenuItem(),
         {
-            trigger: ".o_navbar_apps_menu button",
-            extra_trigger: ".init_action_div:has(a[name='init_action'])",
-        },
-        {
-            trigger: "a[data-menu-xmlid='base.menu_administration']",
+            trigger: ".init_action_div:has(a[name='init_action'])",
+            isCheck: true,
         },
         {
             trigger: "a[name='init_action']",

--- a/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.scss
+++ b/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.scss
@@ -3,3 +3,7 @@
         resize: none;
     }
 }
+.o_field_product_label_section_and_note_field_o2m ~ .row.o_group {
+    clear: both;
+    justify-content: space-between;
+}


### PR DESCRIPTION
Define the appropriate styles for the o_group div (similar to web)

https://github.com/odoo/odoo/blob/fa0a4e7bc272105cad210867c4ddd46a5326cd22/addons/web/static/src/views/form/form_controller.scss#L1234

**Before**
<img width="1507" height="578" alt="antes" src="https://github.com/user-attachments/assets/508c403f-0a41-4622-8f0a-e041cc758c28" />

**After**
<img width="1493" height="601" alt="despues" src="https://github.com/user-attachments/assets/144032db-710d-4c31-a4fe-1143bdaca19d" />

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa