### PR TITLE
[17.0][FIX] web_widget_product_label_section_and_note: Define the appropriate styles for the o_group div (similar to web)

### DIFF
--- a/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.scss
+++ b/web_widget_product_label_section_and_note/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.scss
@@ -3,3 +3,7 @@
         resize: none;
     }
 }
+.o_field_product_label_section_and_note_field_o2m ~ .row.o_group {
+    clear: both;
+    justify-content: space-between;
+}


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/web/pull/3534

Define the appropriate styles for the o_group div (similar to web)

https://github.com/odoo/odoo/blob/e7345340efbd66473da70ccf6680181b158047ce/addons/web/static/src/views/form/form_controller.scss#L1159

**Before**
<img width="1507" height="578" alt="antes" src="https://github.com/user-attachments/assets/508c403f-0a41-4622-8f0a-e041cc758c28" />

**After**
<img width="1493" height="601" alt="despues" src="https://github.com/user-attachments/assets/144032db-710d-4c31-a4fe-1143bdaca19d" />

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa