### PR TITLE
[18.0][FIX] web_responsive: replace this.ui.isSmall with env.isSmall for Odoo 18 compatibility

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.xml
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.xml
@@ -10,13 +10,13 @@
         and the dropdown for the user where can logout
         we had to disable the lef sidebar to keep our web_resposive toggle button working
         and to keep the user dropdown in its original place -->
-        <xpath expr="//t[@t-if='this.ui.isSmall']" position="attributes">
+        <xpath expr="//t[@t-if='env.isSmall']" position="attributes">
             <attribute name="t-if">false</attribute>
         </xpath>
         <!-- The kanban dropdown is replaced with the odoo default one
         as the default one took physical place in the DOM -->
         <xpath expr="//Dropdown" position="replace">
-            <t t-if="this.ui.isSmall">
+            <t t-if="env.isSmall">
                 <t t-call="web.NavBar.AppsMenu.Sidebar" />
             </t>
             <t t-else="" />


### PR DESCRIPTION
Odoo 18 replaced `this.ui.isSmall` with `env.isSmall` in the navbar template (`web.NavBar.AppsMenu`).

The web_responsive module was still using the old property name in both its xpath and template conditions, causing an OwlError:

```
Element '<xpath expr="//t[@t-if='this.ui.isSmall']" position="attributes">
    <attribute name="t-if">false</attribute>
</xpath>' cannot be located in element tree
```

This PR updates:
- The xpath expression from `//t[@t-if='this.ui.isSmall']` to `//t[@t-if='env.isSmall']`
- The template condition from `t-if="this.ui.isSmall"` to `t-if="env.isSmall"`