### PR TITLE
[FIX] web_responsive: use env.isSmall for Odoo 19 compatibility

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.xml
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.xml
@@ -10,13 +10,13 @@
         and the dropdown for the user where can logout
         we had to disable the lef sidebar to keep our web_resposive toggle button working
         and to keep the user dropdown in its original place -->
-        <xpath expr="//t[@t-if='this.ui.isSmall']" position="attributes">
+        <xpath expr="//t[@t-if='env.isSmall']" position="attributes">
             <attribute name="t-if">false</attribute>
         </xpath>
         <!-- The kanban dropdown is replaced with the odoo default one
         as the default one took physical place in the DOM -->
         <xpath expr="//Dropdown" position="replace">
-            <t t-if="this.ui.isSmall">
+            <t t-if="env.isSmall">
                 <t t-call="web.NavBar.AppsMenu.Sidebar" />
             </t>
             <t t-else="" />


### PR DESCRIPTION
## Summary

Fix a template xpath inheritance bug in `web_responsive` that prevents the WebClient from rendering on Odoo 19. Without this fix, `/odoo` returns a blank page with the following OWL error in the browser console:

> `Element '<xpath expr="//t[@t-if='this.ui.isSmall']" position="attributes">' cannot be located in element tree`

## Root cause

`web_responsive/static/src/components/apps_menu/apps_menu.xml` inherits the `web.NavBar.AppsMenu` template and patches an element matched by `//t[@t-if='this.ui.isSmall']`. That expression matched the Odoo 18 template, but Odoo 19's upstream `web.NavBar.AppsMenu` template uses `env.isSmall` instead of `this.ui.isSmall`. The xpath fails silently, the template inheritance throws, and the WebClient OWL component never mounts.

The current 19.0 head of the module ships this bug verbatim from the migration commit. Verified against current Odoo 19 on a fresh Community install: `grep -n "isSmall" /usr/lib/python3/dist-packages/odoo/addons/web/static/src/webclient/navbar/navbar.xml` shows only `env.isSmall` references in the canonical template.

## Fix

Two-line change in `apps_menu.xml`:

- Line 13: xpath expression `//t[@t-if='this.ui.isSmall']` → `//t[@t-if='env.isSmall']`
- Line 19: `<t t-if="this.ui.isSmall">` → `<t t-if="env.isSmall">`

Both refer to the same underlying smallness check; the rename happened upstream when `useService("ui")` was promoted to `env.isSmall` in the Odoo 19 webclient.

## Reproduction (before this fix)

1. Fresh Odoo 19.0 Community DB
2. Install `web_responsive` from `OCA/web` 19.0 head
3. Navigate to `/odoo`
4. Observe blank page; browser console shows the OwlError quoted above

## Verification (after this fix)

1. Same setup, with this fix applied (no code changes needed elsewhere)
2. Navigate to `/odoo`
3. Fullscreen icon-grid launcher renders correctly; fuzzy menu search works; clicking apps opens them as expected

## Test plan

- [x] Module installs without error
- [x] `/odoo` renders the fullscreen launcher after fresh login (with `is_redirect_home=True`)
- [x] Standard navigation still works for users with `is_redirect_home=False`
- [x] Mobile / small-viewport rendering still uses the sidebar fallback (the `env.isSmall` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)