### PR TITLE
[18.0][FIX] web_company_color: integer division in image color extraction

### DIFF
--- a/web_company_color/tests/test_res_company.py
+++ b/web_company_color/tests/test_res_company.py
@@ -3,6 +3,7 @@
 
 import base64
 
+from odoo.exceptions import UserError
 from odoo.tests import common
 
 from ..models.res_company import URL_BASE
@@ -121,3 +122,10 @@ class TestResCompany(common.TransactionCase):
             [("url", "=", company.scss_get_url())]
         )
         self.assertFalse(attachment, "attachment should not have been regenerated")
+
+    def test_convert_to_image_invalid(self):
+        """convert_to_image raises UserError on invalid image data"""
+        from ..utils import convert_to_image
+
+        with self.assertRaises(UserError):
+            convert_to_image(base64.b64encode(b"not an image").decode())

--- a/web_company_color/utils.py
+++ b/web_company_color/utils.py
@@ -4,7 +4,10 @@ import base64
 import math
 from io import BytesIO
 
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
+
+from odoo import _
+from odoo.exceptions import UserError
 
 
 def n_rgb_to_hex(_r, _g, _b):
@@ -12,7 +15,15 @@ def n_rgb_to_hex(_r, _g, _b):
 
 
 def convert_to_image(field_binary):
-    return Image.open(BytesIO(base64.b64decode(field_binary)))
+    try:
+        return Image.open(BytesIO(base64.b64decode(field_binary)))
+    except UnidentifiedImageError as err:
+        raise UserError(
+            _(
+                "Cannot process the company logo. "
+                "Try converting it to PNG or JPEG format first."
+            )
+        ) from err
 
 
 def image_to_rgb(img):
@@ -31,7 +42,7 @@ def image_to_rgb(img):
     # Mix. image colors using addition method
     RGBA_WHITE = (255, 255, 255, 255)
     for i in range(0, height * width):
-        rgba = img.getpixel((i % width, i / width))
+        rgba = img.getpixel((i % width, i // width))
         if rgba[3] > 128 and rgba != RGBA_WHITE:
             rgb_sum[0] += rgba[0]
             rgb_sum[1] += rgba[1]


### PR DESCRIPTION
## Issue

Closes #3532

In image_to_rgb() pixel loop uses i / width returning float in Python 3, causing getpixel() to raise TypeError in Pillow >= 10.2.0 because coordinates must be integers. This completely blocks color extraction when a logo is set.

## Steps to reproduce
1. Install web_company_color on Odoo >= 18.0
2. Set a company logo
3. Click 'Compute Colors from Logo'
4. Traceback: TypeError - 'float' object cannot be interpreted as an integer

## Fix
Replace i / width with i // width so getpixel() receives integer coordinates.

## Backward Compatibility
Fully backward compatible; the behavior is identical for valid integer widths and fixes the crash with newer Pillow.