### PR TITLE
[FIX] web_responsive: target env.isSmall in apps_menu xpath

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.xml
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.xml
@@ -10,13 +10,13 @@
         and the dropdown for the user where can logout
         we had to disable the lef sidebar to keep our web_resposive toggle button working
         and to keep the user dropdown in its original place -->
-        <xpath expr="//t[@t-if='this.ui.isSmall']" position="attributes">
+        <xpath expr="//t[@t-if='env.isSmall']" position="attributes">
             <attribute name="t-if">false</attribute>
         </xpath>
         <!-- The kanban dropdown is replaced with the odoo default one
         as the default one took physical place in the DOM -->
         <xpath expr="//Dropdown" position="replace">
-            <t t-if="this.ui.isSmall">
+            <t t-if="env.isSmall">
                 <t t-call="web.NavBar.AppsMenu.Sidebar" />
             </t>
             <t t-else="" />


### PR DESCRIPTION
## Symptom

`web_responsive` installs cleanly on Odoo 18 CE, but the responsive apps-menu behaviour (sidebar / dropdown swap on small screens) never takes effect — the standard `web.NavBar.AppsMenu` template is rendered unchanged.

## Root cause

`web_responsive/static/src/components/apps_menu/apps_menu.xml` extends `web.NavBar.AppsMenu` with two xpath expressions targeting `t-if='this.ui.isSmall'`. The base Odoo 18 template uses `t-if='env.isSmall'` ([`addons/web/static/src/webclient/navbar/navbar.xml`](https://github.com/odoo/odoo/blob/18.0/addons/web/static/src/webclient/navbar/navbar.xml#L17)). The xpath targets therefore match nothing and both customisations silently no-op.

This is a residue from the Odoo 17 → 18 port: Odoo 17 exposed the small-screen flag via `useService(\"ui\").isSmall`; Odoo 18 moved it onto the env as `env.isSmall`. Other `web_responsive` files were updated for the new pattern — this one was missed.

## Fix

Two-line change: swap the xpath target and the `t-if` expression to use `env.isSmall`, matching the base template.

\`\`\`diff
-        <xpath expr=\"//t[@t-if='this.ui.isSmall']\" position=\"attributes\">
+        <xpath expr=\"//t[@t-if='env.isSmall']\" position=\"attributes\">
             <attribute name=\"t-if\">false</attribute>
         </xpath>
         <!-- The kanban dropdown is replaced with the odoo default one
         as the default one took physical place in the DOM -->
         <xpath expr=\"//Dropdown\" position=\"replace\">
-            <t t-if=\"this.ui.isSmall\">
+            <t t-if=\"env.isSmall\">
                 <t t-call=\"web.NavBar.AppsMenu.Sidebar\" />
             </t>
\`\`\`

## How to verify

1. Apply the patch on top of `18.0`
2. Install / upgrade `web_responsive` on a fresh Odoo 18 CE DB
3. Resize the browser to a small viewport (`< 768px`) or open the web client in a mobile emulator
4. Click the apps menu — the responsive sidebar swap should now render. Without the patch the standard navbar dropdown shows instead.