### PR TITLE
[FIX]web_widget_open_tab : issue with lost header on tab opened

### DIFF
--- a/web_widget_open_tab/static/src/js/open_tab_widget.esm.js
+++ b/web_widget_open_tab/static/src/js/open_tab_widget.esm.js
@@ -6,6 +6,8 @@ import {standardFieldProps} from "@web/views/fields/standard_field_props";
 export class OpenTabWidget extends Component {
     openNewTab(ev) {
         ev.stopPropagation();
+        ev.preventDefault();
+        window.open(this._getReference(), "_blank");
     }
     _getReference() {
         return `/odoo/${this.props.record.resModel}/${this.props.record.data.id}`;

--- a/web_widget_open_tab/static/src/xml/open_tab_widget.xml
+++ b/web_widget_open_tab/static/src/xml/open_tab_widget.xml
@@ -4,7 +4,6 @@
         <a
             class="btn open_tab_widget fa fa-external-link"
             t-att-href="_getReference()"
-            target="_blank"
             t-on-click="openNewTab"
             t-att-title="props.title"
         />


### PR DESCRIPTION
I had an issue with this module

On the tab opened with the widget : the header (app name & menuitems) were missing

This PR fixes this issue