### PR TITLE
[17.0][FIX] web_dialog_size: declare static props on ExpandButton

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -8,6 +8,10 @@ import {patch} from "@web/core/utils/patch";
 import {useService} from "@web/core/utils/hooks";
 
 export class ExpandButton extends Component {
+    static props = {
+        getsize: Function,
+        setsize: Function,
+    };
     setup() {
         this.orm = useService("orm");
         this.last_size = this.props.getsize();


### PR DESCRIPTION
Fix console error `Component 'ExpandButton' does not have a static props description` raised in debug mode.