### PR TITLE
Update copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -16,7 +16,8 @@ odoo_test_flavor: Both
 odoo_version: 18.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- web_responsive
 repo_description: web
 repo_name: web
 repo_slug: web

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,7 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.36
+_commit: v1.42
 _src_path: git+https://github.com/OCA/oca-addons-repo-template
 additional_ruff_rules: []
-ci: GitHub
 convert_readme_fragments_to_markdown: true
 enable_checklog_odoo: true
 generate_requirements_txt: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+
 name: pre-commit
 
 on:
@@ -16,8 +17,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: 'pip'
+          cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,18 +36,18 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo18.0:latest
+            include: "web_responsive"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb18.0:latest
+            include: "web_responsive"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo18.0:latest
             exclude: "web_responsive"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb18.0:latest
             exclude: "web_responsive"
             name: test with OCB
-            makepot: "true"
-          - container: ghcr.io/oca/oca-ci/py3.10-odoo18.0:latest
-            include: "web_responsive"
-            name: test with Odoo (rebel modules)
-          - container: ghcr.io/oca/oca-ci/py3.10-ocb18.0:latest
-            include: "web_responsive"
-            name: test with OCB (rebel modules)
             makepot: "true"
     services:
       postgres:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.12
   node: "22.9.0"
 repos:
   - repo: local
@@ -38,6 +38,11 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: obsolete dotfiles
+        name: obsolete dotfiles
+        entry: found obsolete files; remove them
+        files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md|\.prettierrc\.yml|\.eslintrc\.yml)$'
+        language: fail
   - repo: https://github.com/sbidoul/whool
     rev: v1.3
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 [![Support the OCA](https://odoo-community.org/readme-banner-image)](https://odoo-community.org/get-involved?utm_source=repo-readme)
 
 # web

--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -2,4 +2,4 @@
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
     WARNING .* Killing chrome descendants-or-self .*
-    Missing widget: res_partner_many2one for field of type many2one
+    WARNING.* Missing widget: res_partner_many2one for field of type many2one.*


### PR DESCRIPTION
I have also updated the rebel modules configuration that had been written directly in `test.yaml` (https://github.com/OCA/web/commit/0b5aa6775dfcc46a183e142d3dfa7755b43fbd37), @StefanRijnhart since you committed that change, you might want to have a look.

The order of the configurations has changed because in the template rebel modules are included first (https://github.com/OCA/oca-addons-repo-template/blob/ed7ccbe08991f72f71cfa260e98c9f9902636977/src/.github/workflows/test.yml.jinja#L88), I prefer to change the order so that we are aligned to the template and we will have fewer conflicts in the future.