### PR TITLE
[17.0][FIX] web_responsive: Add static props definition for AppsMenuPreferences component

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu_preferences.esm.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu_preferences.esm.js
@@ -7,6 +7,7 @@ import {registry} from "@web/core/registry";
 import {useService} from "@web/core/utils/hooks";
 
 class AppsMenuPreferences extends Component {
+    static props = {};
     setup() {
         this.action = useService("action");
         this.user = useService("user");


### PR DESCRIPTION
Add static props definition for AppsMenuPreferences component

Resolves the console warning "Component 'AppsMenuPreferences' does not have a static props description" developer mode.

