### PR TITLE
[16.0][IMP] web_refresher: hotkey Alt R

### DIFF
--- a/web_refresher/static/src/xml/refresher.xml
+++ b/web_refresher/static/src/xml/refresher.xml
@@ -14,6 +14,7 @@
                 aria-label="Refresh"
                 t-on-click="onClickRefresh"
                 title="Refresh"
+                data-hotkey="r"
                 tabindex="-1"
             />
         </nav>


### PR DESCRIPTION
Adds a simple hotkey to quick refresh the page with Alt + R

<img width="1352" height="234" alt="image" src="https://github.com/user-attachments/assets/1ad171bc-9b59-41af-939c-43da098d7aef" />
