### PR TITLE
[17.0][FIX] web_company_color: fix WebP support

### DIFF
--- a/web_company_color/readme/CONTRIBUTORS.md
+++ b/web_company_color/readme/CONTRIBUTORS.md
@@ -8,3 +8,4 @@
   - Jairo Llopis
   - Alexandre Díaz
   - Carlos Roca
+- Marwan Behillil \<<marwan.behillil@gmail.com>>

--- a/web_company_color/utils.py
+++ b/web_company_color/utils.py
@@ -4,7 +4,10 @@ import base64
 import math
 from io import BytesIO
 
-from PIL import Image
+from PIL import (
+    Image,
+    WebPImagePlugin,  # noqa: F401 - force WebP opener registration
+)
 
 
 def n_rgb_to_hex(_r, _g, _b):


### PR DESCRIPTION
## Problem
When computing the navbar color from webp picture as company logo

## Solution
- Import `WebPImagePlugin` to force registration of the WebP opener, as lazy plugin initialization proved unreliable in this environment.

## How to test
1. Go to Settings → Companies and open a company.
2. Upload a valid WebP image
3. Trigger the navbar color computation.
4. Confirm the color is computed correctly.

Fixes #3532