### PR TITLE
[FIX][18.0] web_theme_classic: don't double-tint required monetary fields

### DIFF
--- a/web_theme_classic/static/src/scss/web_theme_classic.scss
+++ b/web_theme_classic/static/src/scss/web_theme_classic.scss
@@ -100,6 +100,10 @@ body.classic-theme {
             /* Prevent having double border for monetary fields */
             span.o_input:has(~ input.o_input) {
                 border: $input-border-width solid transparent !important;
+                /* The overlay sits on top of the real input; keep it
+                   transparent so the required-field background is not applied
+                   twice (which renders as a darker band over the value). */
+                background-color: transparent !important;
             }
 
             /* Keep the monetary symbol away from the border when it is outside the border */
@@ -174,6 +178,7 @@ body.classic-theme {
                 // Handle monetary fields in list
                 &.o_field_monetary span.o_input:has(~ input.o_input) {
                     border: $input-border-width solid transparent !important;
+                    background-color: transparent !important;
                 }
             }
         }


### PR DESCRIPTION
The required-field background sets `--o-input-background-color` on every `.o_input` inside an `o_required_modifier`. A monetary field renders an absolutely-positioned overlay span (which also carries `.o_input`) on top of the real input, so the semi-transparent tint was applied to both and the overlap rendered as a darker band over the value.

Keep the overlay background transparent so only the real input carries the required tint, in both form and list views.

Before: 
<img width="609" height="107" alt="image" src="https://github.com/user-attachments/assets/6f3dc5d9-06f1-4958-9cfe-c9c7a6bd3601" />

After:
<img width="566" height="111" alt="image" src="https://github.com/user-attachments/assets/e0a39391-94e2-4fac-9a05-852703e1ab4b" />

This is from delivery.carrier configuration where something like this is used:
```
<label for="free_over" invisible="delivery_type == 'base_on_rule'"/>
<div name="free_over_amount" invisible="delivery_type == 'base_on_rule'">
    <field name="free_over"/>
    <field name="amount" widget="monetary" class="oe_inline" invisible="not free_over" required="free_over"/>
</div>

```