### PR TITLE
[IMP] web_dialog_size: default fullscreen in context of field/action

### DIFF
--- a/web_dialog_size/readme/CONFIGURE.md
+++ b/web_dialog_size/readme/CONFIGURE.md
@@ -1,7 +1,12 @@
 By default, the module respects the caller's `dialog_size` option. If
-you want to set dialog boxes maximized by default, you need to:
+you want to set **all** dialog boxes maximized by default, you need to:
 
-1.  Go to *Settings -\> Technical -\> Parameters -\> System Parameters*
+1. Go to *Settings -\> Technical -\> Parameters -\> System Parameters*
 
-2.  Add a new record with the text *web_dialog_size.default_maximize* in  
-    the *Key* field and the text *True* in the *Value* field
+2. Add a new record with the text *web_dialog_size.default_maximize* in
+   the *Key* field and the text *True* in the *Value* field
+
+To maximize **specific** dialog boxes by default, you can add `dialog_full_screen` to the context:
+
+- Wizard action: `action['context'] = {'dialog_full_screen': True}`
+- M2O, M2M selection: `<field name="partner_id" context="{'dialog_full_screen': True}"`

--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -8,7 +8,7 @@ import {useService} from "@web/core/utils/hooks";
 export class ExpandButton extends Component {
     setup() {
         this.orm = useService("orm");
-        this.last_size = this.props.getsize();
+        this.last_size = this.props.size;
         this.config = this.orm.call(
             "ir.config_parameter",
             "get_web_dialog_size_config"
@@ -65,6 +65,11 @@ patch(SelectCreateDialog.prototype, {
         super.setup();
         this.setSize = this.setSize.bind(this);
         this.getSize = this.getSize.bind(this);
+        onMounted(() => {
+            if (this.props.context?.dialog_full_screen) {
+                this.setSize("dialog_full_screen");
+            }
+        });
     },
 
     setSize(size) {
@@ -74,6 +79,18 @@ patch(SelectCreateDialog.prototype, {
 
     getSize() {
         return this.props.size;
+    },
+});
+
+patch(ActionDialog.prototype, {
+    setup() {
+        super.setup();
+        onMounted(() => {
+            const ctx = this.props.actionProps?.context || {};
+            if (ctx.dialog_full_screen) {
+                this.setSize("dialog_full_screen");
+            }
+        });
     },
 });
 

--- a/web_dialog_size/static/src/xml/ExpandButton.xml
+++ b/web_dialog_size/static/src/xml/ExpandButton.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="web_dialog_size.ExpandButton" owl="1">
         <button
-            t-if="props.getsize() == 'dialog_full_screen'"
+            t-if="props.size == 'dialog_full_screen'"
             type="button"
             class="btn btn-secondary dialog_button_extend"
             t-on-click="dialog_button_restore"
@@ -10,7 +10,7 @@
             <i class="fa fa-window-restore" />
         </button>
         <button
-            t-if="props.getsize() != 'dialog_full_screen'"
+            t-if="props.size != 'dialog_full_screen'"
             type="button"
             class="btn btn-secondary dialog_button_restore"
             t-on-click="dialog_button_extend"

--- a/web_dialog_size/static/src/xml/web_dialog_header.xml
+++ b/web_dialog_size/static/src/xml/web_dialog_header.xml
@@ -4,7 +4,7 @@
     <t t-inherit="web.Dialog.header" t-inherit-mode="extension" owl="1">
         <xpath expr="//button[hasclass('btn-close')]" position="before">
             <ExpandButton
-                getsize="getSize"
+                size="getSize()"
                 setsize="setSize"
                 t-if="!isFullscreen and getSize and setSize"
             />


### PR DESCRIPTION
Adds possibility to set specific popups to full-screen via context in action or field

- Wizard action: `action['context'] = {'dialog_full_screen': True}`
- M2O, M2M selection: `<field name="partner_id" context="{'dialog_full_screen': True}"`