### PR TITLE
[18.0][FIX] web_notify: remove unsupported messageIsHtml prop

### DIFF
--- a/web_notify/static/src/js/services/notification_services.esm.js
+++ b/web_notify/static/src/js/services/notification_services.esm.js
@@ -29,7 +29,6 @@ export const webNotificationService = {
                     type: notification.type,
                     sticky: notification.sticky,
                     className: notification.className,
-                    messageIsHtml: notification.html,
                     buttons: buttons.map((button) => {
                         const onClick = button.onClick;
                         button.onClick = async () => {


### PR DESCRIPTION
- Odoo 18 notification component uses strict OWL prop validation and does not accept messageIsHtml, the markup() wrapper already handles HTML rendering.

Fixes: #3392