### PR TITLE
[FIX] web_remember_tree_column_width: Include non-stored columns to remember width

### DIFF
--- a/web_remember_tree_column_width/__manifest__.py
+++ b/web_remember_tree_column_width/__manifest__.py
@@ -5,7 +5,7 @@
     "website": "https://github.com/OCA/web",
     "license": "LGPL-3",
     "category": "Extra Tools",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "maintainers": [
         "frahikLV",
         "luisg123v",

--- a/web_remember_tree_column_width/static/src/scss/main.scss
+++ b/web_remember_tree_column_width/static/src/scss/main.scss
@@ -1,4 +1,4 @@
-th.o_column_sortable {
+th[data-name] {
     max-width: none !important;
     min-width: 0 !important;
 }


### PR DESCRIPTION
Fixes https://github.com/OCA/web/issues/3112