### PR TITLE
[19.0][IMP] web_dark_mode: blue-dark color palette

### DIFF
--- a/web_dark_mode/static/src/scss/primary_variables.dark.scss
+++ b/web_dark_mode/static/src/scss/primary_variables.dark.scss
@@ -13,16 +13,16 @@ $o-white: #000000 !default;
 $o-black: #ffffff !default;
 
 // Blue-dark palette: canvas #1b1d26, secondary surface #262a36
-// Escala azul-oscura derivada de #070916 (color principal), saltos pequeños
-$o-gray-100: #070916 !default; // canvas / barras (principal, lo más oscuro)
-$o-gray-200: #0d1020 !default; // superficies: vistas, cards, navbar
+// Blue-dark scale from #070916 (base), small steps between surfaces
+$o-gray-100: #070916 !default; // canvas / chrome (darkest)
+$o-gray-200: #0d1020 !default; // surfaces: views, cards, navbar
 $o-gray-300: #151a2b !default; // raised: inputs, hover, dropdowns
-$o-gray-400: #232a42 !default; // bordes y divisores
+$o-gray-400: #232a42 !default; // borders and dividers
 $o-gray-500: #3d4569 !default; // L: ~30%
 $o-gray-600: #6b7298 !default; // L: ~50%
 $o-gray-700: #9aa1c2 !default; // L: ~68%
 $o-gray-800: #c6cae0 !default; // L: ~78%
-$o-gray-900: #e7eaf5 !default; // texto principal
+$o-gray-900: #e7eaf5 !default; // primary text
 
 $o-community-color: $o-gray-200 !default;
 $o-enterprise-color: #71639e !default;

--- a/web_dark_mode/static/src/scss/primary_variables.dark.scss
+++ b/web_dark_mode/static/src/scss/primary_variables.dark.scss
@@ -12,15 +12,17 @@ $o-webclient-color-scheme: dark !default;
 $o-white: #000000 !default;
 $o-black: #ffffff !default;
 
-$o-gray-100: #181818 !default; // L: 9%
-$o-gray-200: #1f1f1f !default; // L: 12%
-$o-gray-300: #303030 !default; // L: 19%
-$o-gray-400: #4a4a4a !default; // L: 29%
-$o-gray-500: #696969 !default; // L: 41%
-$o-gray-600: #8b8b8b !default; // L: 55%
-$o-gray-700: #aeaeae !default; // L: 68%
-$o-gray-800: #c0c0c0 !default; // L: 75%
-$o-gray-900: #c8c8c8 !default; // L: 78%
+// Blue-dark palette: canvas #1b1d26, secondary surface #262a36
+// Escala azul-oscura derivada de #070916 (color principal), saltos pequeños
+$o-gray-100: #070916 !default; // canvas / barras (principal, lo más oscuro)
+$o-gray-200: #0d1020 !default; // superficies: vistas, cards, navbar
+$o-gray-300: #151a2b !default; // raised: inputs, hover, dropdowns
+$o-gray-400: #232a42 !default; // bordes y divisores
+$o-gray-500: #3d4569 !default; // L: ~30%
+$o-gray-600: #6b7298 !default; // L: ~50%
+$o-gray-700: #9aa1c2 !default; // L: ~68%
+$o-gray-800: #c6cae0 !default; // L: ~78%
+$o-gray-900: #e7eaf5 !default; // texto principal
 
 $o-community-color: $o-gray-200 !default;
 $o-enterprise-color: #71639e !default;


### PR DESCRIPTION
Replaces the neutral dark grays with a blue-tinted scale, closer to widely used dark UI references (cool-tinted surfaces instead of flat neutral gray).

Improves depth between canvas, cards, and inputs, and reads more comfortably on long sessions while staying aligned with Odoo’s purple/teal accents.

Change is limited to `$o-gray-100` … `$o-gray-900` in `primary_variables.dark.scss` — no logic or dependency changes.

Screenshots before/after attached.

## Screenshots

**Before**
<img width="2553" height="1319" alt="imagen" src="https://github.com/user-attachments/assets/0d07f84c-4cca-4ef5-8d2f-2a30f30f78d6" />
<img width="2303" height="1316" alt="imagen" src="https://github.com/user-attachments/assets/8f023665-c63b-4d31-a906-06f8b78a154d" />
<img width="2551" height="1319" alt="imagen" src="https://github.com/user-attachments/assets/59ef4641-846f-4ff0-be77-151d593dd31d" />

**After**
<img width="2529" height="1210" alt="imagen" src="https://github.com/user-attachments/assets/5f8e26d3-8851-4643-b1eb-4498741c8fee" />
<img width="2289" height="1312" alt="imagen" src="https://github.com/user-attachments/assets/0b16bfd5-7309-4c15-9136-42ef0312862c" />
<img width="2553" height="1319" alt="imagen" src="https://github.com/user-attachments/assets/98ae7997-a5fe-4e25-8793-c94b0c718760" />
