### PR TITLE
[FIX] Make web_responsive AppsMenu xpath compatible across Odoo versions

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.xml
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.xml
@@ -10,13 +10,14 @@
         and the dropdown for the user where can logout
         we had to disable the lef sidebar to keep our web_resposive toggle button working
         and to keep the user dropdown in its original place -->
-        <xpath expr="//t[@t-if='this.ui.isSmall']" position="attributes">
+        <!-- Version-agnostic xpath: Odoo 18 uses env.isSmall, Odoo 19 uses this.ui.isSmall -->
+        <xpath expr="//t[@t-else='']/preceding-sibling::t[1]" position="attributes">
             <attribute name="t-if">false</attribute>
         </xpath>
         <!-- The kanban dropdown is replaced with the odoo default one
         as the default one took physical place in the DOM -->
         <xpath expr="//Dropdown" position="replace">
-            <t t-if="this.ui.isSmall">
+            <t t-if="env.isSmall">
                 <t t-call="web.NavBar.AppsMenu.Sidebar" />
             </t>
             <t t-else="" />


### PR DESCRIPTION
- Use structural xpath targeting the mobile branch via t-else sibling
- Use env.isSmall in injected template content for broader compatibility

Reason: Odoo 19 changed web.NavBar.AppsMenu from env.isSmall to this.ui.isSmall.
web_responsive inherited that template with an xpath on env.isSmall, which no longer matches in Odoo 19 and crashes the backend at startup.
Use a structural xpath (mobile branch before t-else) so the patch works without depending on the exact t-if expression.

I tested the latest version of web_responsive in Odoo 19 self hosted and I got this error message. This problem I replicated in Odoo 18 but is not common.

<img width="887" height="378" alt="image" src="https://github.com/user-attachments/assets/75dd1337-0e15-4bd2-924b-4a917e6a8a3c" />


@rvalyi Wanna check it out?