### PR TITLE
[16.0][IMP] web_responsive_company: Sort companies by name

### DIFF
--- a/web_responsive_company/static/src/js/web_responsive_company.esm.js
+++ b/web_responsive_company/static/src/js/web_responsive_company.esm.js
@@ -9,11 +9,17 @@ patch(SwitchCompanyMenu.prototype, "web_responsive_company.SwitchCompanyMenu", {
     setup() {
         this._super();
 
+        const companies = Object.values(
+            this.companyService.availableCompanies || {}
+        ).sort((a, b) => a.name.localeCompare(b.name));
+
         this.state = useState({
             companiesToToggle: [],
-            results: Object.values(this.companyService.availableCompanies || {}),
+            allCompaniesSorted: companies,
+            filteredCompaniesSorted: companies,
             hasResults: false,
         });
+
         this.searchInputRef = useRef("SearchBarInput");
     },
 
@@ -36,16 +42,16 @@ patch(SwitchCompanyMenu.prototype, "web_responsive_company.SwitchCompanyMenu", {
     _searchCompanies() {
         const query = this.searchInputRef.el.value;
         this.state.hasResults = query !== "";
-        const companies = Object.values(this.companyService.availableCompanies || {});
-        this.state.results = this.state.hasResults
-            ? fuzzyLookup(query, companies, (c) => c.name)
-            : companies;
+
+        this.state.filteredCompaniesSorted = this.state.hasResults
+            ? fuzzyLookup(query, this.state.allCompaniesSorted, (c) => c.name)
+            : this.state.allCompaniesSorted;
     },
 
     /* Key down on input search bar*/
     _onKeyDownSearchInput(ev) {
         if (ev.code === "Tab" || ev.code === "ArrowDown") {
-            if (this.state.results.length) {
+            if (this.state.filteredCompaniesSorted.length) {
                 ev.preventDefault();
                 document.querySelector(".company-card").focus();
             }

--- a/web_responsive_company/static/src/xml/web_responsive_company.xml
+++ b/web_responsive_company/static/src/xml/web_responsive_company.xml
@@ -31,7 +31,7 @@
 
         <!-- All or filtered companies -->
         <t
-                t-foreach="state.results"
+                t-foreach="state.filteredCompaniesSorted"
                 class="search-results"
                 t-as="company"
                 t-key="company.id"


### PR DESCRIPTION
This PR improves `web_responsive_company` by ordering companies by alphabetical order instead of their id

<img width="1187" height="483" alt="image" src="https://github.com/user-attachments/assets/91eb1d58-6f22-4507-9bfa-873f0f84afc0" />
