### PR TITLE
[18.0][FIX] web_responsive: 'AppsMenuPreferences' does not have a static props description

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu_preferences.esm.js
+++ b/web_responsive/static/src/components/apps_menu/apps_menu_preferences.esm.js
@@ -7,6 +7,7 @@ import {useService} from "@web/core/utils/hooks";
 import {user} from "@web/core/user";
 
 class AppsMenuPreferences extends Component {
+    static props = {};
     setup() {
         this.action = useService("action");
         this.user = user;


### PR DESCRIPTION
If I enable debugging in Chrome (F12 -> console) and then enable developer mode in Odoo, I see the error: "AppsMenuPreferences' does not have a static props description" with web_responsive module installed (see image below):
<img width="1129" height="269" alt="image" src="https://github.com/user-attachments/assets/f18c2aaa-9222-4a56-a955-71c97da7e1c0" />

