### PR TITLE
[FIX] web_field_tooltip: make computed helper flag self-readable

### DIFF
--- a/web_field_tooltip/models/res_users.py
+++ b/web_field_tooltip/models/res_users.py
@@ -22,7 +22,15 @@ class ResUsers(models.Model):
 
     @property
     def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS + self.TOOLTIP_READABLE_FIELDS
+        # ``tooltip_show_add_helper_allowed`` is a computed (read-only) field
+        # added to the user preferences form, so it must be self-readable too.
+        # Otherwise the ``res.users.read`` self-read shortcut is skipped and
+        # reading one's own preferences can raise an AccessError.
+        return (
+            super().SELF_READABLE_FIELDS
+            + self.TOOLTIP_READABLE_FIELDS
+            + ["tooltip_show_add_helper_allowed"]
+        )
 
     @property
     def SELF_WRITEABLE_FIELDS(self):

--- a/web_field_tooltip/tests/test_web_field_tooltip.py
+++ b/web_field_tooltip/tests/test_web_field_tooltip.py
@@ -46,3 +46,21 @@ class TestWebFieldTooltip(TransactionCase):
             self.Tooltip.with_context(default_model=self.partner_model_name)
         )
         self.assertEqual(res_partner_form.model_id, self.partner_model)
+
+    def test_tooltip_allowed_is_self_readable(self):
+        # ``tooltip_show_add_helper_allowed`` is displayed on the user
+        # preferences form, so a user must be able to read it on their own
+        # record. If it is missing from SELF_READABLE_FIELDS, the res.users
+        # self-read shortcut is skipped and reading one's own preferences
+        # (together with any group-restricted field also present on the form)
+        # raises an AccessError.
+        user = self.env["res.users"].create(
+            {
+                "name": "Test Tooltip User",
+                "login": "test_tooltip_user",
+                "groups_id": [(6, 0, [self.env.ref("base.group_user").id])],
+            }
+        )
+        self.assertIn("tooltip_show_add_helper_allowed", user.SELF_READABLE_FIELDS)
+        # A non-manager user can read the field on their own record.
+        user.with_user(user).read(["tooltip_show_add_helper_allowed"])


### PR DESCRIPTION
`tooltip_show_add_helper_allowed` is a computed field added to the user preferences form (`base.view_users_form_simple_modif`), but it was not listed in `SELF_READABLE_FIELDS`.

`res.users.read()` only takes the "read your own record as superuser" shortcut when every requested field is self-readable. Because this field was missing from the list, the shortcut was skipped whenever a user reads their own preferences form. On its own that is harmless, but as soon as another installed module contributes group-restricted fields to that same form (for example the private information fields added by `hr`), reading one's own preferences raises an `AccessError` for users that are not in those groups.

Add the computed (read-only) field to `SELF_READABLE_FIELDS` so the self-read shortcut is preserved. It is intentionally not added to `SELF_WRITEABLE_FIELDS` since the field is computed.