### PR TITLE
[FIX] web_responsive: adapt apps_menu template for Odoo 19 (this.ui.isSmall -> env.isSmall)

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.xml
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.xml
@@ -10,13 +10,13 @@
         and the dropdown for the user where can logout
         we had to disable the lef sidebar to keep our web_resposive toggle button working
         and to keep the user dropdown in its original place -->
-        <xpath expr="//t[@t-if='this.ui.isSmall']" position="attributes">
+        <xpath expr="//t[@t-if='env.isSmall']" position="attributes">
             <attribute name="t-if">false</attribute>
         </xpath>
         <!-- The kanban dropdown is replaced with the odoo default one
         as the default one took physical place in the DOM -->
         <xpath expr="//Dropdown" position="replace">
-            <t t-if="this.ui.isSmall">
+            <t t-if="env.isSmall">
                 <t t-call="web.NavBar.AppsMenu.Sidebar" />
             </t>
             <t t-else="" />


### PR DESCRIPTION
## Problem

In Odoo 19, the `NavBar.AppsMenu` template uses `env.isSmall` instead of the old `this.ui.isSmall`. The `web_responsive` module's `apps_menu.xml` still references the old API, causing xpath expressions to fail:

`Element '<xpath expr="//t[@t-if='this.ui.isSmall']" ...>' cannot be located in element tree`

This OwlError destroys the root component, resulting in a completely blank backend page after login.

## Solution

Replace `this.ui.isSmall` with `env.isSmall` in `apps_menu.xml` (2 occurrences).

## Tested on

- Odoo 19.0 (server version 19.0 final)
- `web_responsive` from OCA/web 19.0 branch