### PR TITLE
[IMP] web_company_color: add reset colors button

### DIFF
--- a/web_company_color/i18n/es.po
+++ b/web_company_color/i18n/es.po
@@ -87,7 +87,7 @@ msgstr "Color de fondo de la barra de navegación"
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_navbar_bg_hover
 msgid "Navbar Background Color Hover"
-msgstr "Desplazamiento del color de fondo de la barra de navegación"
+msgstr "Color de fondo de la barra de navegación Hover"
 
 #. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__color_navbar_text
@@ -100,9 +100,20 @@ msgid "Qweb"
 msgstr "Qweb"
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr "Restablecer colores"
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp
 msgid "SCSS Modif. Timestamp"
 msgstr "SCSS Modif. Marca de tiempo"
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "This will remove the custom colors of this company. Continue?"
+msgstr ""
+"Esto eliminará los colores personalizados de esta compañía. ¿Continuar?"
 
 #~ msgid "Navbar Colors"
 #~ msgstr "Colores de la barra de navegación"

--- a/web_company_color/i18n/web_company_color.pot
+++ b/web_company_color/i18n/web_company_color.pot
@@ -92,6 +92,16 @@ msgid "Qweb"
 msgstr ""
 
 #. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "Reset colors"
+msgstr ""
+
+#. module: web_company_color
 #: model:ir.model.fields,field_description:web_company_color.field_res_company__scss_modif_timestamp
 msgid "SCSS Modif. Timestamp"
+msgstr ""
+
+#. module: web_company_color
+#: model_terms:ir.ui.view,arch_db:web_company_color.view_company_form
+msgid "This will remove the custom colors of this company. Continue?"
 msgstr ""

--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -102,6 +102,17 @@ class ResCompany(models.Model):
         }
     """
 
+    _COMPANY_COLOR_FIELDS = (
+        "color_navbar_bg",
+        "color_navbar_bg_hover",
+        "color_navbar_text",
+        "color_button_bg",
+        "color_button_bg_hover",
+        "color_button_text",
+        "color_link_text",
+        "color_link_text_hover",
+    )
+
     company_colors = fields.Serialized()
     color_navbar_bg = fields.Char("Navbar Background Color", sparse="company_colors")
     color_navbar_bg_hover = fields.Char(
@@ -135,18 +146,8 @@ class ResCompany(models.Model):
 
     def write(self, values):
         if not self.env.context.get("ignore_company_color", False):
-            fields_to_check = (
-                "color_navbar_bg",
-                "color_navbar_bg_hover",
-                "color_navbar_text",
-                "color_button_bg",
-                "color_button_bg_hover",
-                "color_button_text",
-                "color_link_text",
-                "color_link_text_hover",
-            )
             result = super().write(values)
-            if any([field in values for field in fields_to_check]):
+            if any(field in values for field in self._COMPANY_COLOR_FIELDS):
                 self.scss_create_or_update_attachment()
         else:
             result = super().write(values)
@@ -174,6 +175,10 @@ class ResCompany(models.Model):
                 }
             )
         self.write(values)
+
+    def button_reset_colors(self):
+        self.ensure_one()
+        self.write({field: False for field in self._COMPANY_COLOR_FIELDS})
 
     def _scss_get_sanitized_values(self):
         self.ensure_one()

--- a/web_company_color/tests/test_res_company.py
+++ b/web_company_color/tests/test_res_company.py
@@ -1,5 +1,7 @@
 # Copyright 2019 Alexandre Díaz <dev@redneboa.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import base64
+
 from odoo.tests import common
 
 from ..models.res_company import URL_BASE
@@ -74,4 +76,53 @@ class TestResCompany(common.TransactionCase):
             "color_navbar_bg",
             company_id.company_colors,
             "Invalid Navbar Background Color",
+        )
+
+    def test_reset_colors(self):
+        company_id = self.env["res.company"].search([], limit=1)
+        company_id.sudo().write(
+            {"color_navbar_bg": "#DEAD00", "color_button_bg": "#00BEEF"}
+        )
+        self.assertTrue(company_id.company_colors, "Colors should be set before reset")
+        company_id.button_reset_colors()
+        # Oracle independent from the implementation constant
+        self.assertEqual(
+            len(company_id._COMPANY_COLOR_FIELDS),
+            8,
+            "Expected 8 company color fields",
+        )
+        for field in company_id._COMPANY_COLOR_FIELDS:
+            self.assertFalse(
+                company_id[field],
+                "Color %s should be empty after reset" % field,
+            )
+        self.assertFalse(
+            company_id.company_colors,
+            "company_colors should be empty after reset",
+        )
+        # The SCSS attachment that paints the navbar is regenerated with no colors
+        attachment = (
+            self.env["ir.attachment"]
+            .sudo()
+            .search(
+                [
+                    ("url", "=", company_id.scss_get_url()),
+                    ("company_id", "=", company_id.id),
+                ]
+            )
+        )
+        content = base64.b64decode(attachment.datas).decode("utf-8")
+        self.assertIn("No Web Company Color SCSS Content", content)
+
+    def test_reset_colors_other_company_untouched(self):
+        company_a = self.env["res.company"].search([], limit=1)
+        company_b = self.env["res.company"].create({"name": "Company Color Test B"})
+        company_a.sudo().write({"color_navbar_bg": "#DEAD00"})
+        company_b.sudo().write({"color_navbar_bg": "#00BEEF"})
+        company_a.button_reset_colors()
+        self.assertFalse(company_a.color_navbar_bg, "Company A color should be reset")
+        self.assertEqual(
+            company_b.color_navbar_bg,
+            "#00BEEF",
+            "Reset of company A must not affect company B",
         )

--- a/web_company_color/view/res_company.xml
+++ b/web_company_color/view/res_company.xml
@@ -31,6 +31,13 @@
                         type="object"
                         string="Compute colors from logo"
                     />
+                    <button
+                        class="btn-outline-danger"
+                        name="button_reset_colors"
+                        type="object"
+                        string="Reset colors"
+                        confirm="This will remove the custom colors of this company. Continue?"
+                    />
                     <div
                         class="alert alert-info info_icon mt-2 d-flex align-items-center"
                         role="alert"


### PR DESCRIPTION
Add a 'Reset colors' button in the Company Styles page that clears the 8 sparse color fields of the current company (writing False removes each key from company_colors), reverting it to the standard style without uninstalling the module. Covered by test_reset_colors and, for multi-company isolation, test_reset_colors_other_company_untouched.

Also align the es.po translation of color_navbar_bg_hover with the literal 'Hover' criterion used by the other two hover color fields.