### PR TITLE
[16.0] [FIX] web_field_tooltip: make tooltip_show_add_helper_allowed self-readable

### DIFF
--- a/web_field_tooltip/models/res_users.py
+++ b/web_field_tooltip/models/res_users.py
@@ -22,7 +22,11 @@ class ResUsers(models.Model):
 
     @property
     def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS + self.TOOLTIP_READABLE_FIELDS
+        return (
+            super().SELF_READABLE_FIELDS
+            + self.TOOLTIP_READABLE_FIELDS
+            + ["tooltip_show_add_helper_allowed"]
+        )
 
     @property
     def SELF_WRITEABLE_FIELDS(self):


### PR DESCRIPTION
### Description

`web_field_tooltip` adds the computed field `tooltip_show_add_helper_allowed` to res.users and displays it on the user form, but only `tooltip_show_add_helper` is registered in `SELF_READABLE_FIELDS`.

When the hr module is also installed, an internal user without `hr.group_hr_user` who opens their own Preferences gets an `AccessError ("Access Denied")` popup. The web client reads the whole user form in a single `read()` call that now includes `tooltip_show_add_helper_allowed`; because that field is not self-readable, the res.users self-read exemption no longer applies to the call, and the HR fields that hr adds with `groups="hr.group_hr_user"` raise AccessError.

### Steps to reproduce (runboat)

1. Install web_field_tooltip and hr.
2. Log in as an internal user that is not in hr.group_hr_user.
3. Open the user menu → Preferences. → AccessError popup.

FL-703-1158