### PR TITLE
[FIX] web_pwa_customize: Fix singleton error when loading PWA icon

### DIFF
--- a/web_pwa_customize/models/res_config_settings.py
+++ b/web_pwa_customize/models/res_config_settings.py
@@ -32,7 +32,7 @@ class ResConfigSettings(models.TransientModel):
         pwa_icon_attachment = (
             self.env["ir.attachment"]
             .sudo()
-            .search([("url", "like", self._pwa_icon_url_base + ".")])
+            .search([("url", "like", self._pwa_icon_url_base + ".")], limit=1)
         )
         res["pwa_icon"] = pwa_icon_attachment.datas if pwa_icon_attachment else False
         return res

--- a/web_pwa_customize/tests/test_web_pwa_customize.py
+++ b/web_pwa_customize/tests/test_web_pwa_customize.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import tagged
+from odoo.tests.common import Form, tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
@@ -24,3 +24,41 @@ class TestWebPwaCustomize(HttpCaseWithUserDemo):
         self.assertEqual(data["short_name"], "SHORT-NAME")
         self.assertEqual(data["background_color"], "#2E69B5")
         self.assertEqual(data["theme_color"], "#2E69B4")
+
+    def test_default_get_pwa_icon_singleton(self):
+        """Test default_get doesn't crash with multiple PWA icon attachments.
+
+        Reproduces the real scenario: duplicate attachments with the same URL
+        accumulate due to race conditions or repeated saves. The search in
+        get_values() matches all of them, and .datas triggers ensure_one().
+        """
+        attachment_model = self.env["ir.attachment"].sudo()
+        # Simulate production scenario: 2 attachments with the same URL
+        # (the actual bug — duplicate base icon)
+        for _ in range(2):
+            attachment_model.create(
+                {
+                    "name": "/web_pwa_customize/icon.svg",
+                    "url": "/web_pwa_customize/icon.svg",
+                    "type": "binary",
+                    "datas": "dGVzdA==",
+                    "mimetype": "image/svg+xml",
+                }
+            )
+        # Also create resized PNG variants (normal scenario)
+        for size in ["128x128", "144x144", "152x152"]:
+            attachment_model.create(
+                {
+                    "name": f"/web_pwa_customize/icon{size}.png",
+                    "url": f"/web_pwa_customize/icon{size}.png",
+                    "type": "binary",
+                    "datas": "dGVzdA==",
+                    "mimetype": "image/png",
+                }
+            )
+        # Form() triggers default_get() which calls get_values() via super chain
+        # This is the exact flow that crashes in production
+        settings_form = Form(self.env["res.config.settings"])
+        # If the bug exists, this line raises:
+        # ValueError: Expected singleton: ir.attachment(137, 123)
+        settings_form.save()


### PR DESCRIPTION
In production, multiple `ir.attachment` records with the same URL (`/web_pwa_customize/icon.svg`) were found in the database. The exact cause of the duplication is unknown.

The `get_values()` method searches for PWA icon attachments using `search([("url", "like", "/web_pwa_customize/icon.")])`, which in PostgreSQL translates to `LIKE '%/web_pwa_customize/icon.%'`. This matches all attachments whose URL contains that substring. When multiple attachments match, calling `.datas` on the multi-record recordset triggers `ensure_one()`, raising `ValueError: Expected singleton`.

**Steps to reproduce:**
1. Have duplicate `ir.attachment` records with the same PWA icon URL
2. Go to Settings > General Settings > Progressive Web App
3. Error occurs on load

**Full traceback:**

```
Traceback (most recent call last):
  File "/opt/odoo-server/odoo/models.py", line 5898, in ensure_one
    _id, = self._ids
ValueError: too many values to unpack (expected 1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo-server/odoo/http.py", line 1985, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo-server/odoo/service/model.py", line 153, in retrying
    result = func()
  File "/opt/odoo-server/odoo/http.py", line 2013, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo-server/odoo/http.py", line 2217, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo-server/odoo/addons/base/models/ir_http.py", line 221, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo-server/odoo/http.py", line 799, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo-server/addons/web/controllers/dataset.py", line 25, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo-server/addons/web/controllers/dataset.py", line 21, in _call_kw
    return call_kw(Model, method, args, kwargs)
  File "/opt/odoo-server/odoo/api.py", line 484, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo-server/odoo/api.py", line 469, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo-server/addons/web/models/models.py", line 978, in onchange
    defaults = self.default_get(missing_names)
  File "/opt/odoo-server/extra_addons/oca/web/web_pwa_customize/models/res_config_settings.py", line 42, in default_get
    res = super().default_get(fields)
  File "/opt/odoo-server/odoo/addons/base/models/res_config.py", line 512, in default_get
    res.update(self.get_values())
  File "/opt/odoo-server/addons/hr_attendance/models/res_config_settings.py", line 27, in get_values
    res = super(ResConfigSettings, self).get_values()
  File "/opt/odoo-server/addons/portal/models/res_config_settings.py", line 25, in get_values
    res = super(ResConfigSettings, self).get_values()
  File "/opt/odoo-server/extra_addons/oca/web/web_pwa_customize/models/res_config_settings.py", line 37, in get_values
    res["pwa_icon"] = pwa_icon_attachment.datas if pwa_icon_attachment else False
  File "/opt/odoo-server/odoo/fields.py", line 1148, in __get__
    record.ensure_one()
  File "/opt/odoo-server/odoo/models.py", line 5901, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: ir.attachment(137, 123)
```

**Fix:** Add `limit=1` to the search in `get_values()` to return only the first matching attachment, preventing the singleton error regardless of how many duplicate attachments exist.

@BinhexTeam T12289