### PR TITLE
[18.0][IMP] web_group_expand: disable buttons when they would be a no-op

### DIFF
--- a/web_group_expand/readme/CONTRIBUTORS.md
+++ b/web_group_expand/readme/CONTRIBUTORS.md
@@ -8,3 +8,4 @@
 - Mayank Patel \<<mayankpatel3555@gmail.com>\>
 - [360ERP](https://www.360erp.com):
   - Andrea Stirpe
+- Arif Waram \<<arifwaram@gmail.com>\>

--- a/web_group_expand/readme/DESCRIPTION.md
+++ b/web_group_expand/readme/DESCRIPTION.md
@@ -4,3 +4,7 @@ or collapse all the groups at once.
 The buttons appear in the top right, in place of the pagination.
 
 One level of groups is expanded or collapsed at a time.
+
+The buttons are disabled when they would have no effect: the expand
+button when all groups are already expanded, and the collapse button
+when all groups are already collapsed.

--- a/web_group_expand/static/src/js/list_controller.esm.js
+++ b/web_group_expand/static/src/js/list_controller.esm.js
@@ -8,6 +8,22 @@ function flatten(arr) {
 }
 
 patch(ListController.prototype, {
+    get allGroupsExpanded() {
+        let layer = this.model.root.groups || [];
+        while (layer.length) {
+            if (layer.some((group) => group._config.isFolded)) {
+                return false;
+            }
+            layer = layer.flatMap((group) => group.list.groups || []);
+        }
+        return true;
+    },
+
+    get allGroupsCollapsed() {
+        const groups = this.model.root.groups || [];
+        return groups.every((group) => group._config.isFolded);
+    },
+
     async expandAllGroups() {
         // We expand layer by layer. So first we need to find the highest
         // layer that's not already fully expanded.

--- a/web_group_expand/static/src/xml/list_controller.xml
+++ b/web_group_expand/static/src/xml/list_controller.xml
@@ -8,6 +8,7 @@
                     class="btn btn-secondary fa fa-expand oe_group_by_expand"
                     data-tooltip="Expand"
                     aria-label="Expand"
+                    t-att-disabled="allGroupsExpanded"
                     t-on-click="expandAllGroups"
                 />
                 <button
@@ -15,6 +16,7 @@
                     class="btn btn-secondary fa fa-compress oe_group_by_collapse"
                     data-tooltip="Compress"
                     aria-label="Compress"
+                    t-att-disabled="allGroupsCollapsed"
                     t-on-click="collapseAllGroups"
                 />
             </t>


### PR DESCRIPTION
The expand/compress buttons added by `web_group_expand` are always enabled,
even when clicking them would have no effect (e.g. the expand button while
every group is already expanded). This makes it hard to tell at a glance
whether there is anything left to expand or collapse.

This PR disables each button when it would be a no-op:

- the **expand** button is disabled when no group at any level is folded;
- the **compress** button is disabled when every top-level group is folded.

The state is computed in two `ListController` getters that walk the group
layers the same way the existing `expandAllGroups`/`collapseAllGroups`
handlers do, and is applied with `t-att-disabled` on the existing buttons,
so there is no behavior change beyond the disabled state.
