### PR TITLE
[19.0][IMP] web_responsive: add dark mode support for the apps menu

### DIFF
--- a/web_responsive/__manifest__.py
+++ b/web_responsive/__manifest__.py
@@ -48,6 +48,11 @@
             "/web_responsive/static/src/components/control_panel/*",
             "/web_responsive/static/src/components/command_palette/*",
             "/web_responsive/static/src/views/form/*",
+            # Don't include dark mode files in light mode
+            ("remove", "web_responsive/static/src/**/*.dark.scss"),
+        ],
+        "web.assets_web_dark": [
+            "web_responsive/static/src/**/*.dark.scss",
         ],
         "web.assets_clickbot": [
             "/web_responsive/static/src/clickbot/clickbot.esm.js",

--- a/web_responsive/static/src/components/apps_menu/apps_menu.dark.scss
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.dark.scss
@@ -1,0 +1,67 @@
+/* Copyright 2023 Taras Shabaranskyi
+ * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). */
+
+:root {
+    .o_grid_apps_menu[data-theme="milk"],
+    .o_grid_apps_menu[data-theme="community"] {
+        --app-menu-background: linear-gradient(
+            to bottom,
+            #{$o-gray-300},
+            #{desaturate(darken($o-gray-300, 5%), 15)}
+        );
+        --app-menu-text-color: #{$o-gray-900};
+        --app-menu-text-shadow: 1px 1px 1px #{rgba(black, 0.4)};
+        --app-menu-hover-background: #{rgba(white, 0.08)};
+        --apps-menu-scrollbar-background: #{$o-gray-400};
+        --apps-menu-empty-search-color: #{$o-gray-900};
+    }
+}
+
+.o_grid_apps_menu {
+    .o-app-menu-item {
+        &__icon {
+            background-color: $o-gray-400;
+        }
+
+        &__active {
+            background-color: $o-gray-900;
+            border-radius: 50%;
+            color: $o-gray-100;
+            text-shadow: none;
+        }
+    }
+
+    .search-container {
+        // Search box
+        .search-input {
+            background-color: $o-gray-300;
+
+            .search-icon {
+                color: $o-gray-900;
+            }
+
+            .form-control {
+                color: $o-gray-900;
+
+                &::placeholder {
+                    color: $o-gray-700;
+                }
+            }
+        }
+
+        // Search results (canonical searchbar)
+        .search-item {
+            background-color: $o-gray-300;
+
+            &__name {
+                color: $o-gray-900;
+                text-shadow: none;
+            }
+
+            &.highlight,
+            &:hover {
+                background-color: $o-gray-400;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When the user enables dark mode (e.g. with the `web_dark_mode` addon), the
grid apps menu rendered by `web_responsive` kept its light background image,
light gradient and light colors, making the menu inconsistent with the rest
of the backend and hard to read.

## What this PR does

- Adds `web_responsive/static/src/components/apps_menu/apps_menu.dark.scss`,
  registered in the `web.assets_web_dark` bundle so it is only loaded when
  dark mode is active.
- Restyles in dark mode:
  - the apps menu grid background (uses `$o-gray-300` instead of the light
    `$app-menu-background-color` gradient and overlay image)
  - menu item text color, text shadow and hover background
  - the search box (background, icon, input and placeholder)
  - the canonical search results and their highlight/hover state
  - the scrollbar and "empty search" colors
- Adds a `("remove", "web_responsive/static/src/**/*.dark.scss")` directive
  to `web.assets_backend` so dark mode files never leak into light mode,
  mirroring the pattern used by the `web` addon itself.

All colors reuse the dark mode variables (`$o-gray-*`) so the menu follows
the same palette as the rest of `web_dark_mode`.

## How to test

1. Install `web_responsive` and `web_dark_mode`.
2. Enable dark mode from the user menu (or set the user preference).
3. Open the apps menu grid and search: everything is now dark-themed.
4. Switch back to light mode: no visual change from before.

## Affected files

- `web_responsive/__manifest__.py`
- `web_responsive/static/src/components/apps_menu/apps_menu.dark.scss` (new)