### PR TITLE
[FIX] web_responsive: app-menu-container hides open mail chat windows

### DIFF
--- a/web_responsive/static/src/components/apps_menu/apps_menu.scss
+++ b/web_responsive/static/src/components/apps_menu/apps_menu.scss
@@ -93,7 +93,11 @@
     // Display apps in a grid
     align-content: flex-start;
     display: flex !important;
-    z-index: 1024 !important;
+    // Must stay below mail's .o-mail-ChatWindow (z-index: $zindex-sticky):
+    // both are full-height `position: fixed` panels that spatially overlap,
+    // so a value >= $zindex-sticky here permanently hides any open chat
+    // window whenever the apps grid is opened.
+    z-index: $zindex-sticky - 1 !important;
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: flex-start;


### PR DESCRIPTION
## Bug

`.app-menu-container` (the full-screen apps grid overlay, `apps_menu.scss`) sets `z-index: 1024 !important`. Mail's `.o-mail-ChatWindow` (core `mail` module) uses `z-index: $zindex-sticky`, which is `1020` in Bootstrap 5's default z-index scale.

Both elements are `position: fixed` panels that span overlapping regions of the viewport (the apps grid covers the full width from just below the navbar down; chat windows are anchored `fixed-bottom`). Since `1024 > 1020`, opening the apps grid always paints over any already-open chat window, hiding it completely for as long as the apps grid stays open.

## Fix

Lower `.app-menu-container`'s `z-index` to `$zindex-sticky - 1` (1019), so it still sits comfortably above ordinary page content, dropdowns (`$zindex-dropdown` = 1000) and this module's own `.o_searchview_autocomplete` (999), but no longer covers `.o-mail-ChatWindow` or anything else at the sticky tier.

## To reproduce (before fix)

1. Open a chat window (Discuss bubble in the bottom-right corner).
2. Click the apps grid button in the navbar.
3. The open chat window disappears behind the apps grid overlay until it is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoYMgd2neGjAAx8N2xwYur