### PR TITLE
[18.0][FIX] web_dialog_size: Correct resizing of content when maximizing

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -5,6 +5,12 @@ import {SelectCreateDialog} from "@web/views/view_dialogs/select_create_dialog";
 import {patch} from "@web/core/utils/patch";
 import {useService} from "@web/core/utils/hooks";
 
+function triggerWindowResize() {
+    requestAnimationFrame(() => {
+        window.dispatchEvent(new Event("resize"));
+    });
+}
+
 export class ExpandButton extends Component {
     setup() {
         this.orm = useService("orm");
@@ -30,12 +36,12 @@ export class ExpandButton extends Component {
 
     dialog_button_extend() {
         this.props.setsize("dialog_full_screen");
-        this.render();
+        triggerWindowResize();
     }
 
     dialog_button_restore() {
         this.props.setsize(this.last_size);
-        this.render();
+        triggerWindowResize();
     }
 }
 


### PR DESCRIPTION
Correct resizing of content when maximizing

Use case example:
- In a sales order, search for something in the product field to open the list in a modal
- Manually resize a column
- Click the maximize button

The table (the modal's content) should be correctly resized to fill the entire modal

**Before**
<img width="1597" height="791" alt="antes" src="https://github.com/user-attachments/assets/fadbc2f1-d14a-4aa6-a203-2c7fdabd3658" />

**After**
<img width="1597" height="791" alt="despues" src="https://github.com/user-attachments/assets/683ce295-ffa6-432e-8002-7c649d07bfc3" />

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT64312