### PR TITLE
[19.0][FIX] web_dialog_size: Correct resizing of content when maximizing

### DIFF
--- a/web_dialog_size/static/src/js/web_dialog_size.esm.js
+++ b/web_dialog_size/static/src/js/web_dialog_size.esm.js
@@ -6,6 +6,12 @@ import {patch} from "@web/core/utils/patch";
 import {useService} from "@web/core/utils/hooks";
 import {browser} from "@web/core/browser/browser";
 
+function triggerWindowResize() {
+    requestAnimationFrame(() => {
+        window.dispatchEvent(new Event("resize"));
+    });
+}
+
 export class ExpandButton extends Component {
     setup() {
         this.original_size = this.props.getoriginalsize
@@ -18,13 +24,13 @@ export class ExpandButton extends Component {
     dialog_button_extend() {
         this.props.setsize("dialog_full_screen");
         browser.localStorage.setItem("odoo.web_dialog_size.value", "true");
-        this.render();
+        triggerWindowResize();
     }
 
     dialog_button_restore() {
         this.props.setsize(this.original_size);
         browser.localStorage.setItem("odoo.web_dialog_size.value", "false");
-        this.render();
+        triggerWindowResize();
     }
 }
 


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/web/pull/3649

Correct resizing of content when maximizing

Use case example:
- In a sales order, search for something in the product field to open the list in a modal
- Manually resize a column
- Click the maximize button

The table (the modal's content) should be correctly resized to fill the entire modal

**Before**
<img width="1597" height="791" alt="antes" src="https://github.com/user-attachments/assets/e4a058d8-5399-450c-b697-e188c42e6c57" />

**After**
<img width="1597" height="791" alt="despues" src="https://github.com/user-attachments/assets/04c9f26f-89ed-465f-b8a0-b6c81cfcfe12" />


Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT64312