### PR TITLE
[19.0][ADD] web_action_binding_refresh

### DIFF
--- a/web_action_binding_refresh/__manifest__.py
+++ b/web_action_binding_refresh/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Vauxoo
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Web Action Binding Refresh",
+    "summary": "Show new contextual actions without reloading the browser",
+    "version": "19.0.1.0.0",
+    "author": "Vauxoo, Odoo Community Association (OCA)",
+    "maintainers": ["moylop260"],
+    "website": "https://github.com/OCA/web",
+    "license": "AGPL-3",
+    "category": "Web",
+    "depends": ["web"],
+    "installable": True,
+    "assets": {
+        "web.assets_backend": [
+            "web_action_binding_refresh/static/src/**/*.esm.js",
+        ],
+    },
+}

--- a/web_action_binding_refresh/pyproject.toml
+++ b/web_action_binding_refresh/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/web_action_binding_refresh/readme/CONTRIBUTORS.md
+++ b/web_action_binding_refresh/readme/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+- Vauxoo
+
+  - Moisés López \<moylop260@vauxoo.com\>

--- a/web_action_binding_refresh/readme/DESCRIPTION.md
+++ b/web_action_binding_refresh/readme/DESCRIPTION.md
@@ -1,0 +1,25 @@
+Creating a contextual action does not make it appear in the **Actions** menu of
+the model it is bound to.
+
+The toolbar of a view is built server side from the action bindings and travels
+inside the `get_views` response. Since 19.0 the web client serves that response
+from a cache persisted in IndexedDB, and invalidates it for `ir.ui.view` and
+`ir.filters` only. `ir.actions.server` is not in that list, and the *Create
+Contextual Action* / *Remove Contextual Action* buttons call `create_action` and
+`unlink_action` through `call_button`, so they are not in `UPDATE_METHODS`
+either. Binding an action therefore never invalidates the cached `get_views`.
+
+In 18.0 the same cache was a plain in-memory object rebuilt on every page load,
+so a refresh hid the missing invalidation.
+
+This module adds the missing invalidation for the action models, so a newly bound
+action shows up straight away.
+
+It patches nothing in core: `rpcBus` is exported by `@web/core/network/rpc` and
+the `CLEAR-CACHES` event is already consumed there, so the module only publishes
+the event core does not publish for the action models.
+
+Odoo was asked to do this in core in [odoo/odoo#286419](https://github.com/odoo/odoo/pull/286419) and
+[declined](https://github.com/odoo/odoo/pull/286419#issuecomment-5525722682), answering that reloading the webclient is the expected
+behaviour and that creating a server action is too rare a flow to justify the
+extra code. This module is for the installations that would rather not reload.

--- a/web_action_binding_refresh/static/src/action_binding_refresh.esm.js
+++ b/web_action_binding_refresh/static/src/action_binding_refresh.esm.js
@@ -1,0 +1,42 @@
+import {rpcBus} from "@web/core/network/rpc";
+import {UPDATE_METHODS} from "@web/core/orm_service";
+
+// The toolbar of a view is built server side from the action bindings and travels
+// inside the get_views response, which the web client caches on disk. Core
+// invalidates that cache on writes to ir.ui.view and ir.filters only, so binding an
+// action to a model leaves the cached entry in place and the action never reaches
+// the Actions menu.
+//
+// Do not send this upstream again. It was proposed as odoo/odoo#286419 and closed in
+// the same minute it was answered, as intended behaviour:
+// https://github.com/odoo/odoo/pull/286419#issuecomment-5525722682
+//
+//     "You have to reload the webclient to see the action appear. We were aware of
+//      that and believe that it is fine. Creating a server action is an advanced and
+//      quite rare flow, so we prefer the current situation than make the code more
+//      complex."
+//
+// Odoo knows about the behaviour, accepts the reload as the workaround, and judged
+// the flow too rare to carry the extra code in core. That is a product decision, not
+// an oversight, so this module exists to opt into the invalidation instead.
+//
+// This patches nothing: rpcBus is exported by @web/core/network/rpc and CLEAR-CACHES
+// is already consumed there, so the module only publishes the event that core does
+// not publish for the action models.
+const ACTION_MODELS = [
+    "ir.actions.actions",
+    "ir.actions.act_window",
+    "ir.actions.report",
+    "ir.actions.server",
+];
+
+// The create_action and unlink_action buttons ("Create/Remove Contextual Action")
+// change the bindings through call_button, so they are not in UPDATE_METHODS.
+const ACTION_UPDATE_METHODS = [...UPDATE_METHODS, "create_action", "unlink_action"];
+
+rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
+    const {model, method} = ev.detail.data.params || {};
+    if (ACTION_MODELS.includes(model) && ACTION_UPDATE_METHODS.includes(method)) {
+        rpcBus.trigger("CLEAR-CACHES", "get_views");
+    }
+});


### PR DESCRIPTION
New module: **Web Action Binding Refresh**.

Creating a contextual action does not make it appear in the **Actions** menu of the
model it is bound to, and reloading does not obviously fix it either.

### Cause

The view toolbar is built server side from the action bindings and travels inside
`get_views`. Since 19.0 the web client serves that response from a cache persisted in
IndexedDB ([`view_service.js#L98-L102`](https://github.com/odoo/odoo/blob/c3376d7854da41bcf4adae712dbc0c4bb36d8a8d/addons/web/static/src/views/view_service.js#L98-L102)) and invalidates it
for `ir.ui.view` and `ir.filters` only ([`#L47-L54`](https://github.com/odoo/odoo/blob/c3376d7854da41bcf4adae712dbc0c4bb36d8a8d/addons/web/static/src/views/view_service.js#L47-L54)).
`ir.actions.server` is not in that list, and the *Create / Remove Contextual Action*
buttons call `create_action` / `unlink_action` through `call_button`, so they are not
in `UPDATE_METHODS` either. Binding an action therefore never invalidates
`get_views`.

In 18.0 the same cache was a plain in-memory object rebuilt on every page load, so a
refresh hid the missing invalidation. That is why this only surfaces now.

### What the module does

It adds the listener core does not register, for the four action models. It patches
nothing: `rpcBus` is exported by `@web/core/network/rpc` and `CLEAR-CACHES` is
already consumed there at [`rpc.js#L85-L87`](https://github.com/odoo/odoo/blob/c3376d7854da41bcf4adae712dbc0c4bb36d8a8d/addons/web/static/src/core/network/rpc.js#L85-L87), which calls
[`RPCCache.invalidate`](https://github.com/odoo/odoo/blob/c3376d7854da41bcf4adae712dbc0c4bb36d8a8d/addons/web/static/src/core/network/rpc_cache.js#L235-L240) and clears both the IndexedDB
and the RAM cache. The module only publishes the event core does not publish for
action models, so it survives an upstream version bump untouched.

### Why not in core

Proposed as odoo/odoo#286419 and declined — [the maintainer's answer](https://github.com/odoo/odoo/pull/286419#issuecomment-5525722682):

> "You have to reload the webclient to see the action appear. We were aware of that
> and believe that it is fine. Creating a server action is an advanced and quite rare
> flow, so we prefer the current situation than make the code more complex."

A legitimate call for core. This module is for the installations that would rather
not reload.

### Status

The server side is measured: `get_bindings` and `get_views(toolbar=True)` both return
a newly bound action immediately, so the stale data is entirely client side.

The listener itself has **not been exercised in a browser yet** — flagging that
honestly rather than claiming a test I have not run.


Closed since that I'm not able to reproduce it anymore